### PR TITLE
return same error type on any node init failure

### DIFF
--- a/pkg/node/manager.go
+++ b/pkg/node/manager.go
@@ -219,12 +219,11 @@ func (m *manager) performPostUnlockOperation(nodeName string, postUnlockOperatio
 
 	log.Error(err, "failed to performed node operation", "operation", operationName)
 
-	if err == ErrInitResources {
+	if _, ok := err.(*ErrInitResources); ok {
 		// Remove entry from the cache, so it's initialized again
-		log.Info("removing the node from cache as it failed to initialize")
+		log.Error(err, "removing the node from cache as it failed to initialize")
 		delete(m.dataStore, nodeName)
 	}
-
 	return err
 }
 

--- a/pkg/node/manager_test.go
+++ b/pkg/node/manager_test.go
@@ -334,7 +334,7 @@ func Test_performPostUnlockOperation_intiFails(t *testing.T) {
 	assert.True(t, managed)
 
 	postUnlockFunc := func(provider []provider.ResourceProvider, helper api.EC2APIHelper) error {
-		return ErrInitResources
+		return &ErrInitResources{}
 	}
 
 	err = manager.performPostUnlockOperation(v1Node.Name, postUnlockFunc)

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -118,7 +118,7 @@ func TestNode_InitResources_LoadInstanceDetails_Error(t *testing.T) {
 	mockInstance.EXPECT().LoadDetails(mockHelper).Return(mockError)
 
 	err := node.InitResources(convertMockTypeToProvider(mockProviders), mockHelper)
-	assert.Error(t, mockError, err)
+	assert.Error(t, &ErrInitResources{Err: mockError}, err)
 }
 
 // TestNode_InitResources_SecondProviderInitFails tests when one of the resource provider fails to initialize


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-vpc-resource-controller-k8s/issues/16

*Description of changes:* The node can become permanently not ready if the `LoadDetails()` returns an error of a type other than ErrInitResources as we only clean the node from cache if we get ErrInitResources error type from `InitResource`.

Changed all the errors in  `InitResource` to be wrapped in `ErrInitResources` so the node can be cleared from cache on failure to initialize the node.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
