### PR TITLE
add windows integration test

### DIFF
--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -14,14 +14,15 @@
 package framework
 
 import (
+	eniConfig "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	sgp "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
 	ec2Manager "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/aws/ec2"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/deployment"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/jobs"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/namespace"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/pod"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/service"
 	sgpManager "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/sgp"
-
-	eniConfig "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -43,6 +44,8 @@ type Framework struct {
 	EC2Manager        ec2Manager.Manager
 	NSManager         namespace.Manager
 	SGPManager        sgpManager.Manager
+	SVCManager        service.Manager
+	JobManager        jobs.Manager
 }
 
 func New(options Options) *Framework {
@@ -89,5 +92,7 @@ func New(options Options) *Framework {
 		EC2Manager:        ec2Manager.NewManager(ec2, options.AWSVPCID),
 		NSManager:         namespace.NewManager(k8sClient),
 		SGPManager:        sgpManager.NewManager(k8sClient),
+		SVCManager:        service.NewManager(k8sClient),
+		JobManager:        jobs.NewManager(k8sClient),
 	}
 }

--- a/test/framework/manifest/container.go
+++ b/test/framework/manifest/container.go
@@ -13,22 +13,69 @@
 
 package manifest
 
-import v1 "k8s.io/api/core/v1"
-
-var (
-	BusyBoxContainer = v1.Container{
-		Name:            "busybox",
-		Image:           "busybox",
-		Command:         []string{"sleep", "3600"},
-		ImagePullPolicy: "IfNotPresent",
-	}
-
-	WindowsContainer = v1.Container{
-		Name:  "windows-server-iis",
-		Image: "mcr.microsoft.com/windows/servercore:1809",
-		Ports: []v1.ContainerPort{{
-			Name:          "http",
-			ContainerPort: 80,
-		}},
-	}
+import (
+	v1 "k8s.io/api/core/v1"
 )
+
+type Container struct {
+	name            string
+	image           string
+	imagePullPolicy v1.PullPolicy
+	command         []string
+	args            []string
+}
+
+func NewBusyBoxContainerBuilder() *Container {
+	return &Container{
+		name:            "busybox",
+		image:           "busybox",
+		imagePullPolicy: v1.PullIfNotPresent,
+		command:         []string{"sleep", "3600"},
+		args:            []string{},
+	}
+}
+
+func NewWindowsContainerBuilder() *Container {
+	return &Container{
+		name:            "windows-container",
+		image:           "mcr.microsoft.com/windows/servercore:ltsc2019",
+		imagePullPolicy: v1.PullIfNotPresent,
+		command:         []string{"powershell.exe"},
+		args:            []string{"Start-Sleep -s 3600"},
+	}
+}
+
+func (w *Container) Name(name string) *Container {
+	w.name = name
+	return w
+}
+
+func (w *Container) Image(image string) *Container {
+	w.image = image
+	return w
+}
+
+func (w *Container) ImagePullPolicy(policy v1.PullPolicy) *Container {
+	w.imagePullPolicy = policy
+	return w
+}
+
+func (w *Container) Command(cmd []string) *Container {
+	w.command = cmd
+	return w
+}
+
+func (w *Container) Args(arg []string) *Container {
+	w.args = arg
+	return w
+}
+
+func (w *Container) Build() v1.Container {
+	return v1.Container{
+		Name:            w.name,
+		Image:           w.image,
+		Command:         w.command,
+		Args:            w.args,
+		ImagePullPolicy: w.imagePullPolicy,
+	}
+}

--- a/test/framework/manifest/deployment.go
+++ b/test/framework/manifest/deployment.go
@@ -38,7 +38,17 @@ func NewDefaultDeploymentBuilder() *DeploymentBuilder {
 		name:                   utils.ResourceNamePrefix + "deployment",
 		replicas:               10,
 		os:                     "linux",
-		container:              BusyBoxContainer,
+		container:              NewBusyBoxContainerBuilder().Build(),
+		labels:                 map[string]string{},
+		terminationGracePeriod: 0,
+	}
+}
+
+func NewWindowsDeploymentBuilder() *DeploymentBuilder {
+	return &DeploymentBuilder{
+		namespace:              "windows-test",
+		name:                   "windows-deployment",
+		os:                     "windows",
 		labels:                 map[string]string{},
 		terminationGracePeriod: 0,
 	}

--- a/test/framework/manifest/eniconfig.go
+++ b/test/framework/manifest/eniconfig.go
@@ -10,6 +10,7 @@
 // on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
+
 package manifest
 
 import (

--- a/test/framework/manifest/jobs.go
+++ b/test/framework/manifest/jobs.go
@@ -1,0 +1,99 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package manifest
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	batchV1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type JobBuilder struct {
+	namespace              string
+	name                   string
+	parallelism            int
+	os                     string
+	container              v1.Container
+	labels                 map[string]string
+	terminationGracePeriod int
+}
+
+func NewWindowsJob() *JobBuilder {
+	return &JobBuilder{
+		namespace:              "windows-test",
+		name:                   "windows-job",
+		os:                     "windows",
+		terminationGracePeriod: 0,
+		labels:                 map[string]string{},
+	}
+}
+
+func (j *JobBuilder) Name(name string) *JobBuilder {
+	j.name = name
+	return j
+}
+
+func (j *JobBuilder) Namespace(namespace string) *JobBuilder {
+	j.namespace = namespace
+	return j
+}
+
+func (j *JobBuilder) OS(os string) *JobBuilder {
+	j.os = os
+	return j
+}
+
+func (j *JobBuilder) Container(container v1.Container) *JobBuilder {
+	j.container = container
+	return j
+}
+
+func (j *JobBuilder) PodLabels(labelKey string, labelVal string) *JobBuilder {
+	j.labels[labelKey] = labelVal
+	return j
+}
+
+func (j *JobBuilder) TerminationGracePeriod(terminationGracePeriod int) *JobBuilder {
+	j.terminationGracePeriod = terminationGracePeriod
+	return j
+}
+
+func (j *JobBuilder) Parallelism(parallelism int) *JobBuilder {
+	j.parallelism = parallelism
+	return j
+}
+
+func (j *JobBuilder) Build() *batchV1.Job {
+	return &batchV1.Job{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      j.name,
+			Namespace: j.namespace,
+		},
+		Spec: batchV1.JobSpec{
+			Parallelism: aws.Int32(int32(j.parallelism)),
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metaV1.ObjectMeta{
+					Labels: j.labels,
+				},
+				Spec: v1.PodSpec{
+					Containers:                    []v1.Container{j.container},
+					TerminationGracePeriodSeconds: aws.Int64(int64(j.terminationGracePeriod)),
+					NodeSelector:                  map[string]string{"kubernetes.io/os": j.os},
+					RestartPolicy:                 v1.RestartPolicyNever,
+				},
+			},
+		},
+	}
+}

