### PR TITLE
fix unit-test and integration-test github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -4,31 +4,14 @@ on:
     branches:
       - master
   pull_request:
-    types: [unlabeled, opened, synchronize, reopened]
-    branches:
-      - master
+    types: [opened, synchronize, reopened]
 jobs:
-  labeler:
-    if: | # Add/Re-Add testing-disabled anytime there's a commit or PR is opened
-      github.event.action == 'opened' ||
-      github.event.action == 'synchronize' ||
-      github.event.action == 'reopened'
-    permissions:
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/labeler@v3
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
   integration-test:
     name: integration-test
     runs-on: self-hosted
     env:
       CLUSTER_NAME: vpc-rc-ci-test
       K8S_VERSION: 1.19
-    if: | # Run test only when testing-disabled removed or it's push to a branch
-      github.event_name == 'push' ||
-      (github.event.action == 'unlabeled' && !contains(github.event.pull_request.labels.*.name, 'test-disabled'))
     steps:
       - name: clean work dir from previous runs
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened]
+
 jobs:
   integration-test:
     name: integration-test

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
            arch=$(go env GOARCH)
            os=$(go env GOOS)
-           curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
+           curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_${os}_${arch}.tar.gz | tar -xz -C /tmp/
            sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
            export PATH=$PATH:/usr/local/kubebuilder/bin
     - name: Checkout Repository


### PR DESCRIPTION
*Issue #, if available:*

Unit test is breaking because of upstream issue: https://github.com/kubernetes-sigs/kubebuilder/issues/2311
Changing integration-test actions to use manual approval till GitHub supports protected workflow - https://github.com/actions/runner/issues/494

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
