### PR TITLE
Annotate Fargate pod with matching security groups defined in SecurityGroupPolicy (CRD)

### DIFF
--- a/webhook/core/annotation_validation_webhook.go
+++ b/webhook/core/annotation_validation_webhook.go
@@ -99,6 +99,13 @@ func (a *AnnotationValidator) handleUpdate(req admission.Request) admission.Resp
 		return admission.Allowed("")
 	}
 
+	if pod.Annotations[fargatePodSgAnnotKey] !=
+		oldPod.Annotations[fargatePodSgAnnotKey] {
+		logger.Info("denying annotation", "username", req.UserInfo.Username,
+			"annotation key", fargatePodSgAnnotKey)
+		return admission.Denied("annotation is not set by mutating webhook")
+	}
+
 	return admission.Allowed("")
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In VPC Resource Controller Mutating Webhook, Fargate pods will be filtered and annotated with matching security group defined in SecurityGroupPolicy (CRD) based on the pod selector or service account selector. It also means that after this change, VPC Resource Controller Mutating Webhook will only mutate non-fargate pods by injecting “vpc.amazonaws.com/pod-eni” into pod spec limit/request, except those with hostNetwork:True.

In this way, validation logic for pod security group on EKS Fargate is centralized with pods on node groups, which happens in VPC Resource Controller Mutating Webhook. The pod annotation here will support Fargate Scheduler to fetch pod security group information, and pass it to podENI when calling ECS runTask API.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