--- a/test/framework/manifest/pod.go
+++ b/test/framework/manifest/pod.go
@@ -29,6 +29,7 @@ type PodBuilder struct {
 	os                     string
 	labels                 map[string]string
 	terminationGracePeriod int
+	restartPolicy          v1.RestartPolicy
 }
 
 func (p *PodBuilder) Build() (*v1.Pod, error) {
@@ -43,6 +44,7 @@ func (p *PodBuilder) Build() (*v1.Pod, error) {
 			Containers:                    []v1.Container{p.container},
 			NodeSelector:                  map[string]string{"kubernetes.io/os": p.os},
 			TerminationGracePeriodSeconds: aws.Int64(int64(p.terminationGracePeriod)),
+			RestartPolicy:                 p.restartPolicy,
 		},
 	}, nil
 }
@@ -51,10 +53,21 @@ func NewDefaultPodBuilder() *PodBuilder {
 	return &PodBuilder{
 		namespace:              "default",
 		name:                   utils.ResourceNamePrefix + "pod",
-		container:              BusyBoxContainer,
+		container:              NewBusyBoxContainerBuilder().Build(),
 		os:                     "linux",
 		labels:                 map[string]string{},
 		terminationGracePeriod: 0,
+		restartPolicy:          v1.RestartPolicyNever,
+	}
+}
+
+func NewWindowsPodBuilder() *PodBuilder {
+	return &PodBuilder{
+		namespace:              "windows-test",
+		name:                   "windows-pod",
+		os:                     "windows",
+		terminationGracePeriod: 0,
+		restartPolicy:          v1.RestartPolicyNever,
 	}
 }
 
