### PR TITLE
add check to verify ec2 API doesn't return empty response

### DIFF
--- a/pkg/aws/ec2/instance.go
+++ b/pkg/aws/ec2/instance.go
@@ -94,12 +94,19 @@ func (i *ec2Instance) LoadDetails(ec2APIHelper api.EC2APIHelper) error {
 	if err != nil {
 		return err
 	}
+	if instance == nil {
+		return fmt.Errorf("failed to find instance %s details from EC2 API", i.instanceID)
+	}
 
 	// Set instance subnet and cidr during node initialization
 	i.instanceSubnetID = *instance.SubnetId
 	instanceSubnet, err := ec2APIHelper.GetSubnet(&i.instanceSubnetID)
 	if err != nil {
 		return err
+	}
+	if instanceSubnet == nil {
+		return fmt.Errorf("failed to find subnet %s for instance %s",
+			i.instanceSubnetID, i.instanceID)
 	}
 	i.instanceSubnetCidrBlock = *instanceSubnet.CidrBlock
 
@@ -235,6 +242,9 @@ func (i *ec2Instance) updateCurrentSubnetAndCidrBlock(ec2APIHelper api.EC2APIHel
 			customSubnet, err := ec2APIHelper.GetSubnet(&i.newCustomNetworkingSubnetID)
 			if err != nil {
 				return err
+			}
+			if customSubnet == nil {
+				return fmt.Errorf("failed to find subnet %s", i.newCustomNetworkingSubnetID)
 			}
 			i.currentSubnetID = i.newCustomNetworkingSubnetID
 			i.currentSubnetCIDRBlock = *customSubnet.CidrBlock

--- a/pkg/aws/ec2/instance_test.go
+++ b/pkg/aws/ec2/instance_test.go
@@ -122,6 +122,35 @@ func TestEc2Instance_LoadDetails(t *testing.T) {
 	assert.Equal(t, primaryInterfaceID, ec2Instance.PrimaryNetworkInterfaceID())
 }
 
+// TestEc2Instance_LoadDetails_InstanceDetailsIsNull tests error is returned if the instance details
+// response from EC2 API is null
+func TestEc2Instance_LoadDetails_InstanceDetailsIsNull(t *testing.T)  {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2Instance, mockEC2ApiHelper := getMockInstance(ctrl)
+
+	mockEC2ApiHelper.EXPECT().GetInstanceDetails(&instanceID).Return(nil, nil)
+
+	err := ec2Instance.LoadDetails(mockEC2ApiHelper)
+	assert.NotNil(t, err)
+}
+
+// TestEc2Instance_LoadDetails_InstanceSubnetIsNull tests error is returned if the instance subnet
+// response from EC2 API is null
+func TestEc2Instance_LoadDetails_InstanceSubnetIsNull(t *testing.T)  {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2Instance, mockEC2ApiHelper := getMockInstance(ctrl)
+
+	mockEC2ApiHelper.EXPECT().GetInstanceDetails(&instanceID).Return(nwInterfaces, nil)
+	mockEC2ApiHelper.EXPECT().GetSubnet(&subnetID).Return(nil, nil)
+
+	err := ec2Instance.LoadDetails(mockEC2ApiHelper)
+	assert.NotNil(t, err)
+}
+
 // TestEc2Instance_LoadDetails_SubnetPreLoaded if the subnet is already loaded it's not set to the value of the instance's
 // subnet
 func TestEc2Instance_LoadDetails_SubnetPreLoaded(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-vpc-resource-controller-k8s/issues/12

*Description of changes:* Add check if ec2 API returns non empty response to avoid panic when accessing the response object.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
