### PR TITLE
Deprecate v1beta1 in crd and webhooks

### DIFF
--- a/config/crd/bases/vpcresources.k8s.aws_securitygrouppolicies.yaml
+++ b/config/crd/bases/vpcresources.k8s.aws_securitygrouppolicies.yaml
@@ -1,163 +1,153 @@
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.5
-  creationTimestamp: null
   name: securitygrouppolicies.vpcresources.k8s.aws
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.securityGroups.groupIds
-    description: The security group IDs to apply to the elastic network interface
-      of pods that match this policy
-    name: Security-Group-Ids
-    type: string
   group: vpcresources.k8s.aws
   names:
     kind: SecurityGroupPolicy
     listKind: SecurityGroupPolicyList
     plural: securitygrouppolicies
     shortNames:
-    - sgp
+      - sgp
     singular: securitygrouppolicy
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: Custom Resource Definition for applying security groups to pods
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: SecurityGroupPolicySpec defines the desired state of SecurityGroupPolicy
-          properties:
-            podSelector:
-              description: A label selector is a label query over a set of resources.
-                The result of matchLabels and matchExpressions are ANDed. An empty
-                label selector matches all objects. A null label selector matches
-                no objects.
-              properties:
-                matchExpressions:
-                  description: matchExpressions is a list of label selector requirements.
-                    The requirements are ANDed.
-                  items:
-                    description: A label selector requirement is a selector that contains
-                      values, a key, and an operator that relates the key and values.
-                    properties:
-                      key:
-                        description: key is the label key that the selector applies
-                          to.
-                        type: string
-                      operator:
-                        description: operator represents a key's relationship to a
-                          set of values. Valid operators are In, NotIn, Exists and
-                          DoesNotExist.
-                        type: string
-                      values:
-                        description: values is an array of string values. If the operator
-                          is In or NotIn, the values array must be non-empty. If the
-                          operator is Exists or DoesNotExist, the values array must
-                          be empty. This array is replaced during a strategic merge
-                          patch.
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - key
-                    - operator
-                    type: object
-                  type: array
-                matchLabels:
-                  additionalProperties:
-                    type: string
-                  description: matchLabels is a map of {key,value} pairs. A single
-                    {key,value} in the matchLabels map is equivalent to an element
-                    of matchExpressions, whose key field is "key", the operator is
-                    "In", and the values array contains only "value". The requirements
-                    are ANDed.
-                  type: object
-              type: object
-            securityGroups:
-              description: GroupIds contains the list of security groups that will
-                be applied to the network interface of the pod matching the criteria.
-              properties:
-                groupIds:
-                  description: Groups is the list of EC2 Security Groups Ids that
-                    need to be applied to the ENI of a Pod.
-                  items:
-                    type: string
-                  maxItems: 5
-                  minItems: 1
-                  type: array
-              type: object
-            serviceAccountSelector:
-              description: A label selector is a label query over a set of resources.
-                The result of matchLabels and matchExpressions are ANDed. An empty
-                label selector matches all objects. A null label selector matches
-                no objects.
-              properties:
-                matchExpressions:
-                  description: matchExpressions is a list of label selector requirements.
-                    The requirements are ANDed.
-                  items:
-                    description: A label selector requirement is a selector that contains
-                      values, a key, and an operator that relates the key and values.
-                    properties:
-                      key:
-                        description: key is the label key that the selector applies
-                          to.
-                        type: string
-                      operator:
-                        description: operator represents a key's relationship to a
-                          set of values. Valid operators are In, NotIn, Exists and
-                          DoesNotExist.
-                        type: string
-                      values:
-                        description: values is an array of string values. If the operator
-                          is In or NotIn, the values array must be non-empty. If the
-                          operator is Exists or DoesNotExist, the values array must
-                          be empty. This array is replaced during a strategic merge
-                          patch.
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - key
-                    - operator
-                    type: object
-                  type: array
-                matchLabels:
-                  additionalProperties:
-                    type: string
-                  description: matchLabels is a map of {key,value} pairs. A single
-                    {key,value} in the matchLabels map is equivalent to an element
-                    of matchExpressions, whose key field is "key", the operator is
-                    "In", and the values array contains only "value". The requirements
-                    are ANDed.
-                  type: object
-              type: object
-          type: object
-      type: object
-  version: v1beta1
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+    - name: v1beta1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - jsonPath: .spec.securityGroups.groupIds
+          description: The security group IDs to apply to the elastic network interface
+            of pods that match this policy
+          name: Security-Group-Ids
+          type: string
+      subresources: {}
+      schema:
+        openAPIV3Schema:
+          description: Custom Resource Definition for applying security groups to pods
+          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SecurityGroupPolicySpec defines the desired state of SecurityGroupPolicy
+              properties:
+                podSelector:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that contains
+                          values, a key, and an operator that relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a
+                              set of values. Valid operators are In, NotIn, Exists and
+                              DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator
+                              is In or NotIn, the values array must be non-empty. If the
+                              operator is Exists or DoesNotExist, the values array must
+                              be empty. This array is replaced during a strategic merge
+                              patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator is
+                        "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                securityGroups:
+                  description: GroupIds has security groups carried in the CRD SecurityGroupPolicy.
+                  properties:
+                    groupIds:
+                      description: Groups is the list of EC2 Security Groups Ids that
+                        need to be applied to the ENI of a Pod.
+                      items:
+                        type: string
+                      maxItems: 5
+                      minItems: 1
+                      type: array
+                  type: object
+                serviceAccountSelector:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that contains
+                          values, a key, and an operator that relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a
+                              set of values. Valid operators are In, NotIn, Exists and
+                              DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator
+                              is In or NotIn, the values array must be non-empty. If the
+                              operator is Exists or DoesNotExist, the values array must
+                              be empty. This array is replaced during a strategic merge
+                              patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator is
+                        "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+              type: object
+          type: object

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,53 +1,51 @@
 
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
-  name: mutating-webhook-configuration
+  name: vpc-resource-mutating-webhook
 webhooks:
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: webhook-service
-      namespace: system
-      path: /mutate-v1-pod
-  failurePolicy: Ignore
-  name: mpod.vpc.k8s.aws
-  timeoutSeconds: 5
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - pods
-
+  - clientConfig:
+      caBundle: CA_BUNDLE
+      url: "https://127.0.0.1:9443/mutate-v1-pod"
+    failurePolicy: Ignore
+    name: mpod.vpc.k8s.aws
+    timeoutSeconds: 5
+    reinvocationPolicy: IfNeeded
+    admissionReviewVersions: ["v1beta1"]
+    matchPolicy: Equivalent
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
-  name: validating-webhook-configuration
+  name: vpc-resource-validating-webhook
 webhooks:
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-v1-pod
-  failurePolicy: Ignore
-  name: vpod.vpc.k8s.aws
-  timeoutSeconds: 5
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - pods
+  - clientConfig:
+      caBundle: CA_BUNDLE
+      url: "https://127.0.0.1:9443/validate-v1-pod"
+    failurePolicy: Ignore
+    name: vpod.vpc.k8s.aws
+    timeoutSeconds: 5
+    admissionReviewVersions: ["v1beta1"]
+    matchPolicy: Equivalent
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - pods
+    sideEffects: None


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since kubernetes are removing service to version v1beta1, we want to deprecate API version v1beta1 and start using v1 in CustomResourceDefinition and webhooks. 

Tests

- Applied updated CRD to existing cluster
- Applied updated webhooks to existing cluster

No errors were observed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