@@ -75,6 +88,11 @@ func (p *PodBuilder) Container(container v1.Container) *PodBuilder {
 
 func (p *PodBuilder) OS(os string) *PodBuilder {
 	p.os = os
+	return p
+}
+
+func (p *PodBuilder) RestartPolicy(policy v1.RestartPolicy) *PodBuilder {
+	p.restartPolicy = policy
 	return p
 }
 

--- a/test/framework/manifest/service.go
+++ b/test/framework/manifest/service.go
@@ -1,0 +1,93 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package manifest
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type ServiceBuilder struct {
+	name        string
+	namespace   string
+	port        int32
+	nodePort    int32
+	protocol    v1.Protocol
+	selector    map[string]string
+	serviceType v1.ServiceType
+}
+
+func NewHTTPService() *ServiceBuilder {
+	return &ServiceBuilder{
+		port:        80,
+		protocol:    v1.ProtocolTCP,
+		selector: map[string]string{},
+	}
+}
+
+func (s *ServiceBuilder) Name(name string) *ServiceBuilder {
+	s.name = name
+	return s
+}
+
+func (s *ServiceBuilder) Namespace(namespace string) *ServiceBuilder {
+	s.namespace = namespace
+	return s
+}
+
+func (s *ServiceBuilder) Port(port int32) *ServiceBuilder {
+	s.port = port
+	return s
+}
+
+func (s *ServiceBuilder) NodePort(nodePort int32) *ServiceBuilder {
+	s.nodePort = nodePort
+	return s
+}
+
+func (s *ServiceBuilder) Protocol(protocol v1.Protocol) *ServiceBuilder {
+	s.protocol = protocol
+	return s
+}
+
+func (s *ServiceBuilder) Selector(labelKey string, labelVal string) *ServiceBuilder {
+	s.selector[labelKey] = labelVal
+	return s
+}
+
+func (s *ServiceBuilder) ServiceType(serviceType v1.ServiceType) *ServiceBuilder {
+	s.serviceType = serviceType
+	return s
+}
+
+func (s *ServiceBuilder) Build() v1.Service {
+	return v1.Service{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      s.name,
+			Namespace: s.namespace,
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "",
+				Protocol:   v1.ProtocolTCP,
+				Port:       s.port,
+				TargetPort: intstr.IntOrString{IntVal: s.port},
+				NodePort:   s.nodePort,
+			}},
+			Selector: s.selector,
+			Type:     s.serviceType,
+		},
+	}
+}

