### PR TITLE
broadcast event on failure to annoate pod and init trunk

### DIFF
--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/mock_k8swrapper.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/mock_k8swrapper.go
@@ -21,6 +21,7 @@ import (
 	v1alpha1 "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	reflect "reflect"
 )
 
@@ -75,16 +76,16 @@ func (mr *MockK8sWrapperMockRecorder) AnnotatePod(arg0, arg1, arg2, arg3 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AnnotatePod", reflect.TypeOf((*MockK8sWrapper)(nil).AnnotatePod), arg0, arg1, arg2, arg3)
 }
 
-// BroadcastPodEvent mocks base method
-func (m *MockK8sWrapper) BroadcastPodEvent(arg0 *v1.Pod, arg1, arg2, arg3 string) {
+// BroadcastEvent mocks base method
+func (m *MockK8sWrapper) BroadcastEvent(arg0 runtime.Object, arg1, arg2, arg3 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "BroadcastPodEvent", arg0, arg1, arg2, arg3)
+	m.ctrl.Call(m, "BroadcastEvent", arg0, arg1, arg2, arg3)
 }
 
-// BroadcastPodEvent indicates an expected call of BroadcastPodEvent
-func (mr *MockK8sWrapperMockRecorder) BroadcastPodEvent(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// BroadcastEvent indicates an expected call of BroadcastEvent
+func (mr *MockK8sWrapperMockRecorder) BroadcastEvent(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BroadcastPodEvent", reflect.TypeOf((*MockK8sWrapper)(nil).BroadcastPodEvent), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BroadcastEvent", reflect.TypeOf((*MockK8sWrapper)(nil).BroadcastEvent), arg0, arg1, arg2, arg3)
 }
 
 // GetENIConfig mocks base method
@@ -100,6 +101,21 @@ func (m *MockK8sWrapper) GetENIConfig(arg0 string) (*v1alpha1.ENIConfig, error) 
 func (mr *MockK8sWrapperMockRecorder) GetENIConfig(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetENIConfig", reflect.TypeOf((*MockK8sWrapper)(nil).GetENIConfig), arg0)
+}
+
+// GetNode mocks base method
+func (m *MockK8sWrapper) GetNode(arg0 string) (*v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNode", arg0)
+	ret0, _ := ret[0].(*v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNode indicates an expected call of GetNode
+func (mr *MockK8sWrapperMockRecorder) GetNode(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockK8sWrapper)(nil).GetNode), arg0)
 }
 
 // GetPod mocks base method

