### PR TITLE
Get old pod from request in annotation webhook instead of cache

### DIFF
--- a/main.go
+++ b/main.go
@@ -294,8 +294,7 @@ func main() {
 
 	// Validating webhook for pod.
 	webhookServer.Register("/validate-v1-pod", &webhook.Admission{Handler: &webhookcore.AnnotationValidator{
-		K8sWrapper: k8sWrapper,
-		Log:        ctrl.Log.WithName("webhook").WithName("Annotation Validator"),
+		Log: ctrl.Log.WithName("webhook").WithName("Annotation Validator"),
 	}})
 
 	setupLog.Info("starting manager")

--- a/test/framework/manifest/pod.go
+++ b/test/framework/manifest/pod.go
@@ -28,6 +28,7 @@ type PodBuilder struct {
 	container              v1.Container
 	os                     string
 	labels                 map[string]string
+	annotations            map[string]string
 	terminationGracePeriod int
 	restartPolicy          v1.RestartPolicy
 }
@@ -35,9 +36,10 @@ type PodBuilder struct {
 func (p *PodBuilder) Build() (*v1.Pod, error) {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      p.name,
-			Namespace: p.namespace,
-			Labels:    p.labels,
+			Name:        p.name,
+			Namespace:   p.namespace,
+			Labels:      p.labels,
+			Annotations: p.annotations,
 		},
 		Spec: v1.PodSpec{
 			ServiceAccountName:            p.serviceAccountName,
@@ -56,6 +58,7 @@ func NewDefaultPodBuilder() *PodBuilder {
 		container:              NewBusyBoxContainerBuilder().Build(),
 		os:                     "linux",
 		labels:                 map[string]string{},
+		annotations:            map[string]string{},
 		terminationGracePeriod: 0,
 		restartPolicy:          v1.RestartPolicyNever,
 	}
@@ -98,6 +101,11 @@ func (p *PodBuilder) RestartPolicy(policy v1.RestartPolicy) *PodBuilder {
 
 func (p *PodBuilder) Labels(labels map[string]string) *PodBuilder {
 	p.labels = labels
+	return p
+}
+
+func (p *PodBuilder) Annotations(annotations map[string]string) *PodBuilder {
+	p.annotations = annotations
 	return p
 }
 

--- a/test/framework/manifest/service.go
+++ b/test/framework/manifest/service.go
@@ -31,8 +31,8 @@ type ServiceBuilder struct {
 
 func NewHTTPService() *ServiceBuilder {
 	return &ServiceBuilder{
-		port:        80,
-		protocol:    v1.ProtocolTCP,
+		port:     80,
+		protocol: v1.ProtocolTCP,
 		selector: map[string]string{},
 	}
 }

--- a/test/framework/resource/k8s/pod/manager.go
+++ b/test/framework/resource/k8s/pod/manager.go
@@ -36,6 +36,7 @@ type Manager interface {
 	DeleteAndWaitTillPodIsDeleted(context context.Context, pod *v1.Pod) error
 	GetENIDetailsFromPodAnnotation(podAnnotation map[string]string) ([]*trunk.ENIDetails, error)
 	GetPodsWithLabel(context context.Context, namespace string, labelKey string, labelValue string) ([]v1.Pod, error)
+	PatchPod(context context.Context, oldPod *v1.Pod, newPod *v1.Pod) error
 }
 
 type defaultManager struct {
@@ -129,6 +130,10 @@ func (d *defaultManager) GetENIDetailsFromPodAnnotation(podAnnotation map[string
 	json.Unmarshal([]byte(branchDetails), &eniDetails)
 
 	return eniDetails, nil
+}
+
+func (d *defaultManager) PatchPod(context context.Context, oldPod *v1.Pod, newPod *v1.Pod) error {
+	return d.k8sClient.Patch(context, newPod, client.MergeFrom(oldPod))
 }
 
 func isPodReady(pod *v1.Pod) bool {

--- a/test/framework/resource/k8s/service/manager.go
+++ b/test/framework/resource/k8s/service/manager.go
@@ -77,4 +77,3 @@ func (s *defaultManager) DeleteService(ctx context.Context, service *v1.Service)
 
 	return nil
 }
-

--- a/test/integration/webhook/validating_webhook_suite_test.go
+++ b/test/integration/webhook/validating_webhook_suite_test.go
@@ -1,0 +1,102 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package webhook
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/manifest"
+	sgpWrapper "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/sgp"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+)
+
+var frameWork *framework.Framework
+var securityGroupID string
+var ctx context.Context
+var err error
+
+var namespace = "per-pod-sg"
+var podMatchLabelKey = "role"
+var podMatchLabelVal = "test"
+var pod *v1.Pod
+var sgp *v1beta1.SecurityGroupPolicy
+
+func TestValidatingWebHook(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validating WebHook Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	frameWork = framework.New(framework.GlobalOptions)
+	ctx = context.Background()
+
+	securityGroupID, err = frameWork.EC2Manager.CreateSecurityGroup(utils.ResourceNamePrefix + "sg")
+	Expect(err).ToNot(HaveOccurred())
+
+	By("creating the namespace")
+	err := frameWork.NSManager.CreateNamespace(ctx, namespace)
+	Expect(err).ToNot(HaveOccurred())
+
+	sgp, err = manifest.NewSGPBuilder().
+		Namespace(namespace).
+		PodMatchLabel(podMatchLabelKey, podMatchLabelVal).
+		SecurityGroup([]string{securityGroupID}).Build()
+	Expect(err).NotTo(HaveOccurred())
+
+	By("creating the security group policy")
+	sgpWrapper.CreateSecurityGroupPolicy(frameWork.K8sClient, ctx, sgp)
+
+	By("creating a pod with branch ENI")
+	pod, err = manifest.NewDefaultPodBuilder().
+		Labels(map[string]string{podMatchLabelKey: podMatchLabelVal}).
+		Namespace(namespace).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+
+	pod, err = frameWork.PodManager.CreateAndWaitTillPodIsRunning(ctx, pod)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("verifying the pod eni annotation is present on branch pod")
+	Expect(pod.Annotations).To(HaveKey(config.ResourceNamePodENI))
+})
+
+var _ = AfterSuite(func() {
+	By("deleting the pod")
+	err := frameWork.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, pod)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("deleting the security group policy")
+	err = frameWork.SGPManager.DeleteAndWaitTillSecurityGroupIsDeleted(ctx, sgp)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("deleting the namespace")
+	err = frameWork.NSManager.DeleteAndWaitTillNamespaceDeleted(ctx, namespace)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("waiting for all the ENIs to be deleted after being cooled down")
+	time.Sleep(time.Second * 90)
+
+	By("deleting the security group from ec2")
+	err = frameWork.EC2Manager.DeleteSecurityGroup(securityGroupID)
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/test/integration/webhook/validating_webhook_test.go
+++ b/test/integration/webhook/validating_webhook_test.go
@@ -14,46 +14,72 @@
 package webhook
 
 import (
+	"time"
+
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/manifest"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("when updating security group annotation from unauthorized user", func() {
-	It("should fail on updating the annotation", func() {
-		newPod := pod.DeepCopy()
-		newPod.Annotations[config.ResourceNamePodENI] = "updated-annotation"
+var _ = Describe("when doing pod operations from non vpc-resource-controller user", func() {
+	Context("when updating annotations", func() {
+		It("should fail on updating pod sgp annotation", func() {
+			newPod := pod.DeepCopy()
+			newPod.Annotations[config.ResourceNamePodENI] = "updated-annotation"
 
-		err := frameWork.PodManager.PatchPod(ctx, pod, newPod)
-		Expect(err).To(HaveOccurred())
+			err := frameWork.PodManager.PatchPod(ctx, pod, newPod)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail on deleting the pod sgp annotation", func() {
+			newPod := pod.DeepCopy()
+			delete(newPod.Annotations, config.ResourceNamePodENI)
+
+			err := frameWork.PodManager.PatchPod(ctx, pod, newPod)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should not fail when modifying other annotations", func() {
+			newPod := pod.DeepCopy()
+			newPod.Annotations["some-other-annotation"] = "new-annotation"
+
+			err := frameWork.PodManager.PatchPod(ctx, pod, newPod)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 
-	It("should fail on deleting the annotation", func() {
-		newPod := pod.DeepCopy()
-		delete(newPod.Annotations, config.ResourceNamePodENI)
+	Context("when creating new pod", func() {
+		It("should fail on creating pod with sgp annotation", func() {
+			newPod, err := manifest.NewDefaultPodBuilder().
+				Annotations(map[string]string{config.ResourceNamePodENI: "new-annotation"}).
+				Namespace(namespace).
+				Name("new-pod").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
 
-		err := frameWork.PodManager.PatchPod(ctx, pod, newPod)
-		Expect(err).To(HaveOccurred())
-	})
+			_, err = frameWork.PodManager.CreateAndWaitTillPodIsRunning(ctx, newPod)
+			Expect(err).To(HaveOccurred())
+		})
 
-	It("should go through when modifying other annotations", func() {
-		newPod := pod.DeepCopy()
-		newPod.Annotations["some-other-annotation"] = "new-annotation"
+		It("should not fail on creating new pod without sgp annotation", func() {
+			newPod, err := manifest.NewDefaultPodBuilder().
+				Annotations(map[string]string{"some-other-annotation": "new-annotation"}).
+				Namespace(namespace).
+				Name("new-pod").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
 
-		err := frameWork.PodManager.PatchPod(ctx, pod, newPod)
-		Expect(err).ToNot(HaveOccurred())
-	})
+			_, err = frameWork.PodManager.CreateAndWaitTillPodIsRunning(ctx, newPod)
+			Expect(err).ToNot(HaveOccurred())
 
-	It("should fail on creating new pod with annotation", func() {
-		pod, err = manifest.NewDefaultPodBuilder().
-			Annotations(map[string]string{config.ResourceNamePodENI: "new-annotation"}).
-			Namespace(namespace).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
+			// Allow the cache to sync
+			time.Sleep(utils.PollIntervalShort)
 
-		_, err = frameWork.PodManager.CreateAndWaitTillPodIsRunning(ctx, pod)
-		Expect(err).To(HaveOccurred())
+			err = frameWork.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, newPod)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 })

--- a/test/integration/webhook/validating_webhook_test.go
+++ b/test/integration/webhook/validating_webhook_test.go
@@ -38,6 +38,14 @@ var _ = Describe("when updating security group annotation from unauthorized user
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("should go through when modifying other annotations", func() {
+		newPod := pod.DeepCopy()
+		newPod.Annotations["some-other-annotation"] = "new-annotation"
+
+		err := frameWork.PodManager.PatchPod(ctx, pod, newPod)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	It("should fail on creating new pod with annotation", func() {
 		pod, err = manifest.NewDefaultPodBuilder().
 			Annotations(map[string]string{config.ResourceNamePodENI: "new-annotation"}).

--- a/test/integration/webhook/validating_webhook_test.go
+++ b/test/integration/webhook/validating_webhook_test.go
@@ -1,0 +1,51 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package webhook
+
+import (
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/manifest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("when updating security group annotation from unauthorized user", func() {
+	It("should fail on updating the annotation", func() {
+		newPod := pod.DeepCopy()
+		newPod.Annotations[config.ResourceNamePodENI] = "updated-annotation"
+
+		err := frameWork.PodManager.PatchPod(ctx, pod, newPod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should fail on deleting the annotation", func() {
+		newPod := pod.DeepCopy()
+		delete(newPod.Annotations, config.ResourceNamePodENI)
+
+		err := frameWork.PodManager.PatchPod(ctx, pod, newPod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should fail on creating new pod with annotation", func() {
+		pod, err = manifest.NewDefaultPodBuilder().
+			Annotations(map[string]string{config.ResourceNamePodENI: "new-annotation"}).
+			Namespace(namespace).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = frameWork.PodManager.CreateAndWaitTillPodIsRunning(ctx, pod)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/test/integration/windows/windows_suite_test.go
+++ b/test/integration/windows/windows_suite_test.go
@@ -28,9 +28,9 @@ import (
 
 var (
 	frameWork *framework.Framework
-	verify *verifier.PodVerification
-	ctx context.Context
-	err error
+	verify    *verifier.PodVerification
+	ctx       context.Context
+	err       error
 )
 
 func TestWindowsVPCResourceController(t *testing.T) {

--- a/test/integration/windows/windows_test.go
+++ b/test/integration/windows/windows_test.go
@@ -327,7 +327,7 @@ var _ = Describe("Windows Integration Test", func() {
 					"kube-system", "vpc-resource-controller", 0)
 
 				By("scaling the vpc controller deployment to 1")
-				frameWork.DeploymentManager.ScaleDeploymentAndWaitTillReady(ctx, "" +
+				frameWork.DeploymentManager.ScaleDeploymentAndWaitTillReady(ctx, ""+
 					"kube-system", "vpc-resource-controller", 1)
 
 				// If the IP is re-assigned to some other pod the container will be stuck

--- a/webhook/core/annotation_validation_webhook_test.go
+++ b/webhook/core/annotation_validation_webhook_test.go
@@ -1,0 +1,290 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package core
+
+import (
+	"context"
+	"encoding/json"
+	v1 "k8s.io/api/authentication/v1"
+	"net/http"
+	"testing"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestAnnotationValidator_InjectDecoder(t *testing.T) {
+	a := AnnotationValidator{}
+	decoder := &admission.Decoder{}
+	a.InjectDecoder(decoder)
+
+	assert.Equal(t, decoder, a.decoder)
+}
+
+func TestAnnotationValidator_Handle(t *testing.T) {
+	schema := runtime.NewScheme()
+	err := clientgoscheme.AddToScheme(schema)
+	assert.NoError(t, err)
+
+	decoder, _ := admission.NewDecoder(schema)
+
+	basePod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "foo",
+			Annotations: map[string]string{
+				"existing-key": "existing-val",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "bar",
+				},
+			},
+		},
+	}
+
+	podWithoutAnnotation := basePod.DeepCopy()
+	podWithoutAnnotationRaw, err := json.Marshal(podWithoutAnnotation)
+	assert.NoError(t, err)
+
+	podWithAnnotation := basePod.DeepCopy()
+	podWithAnnotation.Annotations[config.ResourceNamePodENI] = "annotation-value"
+	podWithAnnotationRaw, err := json.Marshal(podWithAnnotation)
+	assert.NoError(t, err)
+
+	podWithDifferentAnnotation := basePod.DeepCopy()
+	podWithDifferentAnnotation.Annotations[config.ResourceNamePodENI] = "annotation-value-2"
+	podWithDifferentAnnotationRaw, err := json.Marshal(podWithDifferentAnnotation)
+	assert.NoError(t, err)
+
+	test := []struct {
+		name string
+		req  admission.Request
+		want admission.Response
+	}{
+		{
+			name: "[create] when no annotation, approve request ",
+			req: admission.Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					Operation: v1beta1.Create,
+					Object: runtime.RawExtension{
+						Raw:    podWithoutAnnotationRaw,
+						Object: podWithoutAnnotation,
+					},
+				},
+			},
+			want: admission.Response{
+				AdmissionResponse: v1beta1.AdmissionResponse{
+					Allowed: true,
+					Result: &metav1.Status{
+						Code: http.StatusOK,
+					},
+				},
+			},
+		},
+		{
+			name: "[create] when there's annotation, reject request",
+			req: admission.Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					Operation: v1beta1.Create,
+					Object: runtime.RawExtension{
+						Raw:    podWithAnnotationRaw,
+						Object: podWithAnnotation,
+					},
+				},
+			},
+			want: admission.Response{
+				AdmissionResponse: v1beta1.AdmissionResponse{
+					Allowed: false,
+					Result: &metav1.Status{
+						Code: http.StatusForbidden,
+					},
+				},
+			},
+		},
+		{
+			name: "[update] annotation created by old vpc-resource-controller SA, allow request",
+			req: admission.Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					UserInfo:  v1.UserInfo{Username: validUserInfo},
+					Operation: v1beta1.Update,
+					Object: runtime.RawExtension{
+						Raw:    podWithAnnotationRaw,
+						Object: podWithAnnotation,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    podWithoutAnnotationRaw,
+						Object: podWithoutAnnotation,
+					},
+				},
+			},
+			want: admission.Response{
+				AdmissionResponse: v1beta1.AdmissionResponse{
+					Allowed: true,
+					Result: &metav1.Status{
+						Code: http.StatusOK,
+					},
+				},
+			},
+		},
+		{
+			name: "[update] annotation created by new vpc-resource-controller SA, allow request",
+			req: admission.Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					UserInfo:  v1.UserInfo{Username: newValidUserInfo},
+					Operation: v1beta1.Update,
+					Object: runtime.RawExtension{
+						Raw:    podWithAnnotationRaw,
+						Object: podWithAnnotation,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    podWithoutAnnotationRaw,
+						Object: podWithoutAnnotation,
+					},
+				},
+			},
+			want: admission.Response{
+				AdmissionResponse: v1beta1.AdmissionResponse{
+					Allowed: true,
+					Result: &metav1.Status{
+						Code: http.StatusOK,
+					},
+				},
+			},
+		},
+		{
+			name: "[update] annotation created by unauthorized user, deny request",
+			req: admission.Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					UserInfo:  v1.UserInfo{Username: "some unauthorized user"},
+					Operation: v1beta1.Update,
+					Object: runtime.RawExtension{
+						Raw:    podWithAnnotationRaw,
+						Object: podWithAnnotation,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    podWithoutAnnotationRaw,
+						Object: podWithoutAnnotation,
+					},
+				},
+			},
+			want: admission.Response{
+				AdmissionResponse: v1beta1.AdmissionResponse{
+					Allowed: false,
+					Result: &metav1.Status{
+						Code: http.StatusForbidden,
+					},
+				},
+			},
+		},
+		{
+			name: "[update] annotation updated by unauthorized user, deny request",
+			req: admission.Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					UserInfo:  v1.UserInfo{Username: "some unauthorized user"},
+					Operation: v1beta1.Update,
+					Object: runtime.RawExtension{
+						Raw:    podWithAnnotationRaw,
+						Object: podWithAnnotation,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    podWithDifferentAnnotationRaw,
+						Object: podWithDifferentAnnotation,
+					},
+				},
+			},
+			want: admission.Response{
+				AdmissionResponse: v1beta1.AdmissionResponse{
+					Allowed: false,
+					Result: &metav1.Status{
+						Code: http.StatusForbidden,
+					},
+				},
+			},
+		},
+		{
+			name: "[update] annotation deleted by unauthorized user, deny request",
+			req: admission.Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					UserInfo:  v1.UserInfo{Username: "some unauthorized user"},
+					Operation: v1beta1.Update,
+					Object: runtime.RawExtension{
+						Raw:    podWithoutAnnotationRaw,
+						Object: podWithoutAnnotation,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    podWithAnnotationRaw,
+						Object: podWithAnnotation,
+					},
+				},
+			},
+			want: admission.Response{
+				AdmissionResponse: v1beta1.AdmissionResponse{
+					Allowed: false,
+					Result: &metav1.Status{
+						Code: http.StatusForbidden,
+					},
+				},
+			},
+		},
+		{
+			name: "[delete] delete, allow request",
+			req: admission.Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					UserInfo:  v1.UserInfo{Username: "some unauthorized user"},
+					Operation: v1beta1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw:    podWithAnnotationRaw,
+						Object: podWithAnnotation,
+					},
+				},
+			},
+			want: admission.Response{
+				AdmissionResponse: v1beta1.AdmissionResponse{
+					Allowed: true,
+					Result: &metav1.Status{
+						Code: http.StatusOK,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			h := &AnnotationValidator{
+				decoder: decoder,
+				Log:     zap.New(),
+			}
+			got := h.Handle(ctx, tt.req)
+			assert.Equal(t, tt.want.Allowed, got.Allowed)
+			assert.Equal(t, tt.want.Result.Status, got.Result.Status)
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*
Switched to get the old pod from the webhook request instead of getting it from the cache.

*Description of changes:*
- get old pod from request instead of using cache
- add unit test cases for annotation webhook
- add integration test suite for validating annotation webhook

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