--- a/test/framework/resource/k8s/jobs/manager.go
+++ b/test/framework/resource/k8s/jobs/manager.go
@@ -1,0 +1,82 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
+
+	batchV1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Manager interface {
+	CreateAndWaitForJobToComplete(ctx context.Context, jobs *batchV1.Job) (*batchV1.Job, error)
+	DeleteAndWaitTillJobIsDeleted(ctx context.Context, jobs *batchV1.Job) error
+}
+
+func NewManager(k8sClient client.Client) Manager {
+	return &defaultManager{k8sClient: k8sClient}
+}
+
+type defaultManager struct {
+	k8sClient client.Client
+}
+
+func (m *defaultManager) CreateAndWaitForJobToComplete(ctx context.Context,
+	jobs *batchV1.Job) (*batchV1.Job, error) {
+
+	err := m.k8sClient.Create(ctx, jobs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wait till the cache is refreshed
+	time.Sleep(utils.PollIntervalShort)
+
+	observedJob := &batchV1.Job{}
+	return observedJob, wait.PollImmediateUntil(utils.PollIntervalShort, func() (bool, error) {
+		if err := m.k8sClient.Get(ctx, utils.NamespacedName(jobs), observedJob); err != nil {
+			return false, err
+		}
+		if observedJob.Status.Failed > 0 {
+			return false, fmt.Errorf("failed to execute job :%v", observedJob.Status)
+		} else if observedJob.Status.Succeeded == (*jobs.Spec.Parallelism) {
+			return true, nil
+		}
+		return false, nil
+	}, ctx.Done())
+}
+
+func (m *defaultManager) DeleteAndWaitTillJobIsDeleted(ctx context.Context, job *batchV1.Job) error {
+	err := m.k8sClient.Delete(ctx, job)
+	if err != nil {
+		return err
+	}
+	observedJob := &batchV1.Job{}
+	return wait.PollImmediateUntil(utils.PollIntervalShort, func() (bool, error) {
+		if err := m.k8sClient.Get(ctx, utils.NamespacedName(job), observedJob); err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	}, ctx.Done())
+}

--- a/test/framework/resource/k8s/service/manager.go
+++ b/test/framework/resource/k8s/service/manager.go
@@ -1,0 +1,80 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Manager interface {
+	GetService(ctx context.Context, namespace string, name string) (*v1.Service, error)
+	CreateService(ctx context.Context, service *v1.Service) (*v1.Service, error)
+	DeleteService(ctx context.Context, service *v1.Service) error
+}
+
+type defaultManager struct {
+	k8sClient client.Client
+}
+
+func NewManager(k8sClient client.Client) Manager {
+	return &defaultManager{k8sClient: k8sClient}
+}
+
+func (s *defaultManager) GetService(ctx context.Context, namespace string,
+	name string) (*v1.Service, error) {
+
+	service := &v1.Service{}
+	err := s.k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}, service)
+
+	return service, err
+}
+
+func (s *defaultManager) CreateService(ctx context.Context, service *v1.Service) (*v1.Service, error) {
+	err := s.k8sClient.Create(ctx, service)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wait till the cache is refreshed
+	time.Sleep(utils.PollIntervalShort)
+
+	observedService := &v1.Service{}
+	return observedService, wait.PollImmediateUntil(utils.PollIntervalShort, func() (bool, error) {
+		if err := s.k8sClient.Get(ctx, utils.NamespacedName(service), observedService); err != nil {
+			return false, err
+		}
+		return true, nil
+	}, ctx.Done())
+}
+
+func (s *defaultManager) DeleteService(ctx context.Context, service *v1.Service) error {
+	err := s.k8sClient.Delete(ctx, service)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+

--- a/test/integration/windows/run.sh
+++ b/test/integration/windows/run.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set -e
+
+echo "Running the windows vpc-resource-controller integraiton test
+KUBE_CONFIG_PATH: $KUBE_CONFIG_PATH
+CLUSTER_NAME: $CLUSTER_NAME
+AWS_REGION: $AWS_REGION
+"
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+curl -s -o vpc-resource-controller.yaml https://s3.us-west-2.amazonaws.com/amazon-eks/manifests/$AWS_REGION/vpc-resource-controller/latest/vpc-resource-controller.yaml  > /dev/null
+curl -s -o webhook-create-signed-cert.sh https://s3.us-west-2.amazonaws.com/amazon-eks/manifests/$AWS_REGION/vpc-admission-webhook/latest/webhook-create-signed-cert.sh  > /dev/null
+curl -s -o webhook-patch-ca-bundle.sh https://s3.us-west-2.amazonaws.com/amazon-eks/manifests/$AWS_REGION/vpc-admission-webhook/latest/webhook-patch-ca-bundle.sh  > /dev/null
+curl -s -o vpc-admission-webhook-deployment.yaml https://s3.us-west-2.amazonaws.com/amazon-eks/manifests/$AWS_REGION/vpc-admission-webhook/latest/vpc-admission-webhook-deployment.yaml  > /dev/null
+
+# Install the windows vpc-resource-controller and vpc-admission-webhook
+kubectl apply -f vpc-resource-controller.yaml
+chmod +x webhook-create-signed-cert.sh webhook-patch-ca-bundle.sh
+./webhook-create-signed-cert.sh
+cat ./vpc-admission-webhook-deployment.yaml | ./webhook-patch-ca-bundle.sh > vpc-admission-webhook.yaml
+kubectl apply -f vpc-admission-webhook.yaml
+
+#Start the test
+echo "Starting the ginkgo test suite"
+(cd $SCRIPT_DIR && CGO_ENABLED=0 GOOS=darwin ginkgo -v -timeout 15m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id "not-required")
+
+# Unisntall the windows vpc-resource-controller and vpc-admission-webhook
+kubectl delete -f vpc-resource-controller.yaml
+kubectl delete -f vpc-admission-webhook.yaml
+
+rm vpc-resource-controller.yaml
+rm webhook-create-signed-cert.sh
+rm webhook-patch-ca-bundle.sh
+rm vpc-admission-webhook-deployment.yaml

--- a/test/integration/windows/windows_suite_test.go
+++ b/test/integration/windows/windows_suite_test.go
@@ -1,0 +1,45 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package windows_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework"
+	_ "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
+	_ "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/verify"
+	verifier "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/verify"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	frameWork *framework.Framework
+	verify *verifier.PodVerification
+	ctx context.Context
+	err error
+)
+
+func TestWindowsVPCResourceController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Windows Integration Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	frameWork = framework.New(framework.GlobalOptions)
+	ctx = context.Background()
+	verify = verifier.NewPodVerification(frameWork, ctx)
+})

