### PR TITLE
check for nil response from ec2 on node init/delete workflow

### DIFF
--- a/pkg/aws/ec2/instance.go
+++ b/pkg/aws/ec2/instance.go
@@ -94,7 +94,7 @@ func (i *ec2Instance) LoadDetails(ec2APIHelper api.EC2APIHelper) error {
 	if err != nil {
 		return err
 	}
-	if instance == nil {
+	if instance == nil || instance.SubnetId == nil {
 		return fmt.Errorf("failed to find instance %s details from EC2 API", i.instanceID)
 	}
 
@@ -104,8 +104,8 @@ func (i *ec2Instance) LoadDetails(ec2APIHelper api.EC2APIHelper) error {
 	if err != nil {
 		return err
 	}
-	if instanceSubnet == nil {
-		return fmt.Errorf("failed to find subnet %s for instance %s",
+	if instanceSubnet == nil || instanceSubnet.CidrBlock == nil {
+		return fmt.Errorf("failed to find subnet or CIDR block for subnet %s for instance %s",
 			i.instanceSubnetID, i.instanceID)
 	}
 	i.instanceSubnetCidrBlock = *instanceSubnet.CidrBlock
@@ -243,7 +243,7 @@ func (i *ec2Instance) updateCurrentSubnetAndCidrBlock(ec2APIHelper api.EC2APIHel
 			if err != nil {
 				return err
 			}
-			if customSubnet == nil {
+			if customSubnet == nil || customSubnet.CidrBlock == nil {
 				return fmt.Errorf("failed to find subnet %s", i.newCustomNetworkingSubnetID)
 			}
 			i.currentSubnetID = i.newCustomNetworkingSubnetID

--- a/pkg/aws/ec2/instance_test.go
+++ b/pkg/aws/ec2/instance_test.go
@@ -124,7 +124,7 @@ func TestEc2Instance_LoadDetails(t *testing.T) {
 
 // TestEc2Instance_LoadDetails_InstanceDetailsIsNull tests error is returned if the instance details
 // response from EC2 API is null
-func TestEc2Instance_LoadDetails_InstanceDetailsIsNull(t *testing.T)  {
+func TestEc2Instance_LoadDetails_InstanceDetailsIsNull(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -136,9 +136,23 @@ func TestEc2Instance_LoadDetails_InstanceDetailsIsNull(t *testing.T)  {
 	assert.NotNil(t, err)
 }
 
-// TestEc2Instance_LoadDetails_InstanceSubnetIsNull tests error is returned if the instance subnet
+// TestEc2Instance_LoadDetails_InstanceDetails_SubnetID_IsNull tests error is returned if the instance
+// is not details null but the subnet is nil
+func TestEc2Instance_LoadDetails_InstanceDetails_SubnetID_IsNull(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2Instance, mockEC2ApiHelper := getMockInstance(ctrl)
+
+	mockEC2ApiHelper.EXPECT().GetInstanceDetails(&instanceID).Return(&ec2.Instance{}, nil)
+
+	err := ec2Instance.LoadDetails(mockEC2ApiHelper)
+	assert.NotNil(t, err)
+}
+
+// TestEc2Instance_LoadDetails_InstanceSubnet_IsNull tests error is returned if the instance subnet
 // response from EC2 API is null
-func TestEc2Instance_LoadDetails_InstanceSubnetIsNull(t *testing.T)  {
+func TestEc2Instance_LoadDetails_InstanceSubnet_IsNull(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -146,6 +160,21 @@ func TestEc2Instance_LoadDetails_InstanceSubnetIsNull(t *testing.T)  {
 
 	mockEC2ApiHelper.EXPECT().GetInstanceDetails(&instanceID).Return(nwInterfaces, nil)
 	mockEC2ApiHelper.EXPECT().GetSubnet(&subnetID).Return(nil, nil)
+
+	err := ec2Instance.LoadDetails(mockEC2ApiHelper)
+	assert.NotNil(t, err)
+}
+
+// TestEc2Instance_LoadDetails_InstanceSubnet_CidrBlock_IsNull tests error is returned if the instance
+// subnet CIDR Block from GetSubnet response from EC2 API is null
+func TestEc2Instance_LoadDetails_InstanceSubnet_CidrBlock_IsNull(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2Instance, mockEC2ApiHelper := getMockInstance(ctrl)
+
+	mockEC2ApiHelper.EXPECT().GetInstanceDetails(&instanceID).Return(nwInterfaces, nil)
+	mockEC2ApiHelper.EXPECT().GetSubnet(&subnetID).Return(&ec2.Subnet{}, nil)
 
 	err := ec2Instance.LoadDetails(mockEC2ApiHelper)
 	assert.NotNil(t, err)

--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -156,7 +156,7 @@ func (b *branchENIProvider) InitResource(instance ec2.EC2Instance) error {
 			if errGetNode != nil {
 				return fmt.Errorf("failed to get node for event advertisment: %v: %v", errGetNode, err)
 			}
-			var eventMessage = fmt.Sprintf("Failed to create trunk interface: " +
+			var eventMessage = fmt.Sprintf("Failed to create trunk interface: "+
 				"Error Code: %s", awsErr.Code())
 			if awsErr.Code() == "UnauthorizedOperation" {
 				// Append resolution to the event message for users for common error

--- a/pkg/provider/branch/trunk/trunk.go
+++ b/pkg/provider/branch/trunk/trunk.go
@@ -158,6 +158,12 @@ func (t *trunkENI) InitTrunk(instance ec2.EC2Instance, podList []v1.Pod) error {
 
 	// Get trunk network interface
 	for _, nwInterface := range nwInterfaces {
+		// It's possible to get an empty network interface response if the instnace
+		// is being deleted.
+		if nwInterface == nil || nwInterface.InterfaceType == nil {
+			return fmt.Errorf("received an empty network interface response "+
+				"from EC2 %+v", nwInterface)
+		}
 		if *nwInterface.InterfaceType == "trunk" {
 			t.trunkENIId = *nwInterface.NetworkInterfaceId
 		}

--- a/pkg/provider/branch/trunk/trunk_test.go
+++ b/pkg/provider/branch/trunk/trunk_test.go
@@ -618,6 +618,23 @@ func TestTrunkENI_InitTrunk_TrunkNotExists(t *testing.T) {
 	assert.Equal(t, trunkId, trunkENI.trunkENIId)
 }
 
+// TestTrunkENI_InitTrunk_ErrWhen_EmptyNWInterfaceResponse tests error is returned if an network
+// interface without an interface type is returned
+func TestTrunkENI_InitTrunk_ErrWhen_EmptyNWInterfaceResponse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, mockEC2APIHelper, mockInstance := getMockHelperInstanceAndTrunkObject(ctrl)
+
+	mockInstance.EXPECT().InstanceID().Return(InstanceId)
+	mockEC2APIHelper.EXPECT().GetInstanceNetworkInterface(&InstanceId).Return(
+		[]*awsEc2.InstanceNetworkInterface{{InterfaceType: nil}}, nil)
+
+	err := trunkENI.InitTrunk(mockInstance, []v1.Pod{*MockPod2})
+
+	assert.NotNil(t, err)
+}
+
 // TestTrunkENI_InitTrunk_GetTrunkError tests that error is returned if the get trunk call fails
 func TestTrunkENI_InitTrunk_GetTrunkError(t *testing.T) {
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
Check if the Response return from EC2 API is not nil to prevent panic occurring occasionally when node is being deleted.
 
*Issue #, if available:* https://github.com/aws/amazon-vpc-resource-controller-k8s/issues/12

The guards added prevent panic from happening as seen in the below logs

```
{"level":"error","timestamp":"2021-03-10T02:22:34.617Z","logger":"node manager","msg":"removing the node from cache as it failed to initialize","node":"ip-10-2-237-178.us-west-2.compute.internal","error":"failed to init resources: received an empty network interface response from EC2 {\n  Attachment: {\n    AttachTime: 2021-03-10 02:19:29 +0000 UTC,\n    AttachmentId: \"eni-attach-0664c2f56a5eb3641\",\n    DeleteOnTermination: true,\n    DeviceIndex: 0,\n    Status: \"detaching\"\n  },\n  NetworkInterfaceId: \"eni-0868ff740010dba71\",\n  OwnerId: \"891055137431\",\n  Status: \"in-use\"\n}","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128\ngithub.com/aws/amazon-vpc-resource-controller-k8s/pkg/node.(*manager).performPostUnlockOperation\n\t/workspace/pkg/node/manager.go:224\ngithub.com/aws/amazon-vpc-resource-controller-k8s/pkg/node.(*manager).AddOrUpdateNode\n\t/workspace/pkg/node/manager.go:85\ngithub.com/aws/amazon-vpc-resource-controller-k8s/controllers/core.(*NodeReconciler).Reconcile\n\t/workspace/controllers/core/node_controller.go:59\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.0/pkg/internal/controller/controller.go:256\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.0/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.0/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.17.2/pkg/util/wait/wait.go:152\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.17.2/pkg/util/wait/wait.go:153\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/pkg/mod/k8s.io/apimachinery@v0.17.2/pkg/util/wait/wait.go:88"}
```

```
{"level":"error","timestamp":"2021-03-10T02:21:44.460Z","logger":"controllers.Node","msg":"failed to add node","node":"/ip-10-2-52-144.us-west-2.compute.internal","error":"failed to load instance details: failed to find instance i-04b6bcaa6672f5254 details from EC2 API","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128\ngithub.com/aws/amazon-vpc-resource-controller-k8s/controllers/core.(*NodeReconciler).Reconcile\n\t/workspace/controllers/core/node_controller.go:61\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.0/pkg/internal/controller/controller.go:256\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.0/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.0/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.17.2/pkg/util/wait/wait.go:152\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.17.2/pkg/util/wait/wait.go:153\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/pkg/mod/k8s.io/apimachinery@v0.17.2/pkg/util/wait/wait.go:88"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