--- a/pkg/aws/ec2/api/helper.go
+++ b/pkg/aws/ec2/api/helper.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 
@@ -139,7 +138,7 @@ func (h *ec2APIHelper) CreateNetworkInterface(description *string, subnetId *str
 
 	createOutput, err := h.ec2Wrapper.CreateNetworkInterface(createInput)
 	if err != nil {
-		return nil, errors.Wrap(err, "eni wrapper: unable to create network interface")
+		return nil, err
 	}
 	if createOutput == nil ||
 		createOutput.NetworkInterface == nil ||

--- a/pkg/handler/warm.go
+++ b/pkg/handler/warm.go
@@ -71,12 +71,12 @@ func (w *warmResourceHandler) HandleCreate(resourceName string, requestCount int
 		// Reconcile the pool before retrying or returning an error
 		w.reconcilePool(shouldReconcile, resourceName, resourcePool)
 		if err == pool.ErrResourceAreBeingCooledDown {
-			w.k8sWrapper.BroadcastPodEvent(pod, ReasonResourceAllocationFailed,
+			w.k8sWrapper.BroadcastEvent(pod, ReasonResourceAllocationFailed,
 				fmt.Sprintf("Resource %s are being cooled down, will retry in %s", resourceName,
 					RequeueAfterWhenResourceCooling), v1.EventTypeWarning)
 			return ctrl.Result{Requeue: true, RequeueAfter: RequeueAfterWhenResourceCooling}, nil
 		} else if err == pool.ErrResourcesAreBeingCreated || err == pool.ErrWarmPoolEmpty {
-			w.k8sWrapper.BroadcastPodEvent(pod, ReasonResourceAllocationFailed,
+			w.k8sWrapper.BroadcastEvent(pod, ReasonResourceAllocationFailed,
 				fmt.Sprintf("Warm pool for resource %s is currently empty, will retry in %s", resourceName,
 					RequeueAfterWhenWPEmpty), v1.EventTypeWarning)
 			return ctrl.Result{Requeue: true, RequeueAfter: RequeueAfterWhenWPEmpty}, nil
@@ -93,7 +93,7 @@ func (w *warmResourceHandler) HandleCreate(resourceName string, requestCount int
 		}
 	}
 
-	w.k8sWrapper.BroadcastPodEvent(pod, ReasonResourceAllocated, fmt.Sprintf("Allocated Resource %s: %s to the pod",
+	w.k8sWrapper.BroadcastEvent(pod, ReasonResourceAllocated, fmt.Sprintf("Allocated Resource %s: %s to the pod",
 		resourceName, resID), v1.EventTypeNormal)
 
 	w.log.Info("successfully allocated and annotated resource", "UID", string(pod.UID),

--- a/pkg/handler/warm_test.go
+++ b/pkg/handler/warm_test.go
@@ -94,7 +94,7 @@ func TestWarmResourceHandler_HandleCreate(t *testing.T) {
 	mockProvider.EXPECT().GetPool(nodeName).Return(mockPool, true)
 	mockPool.EXPECT().AssignResource(uid).Return(ipAddress, true, nil)
 	mockK8sWrapper.EXPECT().AnnotatePod(pod.Namespace, pod.Name, resourceName, ipAddress).Return(nil)
-	mockK8sWrapper.EXPECT().BroadcastPodEvent(podCopy, ReasonResourceAllocated, gomock.Any(), v1.EventTypeNormal)
+	mockK8sWrapper.EXPECT().BroadcastEvent(podCopy, ReasonResourceAllocated, gomock.Any(), v1.EventTypeNormal)
 
 	mockPool.EXPECT().ReconcilePool().Return(job)
 	mockProvider.EXPECT().SubmitAsyncJob(job)
@@ -114,7 +114,7 @@ func TestWarmResourceHandler_PoolEmpty(t *testing.T) {
 
 	mockProvider.EXPECT().GetPool(nodeName).Return(mockPool, true)
 	mockPool.EXPECT().AssignResource(uid).Return("", true, pool.ErrWarmPoolEmpty)
-	mockK8sWrapper.EXPECT().BroadcastPodEvent(podCopy, ReasonResourceAllocationFailed, gomock.Any(), v1.EventTypeWarning)
+	mockK8sWrapper.EXPECT().BroadcastEvent(podCopy, ReasonResourceAllocationFailed, gomock.Any(), v1.EventTypeWarning)
 	mockPool.EXPECT().ReconcilePool().Return(job)
 	mockProvider.EXPECT().SubmitAsyncJob(job)
 

--- a/pkg/provider/branch/provider_test.go
+++ b/pkg/provider/branch/provider_test.go
@@ -298,11 +298,11 @@ func TestBranchENIProvider_CreateAndAnnotateResources(t *testing.T) {
 	mockK8sWrapper.EXPECT().GetPod(MockPodNamespace1, MockPodName1).Return(MockPod1, nil)
 	mockK8sWrapper.EXPECT().GetPodFromAPIServer(MockPodNamespace1, MockPodName1).Return(MockPod1, nil)
 	k8sHelper.EXPECT().GetPodSecurityGroups(MockPod1).Return(SecurityGroups, nil)
-	mockK8sWrapper.EXPECT().BroadcastPodEvent(MockPod1, ReasonSecurityGroupRequested, gomock.Any(), v1.EventTypeNormal)
+	mockK8sWrapper.EXPECT().BroadcastEvent(MockPod1, ReasonSecurityGroupRequested, gomock.Any(), v1.EventTypeNormal)
 	fakeTrunk.EXPECT().CreateAndAssociateBranchENIs(MockPod1, SecurityGroups, resCount).Return(EniDetails, nil)
 	mockK8sWrapper.EXPECT().AnnotatePod(MockPodNamespace1, MockPodName1, config.ResourceNamePodENI,
 		string(expectedAnnotation)).Return(nil)
-	mockK8sWrapper.EXPECT().BroadcastPodEvent(MockPod1, ReasonResourceAllocated, gomock.Any(), v1.EventTypeNormal)
+	mockK8sWrapper.EXPECT().BroadcastEvent(MockPod1, ReasonResourceAllocated, gomock.Any(), v1.EventTypeNormal)
 
 	_, err := provider.CreateAndAnnotateResources(MockPodNamespace1, MockPodName1, resCount)
 
@@ -428,10 +428,11 @@ func TestBranchENIProvider_CreateAndAnnotateResources_Annotate_Error(t *testing.
 
 	mockK8sWrapper.EXPECT().GetPod(MockPodNamespace1, MockPodName1).Return(MockPod1, nil)
 	mockK8sWrapper.EXPECT().GetPodFromAPIServer(MockPodNamespace1, MockPodName1).Return(MockPod1, nil)
-	mockK8sWrapper.EXPECT().BroadcastPodEvent(MockPod1, ReasonSecurityGroupRequested, gomock.Any(), v1.EventTypeNormal)
+	mockK8sWrapper.EXPECT().BroadcastEvent(MockPod1, ReasonSecurityGroupRequested, gomock.Any(), v1.EventTypeNormal)
 	k8sHelper.EXPECT().GetPodSecurityGroups(MockPod1).Return(SecurityGroups, nil)
 	fakeTrunk.EXPECT().CreateAndAssociateBranchENIs(MockPod1, SecurityGroups, resCount).Return(EniDetails, nil)
 	mockK8sWrapper.EXPECT().AnnotatePod(MockPodNamespace1, MockPodName1, config.ResourceNamePodENI, string(expectedAnnotation)).Return(MockError)
+	mockK8sWrapper.EXPECT().BroadcastEvent(MockPod1, ReasonBranchENIAnnotationFailed, gomock.Any(), v1.EventTypeWarning)
 	fakeTrunk.EXPECT().PushENIsToFrontOfDeleteQueue(MockPod1, EniDetails)
 
 	_, err := provider.CreateAndAnnotateResources(MockPodNamespace1, MockPodName1, resCount)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-vpc-resource-controller-k8s/issues/15

*Description of changes:* Broadcast Events when

**Trunk ENI Creation fails**
Add event with exit code and resolution on the node event when trunk ENI Creation fails.

Testing
```
kubectl get events
63s         Warning   TrunkENICreationFailed    node/ip-192-168-215-29.us-west-2.compute.internal    Failed to create trunk interface: Error Code: UnauthorizedOperation: Please verify the cluster IAM role has AmazonEKSVPCResourceController policy

```

**Branch ENI Annotation fails**
Add event to pod if branch ENI Annotation to the pod fails.

Testing
```
  Warning  BranchENIAnnotationFailed  8s (x12 over 18s)  vpc-resource-controller  failed to annotate pod with branch ENI details: pods "vpc-resource-controller-integration-deployment-8b5b68ff8-r5msc" is forbidden: User "system:serviceaccount:kube-system:eks-vpc-resource-controller" cannot patch resource "pods" in API group "" in the namespace "per-pod-sg"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