--- a/test/integration/windows/windows_test.go
+++ b/test/integration/windows/windows_test.go
@@ -1,0 +1,366 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package windows_test
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/manifest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsV1 "k8s.io/api/apps/v1"
+	batchV1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Windows Integration Test", func() {
+	var (
+		namespace string
+
+		// pod label kay and value which can be used to
+		// target pods to run behind a service and to
+		// get a list of pods having to key value pair
+		// for verification
+		podLabelKey string
+		podLabelVal string
+
+		// Tester Container that can be used to test network
+		// connectivity to a pod/service etc
+		testerContainer         v1.Container
+		testerContainerCommands []string
+
+		// Tester container can be wrapped in job to run parallel
+		// jobs and monitor the status of the jobs to verify if
+		// tests succeeded or failed
+		job            *batchV1.Job
+		jobParallelism int
+	)
+
+	BeforeEach(func() {
+		namespace = "windows-test"
+		jobParallelism = 1
+		podLabelKey = "role"
+		podLabelVal = "integration-test"
+	})
+
+	JustBeforeEach(func() {
+		frameWork.NSManager.CreateNamespace(ctx, namespace)
+
+		testerContainer = manifest.NewWindowsContainerBuilder().
+			Args(testerContainerCommands).
+			Build()
+
+		job = manifest.NewWindowsJob().
+			Parallelism(jobParallelism).
+			PodLabels(podLabelKey, podLabelVal).
+			Container(testerContainer).
+			Build()
+	})
+
+	JustAfterEach(func() {
+		// Will clean up all the resources used by a test
+		frameWork.NSManager.DeleteAndWaitTillNamespaceDeleted(ctx, namespace)
+	})
+
+	Describe("windows connectivity tests", func() {
+		var service *v1.Service
+
+		BeforeEach(func() {
+			service, err = frameWork.SVCManager.
+				GetService(ctx, "default", "kubernetes")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		JustBeforeEach(func() {
+			_, err = frameWork.JobManager.CreateAndWaitForJobToComplete(ctx, job)
+		})
+
+		JustAfterEach(func() {
+			err = frameWork.JobManager.DeleteAndWaitTillJobIsDeleted(ctx, job)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when multiples jobs are created that try connect to a service", func() {
+
+			BeforeEach(func() {
+				jobParallelism = 30
+				testerContainerCommands = []string{
+					GetCommandToTestTCPConnection(service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+				}
+			})
+
+			It("all job should complete", func() {
+				Expect(err).ToNot(HaveOccurred())
+
+				By("verifying the job has same IPv4 Address as allocated by the controller")
+				verify.WindowsPodsHaveExpectedIPv4Address(namespace, podLabelKey, podLabelVal)
+			})
+		})
+
+		// Negative test to reinforce the positive one works
+		Context("when creating window job to connect to unreachable port", func() {
+			BeforeEach(func() {
+				jobParallelism = 1
+				testerContainerCommands = []string{
+					GetCommandToTestTCPConnection(service.Spec.ClusterIP, 1),
+				}
+			})
+
+			It("all jobs should fail", func() {
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("when connecting to internet", func() {
+			BeforeEach(func() {
+				testerContainerCommands = []string{
+					GetCommandToTestHostConnectivity("www.amazon.com"),
+				}
+			})
+
+			It("should connect", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		// Negative test to reinforce the positive one works
+		Context("when connecting to invalid url", func() {
+			BeforeEach(func() {
+				testerContainerCommands = []string{
+					GetCommandToTestHostConnectivity("www.amazon.zzz"),
+				}
+			})
+
+			It("should fail to connect", func() {
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("windows service tests", func() {
+		var service v1.Service
+		var deployment *appsV1.Deployment
+		var deploymentContainer v1.Container
+		var testerContainer v1.Container
+		var testerJob *batchV1.Job
+		var serviceType v1.ServiceType
+		var bufferForSvcToBecomeReady time.Duration
+
+		JustBeforeEach(func() {
+
+			deploymentContainer = manifest.NewWindowsContainerBuilder().
+				Args([]string{GetCommandToStartHttpServer()}).
+				Build()
+
+			deployment = manifest.NewWindowsDeploymentBuilder().
+				Replicas(10).
+				PodLabel(podLabelKey, podLabelVal).
+				Container(deploymentContainer).
+				Build()
+
+			By("creating a deployment running a web server")
+			_, err = frameWork.DeploymentManager.CreateAndWaitUntilDeploymentReady(ctx, deployment)
+			Expect(err).ToNot(HaveOccurred())
+
+			service = manifest.NewHTTPService().
+				ServiceType(serviceType).
+				Namespace(namespace).
+				Name("windows-service-"+strings.ToLower(string(serviceType))).
+				Selector(podLabelKey, podLabelVal).
+				Build()
+
+			By("creating a service of type " + string(serviceType))
+			_, err := frameWork.SVCManager.CreateService(ctx, &service)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Allow some time for service to become ready
+			time.Sleep(bufferForSvcToBecomeReady)
+
+			testerContainer = manifest.NewWindowsContainerBuilder().
+				Args([]string{
+					GetCommandToTestTCPConnection(service.Spec.ClusterIP, service.Spec.Ports[0].Port)}).
+				Build()
+
+			testerJob = manifest.NewWindowsJob().
+				Parallelism(10).
+				Container(testerContainer).
+				Build()
+
+			By(fmt.Sprintf("creating testers to connect to service %s on %s on %d",
+				service.Name, service.Spec.ClusterIP, service.Spec.Ports[0].Port))
+			_, err = frameWork.JobManager.CreateAndWaitForJobToComplete(ctx, testerJob)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		JustAfterEach(func() {
+			err = frameWork.JobManager.DeleteAndWaitTillJobIsDeleted(ctx, testerJob)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = frameWork.SVCManager.DeleteService(ctx, &service)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = frameWork.DeploymentManager.DeleteAndWaitUntilDeploymentDeleted(ctx, deployment)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when a deployment behind lb service is created", func() {
+			BeforeEach(func() {
+				serviceType = v1.ServiceTypeLoadBalancer
+				// LB takes some extra time
+				bufferForSvcToBecomeReady = time.Minute * 2
+			})
+
+			It("load balancer service pods should be reachable", func() {})
+		})
+
+		Context("when a deployment behind cluster ip is created", func() {
+			BeforeEach(func() {
+				serviceType = v1.ServiceTypeClusterIP
+				bufferForSvcToBecomeReady = time.Second * 30
+			})
+
+			It("clusterIP service pods should be reachable", func() {})
+		})
+
+		Context("when a deployment behind cluster ip is created", func() {
+			BeforeEach(func() {
+				serviceType = v1.ServiceTypeNodePort
+				bufferForSvcToBecomeReady = time.Second * 30
+			})
+
+			It("nodeport service pods should be reachable", func() {})
+		})
+	})
+
+	Describe("when creating pod with same namespace and name", func() {
+		BeforeEach(func() {
+			testerContainerCommands = []string{
+				GetCommandToTestHostConnectivity("www.amazon.com"),
+			}
+		})
+
+		It("should successfully run the pod each time", func() {
+			for i := 0; i < 5; i++ {
+				By(fmt.Sprintf("run # %d: creating pod with sanme ns/name", i))
+				pod, err := manifest.NewWindowsPodBuilder().Container(testerContainer).Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = frameWork.PodManager.CreateAndWaitTillPodIsCompleted(ctx, pod)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = frameWork.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, pod)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	})
+
+	Describe("windows deployment tests", func() {
+		var deployment *appsV1.Deployment
+
+		Context("creating a deployment multiple times", func() {
+
+			It("deployment should be ready each time", func() {
+
+				for i := 0; i < 5; i++ {
+					By(fmt.Sprintf("run # %d: creating the deployment", i))
+
+					deployment = manifest.NewWindowsDeploymentBuilder().
+						Replicas(30).
+						Container(manifest.NewWindowsContainerBuilder().Build()).
+						PodLabel(podLabelKey, podLabelVal).
+						Build()
+
+					_, err = frameWork.DeploymentManager.CreateAndWaitUntilDeploymentReady(ctx, deployment)
+					Expect(err).ToNot(HaveOccurred())
+
+					verify.WindowsPodsHaveExpectedIPv4Address(namespace, podLabelKey, podLabelVal)
+
+					err = frameWork.DeploymentManager.DeleteAndWaitUntilDeploymentDeleted(ctx, deployment)
+					Expect(err).ToNot(HaveOccurred())
+				}
+			})
+		})
+	})
+
+	Describe("restart the vpc-resource-controller", func() {
+		var deployment *appsV1.Deployment
+		Context("pod should retain IP when vpc resource controller is deleted", func() {
+
+			JustBeforeEach(func() {
+				deploymentContainer := manifest.NewWindowsContainerBuilder().
+					Args([]string{GetCommandToStartHttpServer()}).
+					Build()
+
+				deployment = manifest.NewWindowsDeploymentBuilder().
+					Replicas(10).
+					PodLabel(podLabelKey, podLabelVal).
+					Container(deploymentContainer).
+					Build()
+			})
+
+			JustAfterEach(func() {
+				err = frameWork.DeploymentManager.DeleteAndWaitUntilDeploymentDeleted(ctx, deployment)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("", func() {
+				By("creating a deployment")
+				_, err = frameWork.DeploymentManager.CreateAndWaitUntilDeploymentReady(ctx, deployment)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("scaling the vpc controller deployment to 0")
+				frameWork.DeploymentManager.ScaleDeploymentAndWaitTillReady(ctx,
+					"kube-system", "vpc-resource-controller", 0)
+
+				By("scaling the vpc controller deployment to 1")
+				frameWork.DeploymentManager.ScaleDeploymentAndWaitTillReady(ctx, "" +
+					"kube-system", "vpc-resource-controller", 1)
+
+				// If the IP is re-assigned to some other pod the container will be stuck
+				By("scale up the windows deployment")
+				err = frameWork.DeploymentManager.ScaleDeploymentAndWaitTillReady(ctx,
+					deployment.Namespace, deployment.Name, 20)
+				Expect(err).ToNot(HaveOccurred())
+
+				verify.WindowsPodsHaveExpectedIPv4Address(namespace, podLabelKey, podLabelVal)
+			})
+		})
+	})
+})
+
+// GetCommandToTestTCPConnection checks TCP connection with the given host and port, if the
+// connection fails then the container will exit with non zero exit code which should be used
+// by the test case to fail the test case
+func GetCommandToTestTCPConnection(host string, port int32) string {
+	return fmt.Sprintf("if (-Not (Test-NetConnection %s -Port %d).TcpTestSucceeded)"+
+		" {Write-Output 'connection failed:'; exit 10}", host, port)
+}
+
+// GetCommandToTestHostConnectivity tests the DNS Resolution and the tcp connection to the
+// host
+func GetCommandToTestHostConnectivity(host string) string {
+	return fmt.Sprintf("if (-Not (Test-NetConnection -ComputerName %s "+
+		"-CommonTCPPort HTTP).TcpTestSucceeded) {Write-Output 'connection failed:'; exit 10}", host)
+}
+
+// Install and start the dot net web server, it's light weight so starts pretty quick
+func GetCommandToStartHttpServer() string {
+	return "Add-WindowsFeature Web-Server; Invoke-WebRequest " +
+		"-Uri 'https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe'" +
+		" -OutFile 'C:\\ServiceMonitor.exe'; " +
+		"echo 'ok' > C:\\inetpub\\wwwroot\\default.html; " + "C:\\ServiceMonitor.exe 'w3svc'; "
+}


### PR DESCRIPTION
*Description of changes:*
List of test cases added

- Test Networking connectivity to Service/Internet
- Create Windows Deployment behind Service of type - LB, NodePort, ClusterIP and test connection to the pods behind the service
- Create deployment multiple times and verify networking is intact
- Create pod with same name + namespace multiple time.
- Create deployment and restart vpc-resource-controller and then scale the windows deployment again to verify older IPs are not reused.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
