### PR TITLE
fix running integration test script for non default regions

### DIFF
--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -81,8 +81,10 @@ func New(options Options) *Framework {
 		StatusClient: realClient,
 	}
 
-	ec2 := ec2.New(session.Must(session.NewSession()), aws.NewConfig().
-		WithRegion(options.AWSRegion))
+	sess := session.Must(session.NewSession(&aws.Config{
+		Region: aws.String(options.AWSRegion),
+	}))
+	ec2 := ec2.New(sess, &aws.Config{Region: aws.String(options.AWSRegion)})
 
 	return &Framework{
 		K8sClient:         k8sClient,

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -6,7 +6,12 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 echo "Running VPC Resource Controller integration test with the following variables
 KUBE CONFIG: $KUBE_CONFIG_PATH
 CLUSTER_NAME: $CLUSTER_NAME
-REGION: $REGION"
+REGION: $REGION
+OS_OVERRIDE: $OS_OVERRIDE"
+
+if [[ -z "${OS_OVERRIDE}" ]]; then
+  OS_OVERRIDE=linux
+fi
 
 CLUSTER_INFO=$(aws eks describe-cluster --name $CLUSTER_NAME --region $REGION)
 
@@ -28,7 +33,7 @@ kubectl set env daemonset aws-node -n kube-system ENABLE_POD_ENI=true
 #Start the test
 echo "Starting the ginkgo test suite" 
 
-(cd $SCRIPT_DIR/perpodsg && CGO_ENABLED=0 GOOS=linux ginkgo -v -timeout 15m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID)
+(cd $SCRIPT_DIR/perpodsg && CGO_ENABLED=0 GOOS=$OS_OVERRIDE ginkgo -v -timeout 15m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID)
 
 #Tear down local resources
 echo "Detaching the IAM Policy from Cluster Service Role"


### PR DESCRIPTION
*Description of changes:*
- Ginko integration test suite was failing for all regions other than us-west-2. This fixes the problem by initializing session with the region passed in the flag.  
- Added additional flag OS_OVERRIDE to run the script on non Linux platform.

Testing
```
OS_OVERRIDE=darwin CLUSTER_NAME=abhipth-test REGION=ca-central-1 KUBE_CONFIG_PATH=~/.kube/config ./test/integration/run.sh

Ran 15 of 15 Specs in 265.092 seconds
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
