### PR TITLE
remove networking for succeeded/failed pods

### DIFF
--- a/config/controller/controller.yaml
+++ b/config/controller/controller.yaml
@@ -17,7 +17,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:

--- a/controllers/core/pod_controller.go
+++ b/controllers/core/pod_controller.go
@@ -47,6 +47,8 @@ type PodReconciler struct {
 // if the resource is supported by the controller.
 func (r *PodReconciler) Reconcile(request custom.Request) (ctrl.Result, error) {
 	var isDeleteEvent bool
+	var hasPodCompleted bool
+
 	var pod *v1.Pod
 
 	if request.DeletedObject != nil {
@@ -67,6 +69,11 @@ func (r *PodReconciler) Reconcile(request custom.Request) (ctrl.Result, error) {
 		// convert to pod object
 		pod = obj.(*v1.Pod)
 	}
+
+	// If Pod is Completed, the networking for the Pod should be removed
+	// given the container will not be restarted again
+	hasPodCompleted = pod.Status.Phase == v1.PodSucceeded ||
+		pod.Status.Phase == v1.PodFailed
 
 	logger := r.Log.WithValues("UID", pod.UID, "pod", request.NamespacedName,
 		"node", pod.Spec.NodeName)
@@ -95,7 +102,7 @@ func (r *PodReconciler) Reconcile(request custom.Request) (ctrl.Result, error) {
 
 		var err error
 		var result ctrl.Result
-		if isDeleteEvent {
+		if isDeleteEvent || hasPodCompleted {
 			result, err = resourceHandler.HandleDelete(pod)
 		} else {
 			result, err = resourceHandler.HandleCreate(int(totalCount), pod)
@@ -104,7 +111,8 @@ func (r *PodReconciler) Reconcile(request custom.Request) (ctrl.Result, error) {
 			return result, err
 		}
 		logger.V(1).Info("handled resource without error",
-			"resource", resourceName, "is delete event", isDeleteEvent)
+			"resource", resourceName, "is delete event", isDeleteEvent,
+			"has completed pod", hasPodCompleted)
 	}
 
 	return ctrl.Result{}, nil
@@ -125,7 +133,7 @@ func getAggregateResources(pod *v1.Pod) map[string]int64 {
 	return aggregateResources
 }
 
-// SetupWithManager adds the custom Pod controller's runnable to the mangers
+// SetupWithManager adds the custom Pod controller's runnable to the manager's
 // list of runnable. After Manager acquire the lease the pod controller runnable
 // will be started and the Pod events will be sent to Reconcile function
 func (r *PodReconciler) SetupWithManager(manager ctrl.Manager,

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/pod/mock_podapiwrapper.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/pod/mock_podapiwrapper.go
@@ -90,6 +90,21 @@ func (mr *MockPodClientAPIWrapperMockRecorder) GetPodFromAPIServer(arg0, arg1 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodFromAPIServer", reflect.TypeOf((*MockPodClientAPIWrapper)(nil).GetPodFromAPIServer), arg0, arg1)
 }
 
+// GetRunningPodsOnNode mocks base method
+func (m *MockPodClientAPIWrapper) GetRunningPodsOnNode(arg0 string) ([]v1.Pod, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRunningPodsOnNode", arg0)
+	ret0, _ := ret[0].([]v1.Pod)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRunningPodsOnNode indicates an expected call of GetRunningPodsOnNode
+func (mr *MockPodClientAPIWrapperMockRecorder) GetRunningPodsOnNode(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunningPodsOnNode", reflect.TypeOf((*MockPodClientAPIWrapper)(nil).GetRunningPodsOnNode), arg0)
+}
+
 // ListPods mocks base method
 func (m *MockPodClientAPIWrapper) ListPods(arg0 string) (*v1.PodList, error) {
 	m.ctrl.T.Helper()

--- a/pkg/k8s/pod/converter.go
+++ b/pkg/k8s/pod/converter.go
@@ -106,6 +106,9 @@ func (c *PodConverter) StripDownPod(pod *v1.Pod) *v1.Pod {
 			ServiceAccountName: pod.Spec.ServiceAccountName,
 			NodeName:           pod.Spec.NodeName,
 		},
+		Status: v1.PodStatus{
+			Phase: pod.Status.Phase,
+		},
 	}
 }
 

--- a/pkg/node/manager.go
+++ b/pkg/node/manager.go
@@ -131,7 +131,7 @@ func (m *manager) addOrUpdateNode(v1Node *v1.Node) (postUnlockOperation func(res
 		}
 
 		// Node is eligible for management.
-		instanceId := getNodeInstanceID(v1Node)
+		instanceId := GetNodeInstanceID(v1Node)
 		os := getNodeOS(v1Node)
 
 		if instanceId == "" || os == "" {
@@ -233,8 +233,8 @@ func (m *manager) isSelectedForManagement(v1node *v1.Node) bool {
 	return canAttachTrunk(v1node)
 }
 
-// getNodeInstanceID returns the EC2 instance ID of a node
-func getNodeInstanceID(node *v1.Node) string {
+// GetNodeInstanceID returns the EC2 instance ID of a node
+func GetNodeInstanceID(node *v1.Node) string {
 	var instanceID string
 
 	if node.Spec.ProviderID != "" {

--- a/pkg/node/manager_test.go
+++ b/pkg/node/manager_test.go
@@ -291,7 +291,7 @@ func Test_isWindowsNode_Linux(t *testing.T) {
 
 // Test_getNodeInstanceID test if the correct node id is retrieved from the provider id
 func Test_getNodeInstanceID(t *testing.T) {
-	id := getNodeInstanceID(v1Node)
+	id := GetNodeInstanceID(v1Node)
 	assert.Equal(t, instanceID, id)
 }
 

--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -134,13 +134,13 @@ func (b *branchENIProvider) InitResource(instance ec2.EC2Instance) error {
 	// Initialize the Trunk ENI
 	start := time.Now()
 
-	podList, err := b.apiWrapper.PodAPI.ListPods(nodeName)
+	podList, err := b.apiWrapper.PodAPI.GetRunningPodsOnNode(nodeName)
 	if err != nil {
 		log.Error(err, "failed to get list of pod on node")
 		return err
 	}
 
-	err = trunkENI.InitTrunk(instance, podList.Items)
+	err = trunkENI.InitTrunk(instance, podList)
 	if err != nil {
 		// If it's an AWS Error, get the exit code without the error message to avoid
 		// broadcasting multiple different messaged events
@@ -404,7 +404,10 @@ func (b *branchENIProvider) DeleteBranchUsedByPods(nodeName string, UID string) 
 
 	err := trunkENI.PushBranchENIsToCoolDownQueue(UID)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to delte branch eni used by the pod %s", UID)
+		// Don't return an error, we don't want to requeue the job
+		log.Info("failed to delete branch ENI, pod networking could have been removed if "+
+			"pod succeeded/failed earlier", "uid", UID, "error", err)
+		return ctrl.Result{}, nil
 	}
 
 	log.V(1).Info("deleted branch interface/s used by the pod")

--- a/pkg/provider/ip/provider.go
+++ b/pkg/provider/ip/provider.go
@@ -71,14 +71,14 @@ func (p *ipv4Provider) InitResource(instance ec2.EC2Instance) error {
 		return err
 	}
 
-	pods, err := p.apiWrapper.PodAPI.ListPods(nodeName)
+	pods, err := p.apiWrapper.PodAPI.GetRunningPodsOnNode(nodeName)
 	if err != nil {
 		return err
 	}
 
 	podToResourceMap := map[string]string{}
 	usedIPSet := map[string]struct{}{}
-	for _, pod := range pods.Items {
+	for _, pod := range pods {
 		annotation, present := pod.Annotations[config.ResourceNameIPAddress]
 		if !present {
 			continue

--- a/pkg/resource/manager_test.go
+++ b/pkg/resource/manager_test.go
@@ -14,7 +14,6 @@
 package resource
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/handler"
@@ -54,5 +53,5 @@ func Test_NewResourceManager(t *testing.T) {
 	assert.True(t, ok)
 
 	handlers := manger.GetResourceHandlers()
-	assert.True(t, reflect.DeepEqual(handlers, []handler.Handler{podENIHandler, ipAddressHandler}))
+	assert.ElementsMatch(t, handlers, []handler.Handler{podENIHandler, ipAddressHandler})
 }

--- a/scripts/test/README.md
+++ b/scripts/test/README.md
@@ -21,7 +21,7 @@ K8S_VERSION=<k8s-Version>
   ```
 - Start test Execution
   ```
-  ./test-on-dataplane.sh -n $CLUSTER_NAME
+  ./test-with-eksctl.sh -n $CLUSTER_NAME
   ```
 - Delete the IAM Role and Policies
   ```

--- a/scripts/test/template/eksctl/eks-cluster.yaml
+++ b/scripts/test/template/eksctl/eks-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
 nodeGroups:
   - name: linux-instance
     instanceType: c5.large  # For SGP Tests, this must be a Nitro-based Instance
-    desiredCapacity: 2
+    desiredCapacity: 3
     iam:
       instanceRoleName: INSTANCE_ROLE_NAME # Static IAM Role Name for easily adding IAM Policies after creation
       attachPolicyARNs:

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,61 @@
+## Ginkgo Test Suites
+
+All Ginkgo Integration test suites are located in `test/integration` directory.
+
+### Prerequisite
+- Have all Nitro Based Instances in your EKS Cluster.
+- Have at least 3 X c5.xlarge instance type or larger in terms of number of ENI/IP allocatable.
+
+### Available Ginkgo Focus
+
+The Integration test suite provides the following focuses.
+
+- **[LOCAL]** 
+   
+  These tests can be run when the controller is running on Data Plane. This is idle for CI Setup where the controller runs on Data Plane instead of Control Plane. See `scripts/test/README.md` for details.
+  ```
+  # Use when running test on the Controller on EKS Control Plane. 
+  --skip=LOCAL 
+  ```
+  
+### How to Run the Integration Tests
+
+#### Running Individual Ginkgo Test Suites
+
+1. Set the environment variables.
+   ```
+   CLUSTER_NAME=<test-cluster-name>
+   KUBE_CONFIG_PATH=<path-to-kube-config>
+   AWS_REGION=<test-cluster-region>
+   VPC_ID=<cluster-vpc-id>
+   OS=<darwin/linux/etc>
+   ```
+2. Invoke all available test suites.
+   ```
+   cd test/integration
+   echo "Running Validation Webhook Tests"
+   (cd webhook && CGO_ENABLED=0 GOOS=$OS ginkgo -v -timeout 40m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id $VPC_ID)
+   echo "Running Security Group for Pods Integration Tests"
+   (cd perpodsg && CGO_ENABLED=0 GOOS=$OS ginkgo -v -timeout 40m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id $VPC_ID)
+   ```
+
+#### Running Integration tests on Controller running on EKS Control Plane
+
+1. Invoke the test script
+   ```
+   cd test/integration
+   CLUSTER_NAME=<test-cluster-name> /
+   KUBE_CONFIG_PATH=<path-to-kube-config> /
+   AWS_REGION=<test-cluster-region> /
+   OS_OVERRIDE=<darwin/linux/etc> /
+   run.sh
+   ```
+
+#### Running Integration tests on Controller running on Data Plane
+
+This is intended for the purposes of local development, testing and CI Setup. For more details refer the steps are provided in `scripts/test/README.md`
+
+### Future Work
+- Once we have more test suites, we can provide a script instead of invoking each suite manually.
+- Add Windows tests to the list once the support is enabled.
+- Move the script based tests in `integration-test` to Ginkgo Based integration/e2e test.

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -17,9 +17,11 @@ import (
 	eniConfig "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	sgp "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
 	ec2Manager "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/aws/ec2"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/controller"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/deployment"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/jobs"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/namespace"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/node"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/pod"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/service"
 	sgpManager "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/sgp"
@@ -46,6 +48,8 @@ type Framework struct {
 	SGPManager        sgpManager.Manager
 	SVCManager        service.Manager
 	JobManager        jobs.Manager
+	NodeManager       node.Manager
+	ControllerManager controller.Manager
 }
 
 func New(options Options) *Framework {
@@ -96,5 +100,7 @@ func New(options Options) *Framework {
 		SGPManager:        sgpManager.NewManager(k8sClient),
 		SVCManager:        service.NewManager(k8sClient),
 		JobManager:        jobs.NewManager(k8sClient),
+		NodeManager:       node.NewManager(k8sClient),
+		ControllerManager: controller.NewManager(k8sClient),
 	}
 }

--- a/test/framework/manifest/container.go
+++ b/test/framework/manifest/container.go
@@ -23,6 +23,7 @@ type Container struct {
 	imagePullPolicy v1.PullPolicy
 	command         []string
 	args            []string
+	containerPort   []v1.ContainerPort
 }
 
 func NewBusyBoxContainerBuilder() *Container {
@@ -70,6 +71,13 @@ func (w *Container) Args(arg []string) *Container {
 	return w
 }
 
+func (w *Container) AddContainerPort(containerPort int) *Container {
+	w.containerPort = append(w.containerPort, v1.ContainerPort{
+		ContainerPort: int32(containerPort),
+	})
+	return w
+}
+
 func (w *Container) Build() v1.Container {
 	return v1.Container{
 		Name:            w.name,
@@ -77,5 +85,6 @@ func (w *Container) Build() v1.Container {
 		Command:         w.command,
 		Args:            w.args,
 		ImagePullPolicy: w.imagePullPolicy,
+		Ports:           w.containerPort,
 	}
 }

--- a/test/framework/manifest/jobs.go
+++ b/test/framework/manifest/jobs.go
@@ -23,11 +23,13 @@ import (
 type JobBuilder struct {
 	namespace              string
 	name                   string
+	nodeName               string
 	parallelism            int
 	os                     string
 	container              v1.Container
 	labels                 map[string]string
 	terminationGracePeriod int
+	restartPolicy          v1.RestartPolicy
 }
 
 func NewWindowsJob() *JobBuilder {
@@ -36,7 +38,19 @@ func NewWindowsJob() *JobBuilder {
 		name:                   "windows-job",
 		os:                     "windows",
 		terminationGracePeriod: 0,
+		restartPolicy:          v1.RestartPolicyNever,
 		labels:                 map[string]string{},
+	}
+}
+
+func NewLinuxJob() *JobBuilder {
+	return &JobBuilder{
+		namespace:              "linux-sgp-test",
+		name:                   "linux-job",
+		os:                     "linux",
+		restartPolicy:          v1.RestartPolicyNever,
+		labels:                 map[string]string{},
+		terminationGracePeriod: 0,
 	}
 }
 
@@ -70,8 +84,18 @@ func (j *JobBuilder) TerminationGracePeriod(terminationGracePeriod int) *JobBuil
 	return j
 }
 
+func (j *JobBuilder) RestartPolicy(policy v1.RestartPolicy) *JobBuilder {
+	j.restartPolicy = policy
+	return j
+}
+
 func (j *JobBuilder) Parallelism(parallelism int) *JobBuilder {
 	j.parallelism = parallelism
+	return j
+}
+
+func (j *JobBuilder) ForNode(nodeName string) *JobBuilder {
+	j.nodeName = nodeName
 	return j
 }
 
@@ -82,16 +106,18 @@ func (j *JobBuilder) Build() *batchV1.Job {
 			Namespace: j.namespace,
 		},
 		Spec: batchV1.JobSpec{
-			Parallelism: aws.Int32(int32(j.parallelism)),
+			Parallelism:  aws.Int32(int32(j.parallelism)),
+			BackoffLimit: aws.Int32(int32(j.parallelism)),
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metaV1.ObjectMeta{
 					Labels: j.labels,
 				},
 				Spec: v1.PodSpec{
+					NodeName:                      j.nodeName,
 					Containers:                    []v1.Container{j.container},
 					TerminationGracePeriodSeconds: aws.Int64(int64(j.terminationGracePeriod)),
 					NodeSelector:                  map[string]string{"kubernetes.io/os": j.os},
-					RestartPolicy:                 v1.RestartPolicyNever,
+					RestartPolicy:                 j.restartPolicy,
 				},
 			},
 		},

--- a/test/framework/resource/k8s/controller/manager.go
+++ b/test/framework/resource/k8s/controller/manager.go
@@ -1,0 +1,96 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	DeploymentName     = "vpc-resource-controller"
+	Namespace          = "kube-system"
+	LeaderLeaseMapName = "cp-vpc-resource-controller"
+)
+
+type LeaderLease struct {
+	HolderIdentity string
+}
+
+type Manager interface {
+	WaitTillControllerHasLeaderLease(ctx context.Context) (string, error)
+}
+
+func NewManager(k8sClient client.Client) Manager {
+	return &defaultManager{k8sClient: k8sClient}
+}
+
+type defaultManager struct {
+	k8sClient client.Client
+}
+
+func (d *defaultManager) WaitTillControllerHasLeaderLease(ctx context.Context) (string, error) {
+	leaderLeaseMap := &v1.ConfigMap{}
+
+	controllerPods := &v1.PodList{}
+	err := d.k8sClient.List(ctx, controllerPods, &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{"app": "vpc-resource-controller"}),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var leaderPodName string
+	err = wait.PollImmediateUntil(utils.PollIntervalMedium, func() (done bool, err error) {
+		err = d.k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: Namespace,
+			Name:      LeaderLeaseMapName,
+		}, leaderLeaseMap)
+		if err != nil {
+			return false, err
+		}
+		key, found := leaderLeaseMap.ObjectMeta.
+			Annotations["control-plane.alpha.kubernetes.io/leader"]
+		if !found {
+			return false, fmt.Errorf("failed to find leader election configmap")
+		}
+
+		lease := &LeaderLease{}
+		err = json.Unmarshal([]byte(key), lease)
+		if err != nil {
+			return false, err
+		}
+
+		for _, pod := range controllerPods.Items {
+			// The Holder identity consists of the Leader Pod name + random UID
+			if strings.Contains(lease.HolderIdentity, pod.Name) {
+				leaderPodName = pod.Name
+				return true, nil
+			}
+		}
+		return false, nil
+	}, ctx.Done())
+
+	return leaderPodName, err
+}

--- a/test/framework/resource/k8s/controller/wrapper.go
+++ b/test/framework/resource/k8s/controller/wrapper.go
@@ -1,0 +1,60 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/deployment"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func RestartController(ctx context.Context, manager Manager, depManager deployment.Manager) string {
+
+	ScaleControllerDeployment(ctx, depManager, 0)
+	ScaleControllerDeployment(ctx, depManager, 2)
+
+	By(fmt.Sprintf("waiting for the leader to take over lease"))
+	time.Sleep(time.Second * 60)
+
+	By("waiting till the new controller has the leader lease")
+	leaderPod, err := manager.WaitTillControllerHasLeaderLease(ctx)
+	Expect(err).ToNot(HaveOccurred())
+
+	By(fmt.Sprintf("waiting for the leader %s to initalize", leaderPod))
+	time.Sleep(time.Second * 30)
+
+	return leaderPod
+}
+
+func ScaleControllerDeployment(ctx context.Context, deploymentManager deployment.Manager, replica int) {
+	By(fmt.Sprintf("scaling down the controller deployment to %d", replica))
+	err := deploymentManager.ScaleDeploymentAndWaitTillReady(ctx,
+		Namespace,
+		DeploymentName,
+		int32(replica))
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func VerifyLeaseHolderIsSame(ctx context.Context, manager Manager,
+	previousLeaseHolder string) {
+	By("verifying the lease didn't switch")
+	newLeaderName, err := manager.WaitTillControllerHasLeaderLease(ctx)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(newLeaderName).To(Equal(previousLeaseHolder))
+}

--- a/test/framework/resource/k8s/deployment/manager.go
+++ b/test/framework/resource/k8s/deployment/manager.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
 
+	"github.com/aws/aws-sdk-go/aws"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -38,6 +39,39 @@ func NewManager(k8sClient client.Client) Manager {
 
 type defaultManager struct {
 	k8sClient client.Client
+}
+
+func (m *defaultManager) ScaleDeployment(ctx context.Context, name string, namespace string, replicas int) error {
+	var deployment *appsv1.Deployment
+	err := m.k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}, deployment)
+	if err != nil {
+		return err
+	}
+
+	scaledDeployment := deployment.DeepCopy()
+	scaledDeployment.Spec.Replicas = aws.Int32(int32(replicas))
+
+	err = m.k8sClient.Patch(ctx, scaledDeployment, client.MergeFrom(deployment))
+	if err != nil {
+		return err
+	}
+
+	observedDP := &appsv1.Deployment{}
+	return wait.PollImmediateUntil(utils.PollIntervalShort, func() (bool, error) {
+		if err := m.k8sClient.Get(ctx, utils.NamespacedName(scaledDeployment), observedDP); err != nil {
+			return false, err
+		}
+		if observedDP.Status.UpdatedReplicas == (*scaledDeployment.Spec.Replicas) &&
+			observedDP.Status.Replicas == (*scaledDeployment.Spec.Replicas) &&
+			observedDP.Status.AvailableReplicas == (*scaledDeployment.Spec.Replicas) &&
+			observedDP.Status.ObservedGeneration >= scaledDeployment.Generation {
+			return true, nil
+		}
+		return false, nil
+	}, ctx.Done())
 }
 
 func (m *defaultManager) CreateAndWaitUntilDeploymentReady(ctx context.Context, dp *appsv1.Deployment) (*appsv1.Deployment, error) {

--- a/test/framework/resource/k8s/jobs/manager.go
+++ b/test/framework/resource/k8s/jobs/manager.go
@@ -16,18 +16,22 @@ package jobs
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
 
 	batchV1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Manager interface {
 	CreateAndWaitForJobToComplete(ctx context.Context, jobs *batchV1.Job) (*batchV1.Job, error)
+	CreateJobAndWaitForJobToRun(ctx context.Context, jobs *batchV1.Job) (*batchV1.Job, error)
 	DeleteAndWaitTillJobIsDeleted(ctx context.Context, jobs *batchV1.Job) error
 }
 
@@ -37,6 +41,44 @@ func NewManager(k8sClient client.Client) Manager {
 
 type defaultManager struct {
 	k8sClient client.Client
+}
+
+func (m *defaultManager) CreateJobAndWaitForJobToRun(ctx context.Context,
+	jobs *batchV1.Job) (*batchV1.Job, error) {
+	err := m.k8sClient.Create(ctx, jobs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wait till the cache is refreshed
+	time.Sleep(utils.PollIntervalShort)
+
+	observedJob := &batchV1.Job{}
+	return observedJob, wait.PollImmediateUntil(utils.PollIntervalShort, func() (bool, error) {
+		podList := &v1.PodList{}
+		err = m.k8sClient.List(ctx, podList, &client.ListOptions{
+			LabelSelector: labels.SelectorFromSet(jobs.Spec.Template.Labels),
+		})
+		if err != nil {
+			return false, err
+		}
+		if err := m.k8sClient.Get(ctx, utils.NamespacedName(jobs), observedJob); err != nil {
+			return false, err
+		}
+		if observedJob.Status.Succeeded > 0 || observedJob.Status.Failed > 0 {
+			return false, fmt.Errorf("some jobs has either"+
+				" succeeded or failed :%v", observedJob.Status)
+		} else if observedJob.Status.Active > 0 {
+			var count int
+			for _, pod := range podList.Items {
+				if pod.Status.Phase == v1.PodRunning && strings.Contains(pod.Name, jobs.Name) {
+					count++
+				}
+			}
+			return count == int(*jobs.Spec.Parallelism), nil
+		}
+		return false, nil
+	}, ctx.Done())
 }
 
 func (m *defaultManager) CreateAndWaitForJobToComplete(ctx context.Context,
@@ -70,7 +112,7 @@ func (m *defaultManager) DeleteAndWaitTillJobIsDeleted(ctx context.Context, job 
 		return err
 	}
 	observedJob := &batchV1.Job{}
-	return wait.PollImmediateUntil(utils.PollIntervalShort, func() (bool, error) {
+	err = wait.PollImmediateUntil(utils.PollIntervalShort, func() (bool, error) {
 		if err := m.k8sClient.Get(ctx, utils.NamespacedName(job), observedJob); err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil
@@ -79,4 +121,24 @@ func (m *defaultManager) DeleteAndWaitTillJobIsDeleted(ctx context.Context, job 
 		}
 		return false, nil
 	}, ctx.Done())
+	if err != nil {
+		return err
+	}
+
+	// Deleting the Job will not removed the Job Pods, they have to be manually deleted
+	jobPods := &v1.PodList{}
+	err = m.k8sClient.List(ctx, jobPods, &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(job.ObjectMeta.Labels),
+		Namespace:     v1.NamespaceAll,
+	})
+	if err != nil {
+		return err
+	}
+	for _, pod := range jobPods.Items {
+		err = m.k8sClient.Delete(ctx, &pod)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/test/framework/resource/k8s/node/manager.go
+++ b/test/framework/resource/k8s/node/manager.go
@@ -1,0 +1,42 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package node
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Manager interface {
+	GetNodesWithOS(os string) (*v1.NodeList, error)
+}
+
+type defaultManager struct {
+	k8sClient client.Client
+}
+
+func NewManager(k8sClient client.Client) Manager {
+	return &defaultManager{k8sClient: k8sClient}
+}
+
+func (d *defaultManager) GetNodesWithOS(os string) (*v1.NodeList, error) {
+	nodeList := &v1.NodeList{}
+	err := d.k8sClient.List(context.TODO(), nodeList, &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{"kubernetes.io/os": os}),
+	})
+	return nodeList, err
+}

--- a/test/framework/verify/pod.go
+++ b/test/framework/verify/pod.go
@@ -15,6 +15,7 @@ package verify
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
@@ -38,33 +39,74 @@ func NewPodVerification(framework *framework.Framework, ctx context.Context) *Po
 	}
 }
 
-func (v *PodVerification) PodHasExpectedSG(pod *v1.Pod, expectedSecurityGroup []string) []*trunk.ENIDetails {
+func (v *PodVerification) verifyPodIPEqualsENIIP(pod v1.Pod) {
 	By("getting the branch ENI from the pod's annotation")
 	eniDetails, err := v.frameWork.PodManager.GetENIDetailsFromPodAnnotation(pod.Annotations)
 	Expect(err).NotTo(HaveOccurred())
 
-	By("getting the security group for the ENI from AWS EC2 ")
-	actualSG, err := v.frameWork.EC2Manager.GetENISecurityGroups(eniDetails[0].ID)
+	By(fmt.Sprintf("Verifying for ENI ID: %s ENI IP: %s Pod Name: %s/%s Pod's IP: %s",
+		eniDetails[0].ID, eniDetails[0].IPV4Addr, pod.Namespace, pod.Name, pod.Status.PodIP))
+
+	Expect(eniDetails[0].IPV4Addr).To(Equal(pod.Status.PodIP))
+}
+
+func (v *PodVerification) VerifyNetworkingOfPodUsingENI(pod v1.Pod, expectedSecurityGroup []string) []*trunk.ENIDetails {
+	v.verifyPodIPEqualsENIIP(pod)
+
+	eniDetails, err := v.frameWork.PodManager.GetENIDetailsFromPodAnnotation(pod.Annotations)
 	Expect(err).NotTo(HaveOccurred())
 
+	By("getting the security group for the ENI from AWS EC2")
+	actualSG, err := v.frameWork.EC2Manager.GetENISecurityGroups(eniDetails[0].ID)
+	Expect(err).NotTo(HaveOccurred())
 	Expect(expectedSecurityGroup).Should(ConsistOf(actualSG))
-
-	By("getting the same IP address as the branch ENI IP")
-	Expect(eniDetails[0].IPV4Addr).To(Equal(pod.Status.PodIP))
 
 	return eniDetails
 }
 
-func (v *PodVerification) PodsHaveExpectedSG(namespace string, podLabelKey string, podLabelVal string,
-	expectedSecurityGroup []string) {
+func (v *PodVerification) VerifyNetworkingOfAllPodUsingENI(namespace string, podLabelKey string,
+	podLabelVal string, expectedSecurityGroup []string) {
 
 	By("getting the pod belonging to the deployment")
 	pods, err := v.frameWork.PodManager.GetPodsWithLabel(v.ctx, namespace, podLabelKey, podLabelVal)
 	Expect(err).ToNot(HaveOccurred())
 
-	for _, pod := range pods {
-		v.PodHasExpectedSG(&pod, expectedSecurityGroup)
+	if len(pods) == 0 {
+		panic(fmt.Errorf("failed to find any pod with label %s:%s in ns %s",
+			podLabelKey, podLabelVal, namespace))
 	}
+
+	for _, pod := range pods {
+		v.VerifyNetworkingOfPodUsingENI(pod, expectedSecurityGroup)
+	}
+}
+
+func (v *PodVerification) VerifyPodENIDeletedForAllPods(namespace string,
+	podLabelKey string, podLabelVal string) {
+
+	By("getting the pod belonging to the deployment")
+	pods, err := v.frameWork.PodManager.GetPodsWithLabel(v.ctx, namespace, podLabelKey, podLabelVal)
+	Expect(err).ToNot(HaveOccurred())
+
+	if len(pods) == 0 {
+		panic(fmt.Errorf("failed to find any pod with label %s:%s in ns %s",
+			podLabelKey, podLabelVal, namespace))
+	}
+
+	for _, pod := range pods {
+		v.VerifyPodENIDeleted(pod)
+	}
+}
+
+func (v *PodVerification) VerifyPodENIDeleted(pod v1.Pod) {
+	v.verifyPodIPEqualsENIIP(pod)
+
+	eniDetails, err := v.frameWork.PodManager.GetENIDetailsFromPodAnnotation(pod.Annotations)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("verifying the ENI is deleted")
+	_, err = v.frameWork.EC2Manager.GetENISecurityGroups(eniDetails[0].ID)
+	Expect(err).To(HaveOccurred())
 }
 
 func (v *PodVerification) PodHasNoBranchENIAnnotationInjected(pod *v1.Pod) {

--- a/test/integration/perpodsg/job_test.go
+++ b/test/integration/perpodsg/job_test.go
@@ -1,0 +1,341 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package perpodsg_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/manifest"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/controller"
+	sgpWrapper "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/sgp"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	batchV1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ControllerInitWaitPeriod is the time to wait for the controller
+// to start running, acquire the lease and initialize it's caches
+const ControllerInitWaitPeriod = time.Second * 90
+
+var _ = Describe("Security Group Per Pod", func() {
+	var (
+		// num of times new jobs that will be created on the same node
+		numJobs int
+		// number of different nodes to run the test on
+		testNodeCount  int
+		namespace      string
+		securityGroups []string
+
+		// serverPod to which all the Jobs will connect to
+		// verify networking
+		serverPod  *v1.Pod
+		serverPort int
+		// List of jobs, each job list is mapped to a single node
+		jobs            map[string][]*batchV1.Job
+		jobSleepSeconds int
+
+		sgp               *v1beta1.SecurityGroupPolicy
+		serverPodLabelKey string
+		serverPodLabelVal string
+		jobPodLabelKey    string
+		jobPodLabelVal    string
+
+		err error
+		ctx context.Context
+	)
+
+	Describe("Jobs", func() {
+		BeforeEach(func() {
+			numJobs = 1
+			testNodeCount = 1
+			namespace = "sgp-job"
+			securityGroups = []string{securityGroupID1}
+
+			jobPodLabelKey = "app"
+			jobPodLabelVal = "sgp-job"
+
+			serverPodLabelKey = "app"
+			serverPodLabelVal = "sgp-app"
+
+			serverPort = 80
+			jobSleepSeconds = 0
+
+			jobs = make(map[string][]*batchV1.Job)
+			ctx = context.TODO()
+		})
+
+		JustBeforeEach(func() {
+			Expect(len(nodeList.Items)).To(BeNumerically(">=", testNodeCount))
+
+			By("creating the namespace")
+			err = frameWork.NSManager.CreateNamespace(ctx, namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			sgp, err = manifest.NewSGPBuilder().
+				Namespace(namespace).
+				SecurityGroup(securityGroups).
+				Name("job-sgp").
+				PodMatchExpression(serverPodLabelKey,
+					metav1.LabelSelectorOpIn, serverPodLabelVal, jobPodLabelVal).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			sgpWrapper.CreateSecurityGroupPolicy(frameWork.K8sClient, ctx, sgp)
+
+			serverContainer := manifest.NewBusyBoxContainerBuilder().
+				Image("nginx").
+				AddContainerPort(serverPort).
+				Command(nil).
+				Build()
+
+			serverPod, err = manifest.NewDefaultPodBuilder().
+				Namespace(namespace).
+				Name("sgp-server").
+				Container(serverContainer).
+				Labels(map[string]string{serverPodLabelKey: serverPodLabelVal}).
+				TerminationGracePeriod(15).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			By("creating the server pod")
+			serverPod, err = frameWork.PodManager.
+				CreateAndWaitTillPodIsRunning(ctx, serverPod)
+			Expect(err).ToNot(HaveOccurred())
+
+			for i := 0; i < testNodeCount; i++ {
+				testNode := nodeList.Items[i]
+				maxPodENICapacity, found := testNode.Status.Allocatable[config.ResourceNamePodENI]
+				Expect(found).To(BeTrue())
+
+				var jobList []*batchV1.Job
+				for j := 0; j < numJobs; j++ {
+					// The Job Pod tests HTTP connection to server Pod which
+					// acts as a High Level check for SGP Pod Networking
+					jobContainer := manifest.NewBusyBoxContainerBuilder().
+						Image("curlimages/curl").
+						Command([]string{"/bin/sh"}).
+						Args([]string{"-c",
+							fmt.Sprintf(
+								"set -e; curl --fail --max-time 5 --retry 3 %s; sleep %d;",
+								serverPod.Status.PodIP, jobSleepSeconds)}).
+						Build()
+
+					// Create More Jobs then supported capacity on the Nodes. If Networking
+					// for Completed Pods is not removed, then second batch of Jobs should
+					// not run and test should fail.
+					job := manifest.NewLinuxJob().
+						Name(fmt.Sprintf("job-node-%d-job-count-%d", i, j)).
+						Namespace(namespace).
+						Parallelism(int(maxPodENICapacity.Value()-1)). // To accommodate for server Pod
+						Container(jobContainer).
+						PodLabels(jobPodLabelKey, jobPodLabelVal).
+						ForNode(testNode.Name).
+						TerminationGracePeriod(10).
+						Build()
+					jobList = append(jobList, job)
+				}
+				jobs[testNode.Name] = jobList
+			}
+		})
+
+		JustAfterEach(func() {
+			By("deleting the namespace")
+			err = frameWork.NSManager.
+				DeleteAndWaitTillNamespaceDeleted(ctx, namespace)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when jobs run successfully", func() {
+			JustBeforeEach(func() {
+				By("authorizing ingress to server port")
+				err = frameWork.EC2Manager.
+					AuthorizeSecurityGroupIngress(securityGroups[0], serverPort, "TCP")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			JustAfterEach(func() {
+				By("revoking ingress to server port")
+				err = frameWork.EC2Manager.
+					RevokeSecurityGroupIngress(securityGroups[0], serverPort, "TCP")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when jobs are completed", func() {
+				BeforeEach(func() {
+					numJobs = 4
+					testNodeCount = 3
+				})
+
+				It("completed job's networking should be removed", func() {
+					VerifyJobNetworkingRemovedOnCompletion(jobs, namespace,
+						jobPodLabelKey, jobPodLabelVal)
+				})
+			})
+
+			Context("when jobs are currently running", func() {
+				BeforeEach(func() {
+					jobSleepSeconds = 100
+				})
+
+				It("job networking should not be removed", func() {
+					CreateJobAndWaitTillItRuns(jobs)
+
+					By("verifying pod networking is not removed for running pods")
+					verify.VerifyNetworkingOfAllPodUsingENI(namespace, jobPodLabelKey, jobPodLabelVal,
+						securityGroups)
+				})
+			})
+
+			Context("[LOCAL] when jobs are running and controller restarts", func() {
+				BeforeEach(func() {
+					testNodeCount = 3
+					jobSleepSeconds = 600
+				})
+
+				It("job networking should not be removed", func() {
+					CreateJobAndWaitTillItRuns(jobs)
+
+					By("restarting the controller")
+					leaderName := controller.RestartController(ctx, frameWork.ControllerManager,
+						frameWork.DeploymentManager)
+
+					By("verifying the Running Pods don't have their ENIs deleted")
+					verify.VerifyNetworkingOfAllPodUsingENI(namespace, jobPodLabelKey, jobPodLabelVal,
+						securityGroups)
+
+					controller.VerifyLeaseHolderIsSame(ctx, frameWork.ControllerManager, leaderName)
+				})
+			})
+
+			Context("[LOCAL] when jobs is completed and controller restarts", func() {
+				BeforeEach(func() {
+					testNodeCount = 2
+					numJobs = 1
+					jobSleepSeconds = 100
+				})
+
+				It("job networking of completed pod should be removed", func() {
+					CreateJobAndWaitTillItRuns(jobs)
+
+					controller.ScaleControllerDeployment(ctx, frameWork.DeploymentManager, 0)
+
+					By("waiting till the job completes")
+					time.Sleep(time.Second * time.Duration(jobSleepSeconds))
+
+					controller.ScaleControllerDeployment(ctx, frameWork.DeploymentManager, 2)
+
+					By("waiting till controller inits and removes completed pod networking")
+					time.Sleep(ControllerInitWaitPeriod) // This account for 30 seconds cool down period too
+
+					By("verifying completed pod have their networking removed")
+					verify.VerifyPodENIDeletedForAllPods(namespace, jobPodLabelKey, jobPodLabelVal)
+				})
+			})
+
+			Context("[LOCAL] when running jobs are deleted while controller is down", func() {
+				BeforeEach(func() {
+					testNodeCount = 2
+					jobSleepSeconds = 120
+				})
+
+				It("deleted job networking should be removed when controller starts up", func() {
+					CreateJobAndWaitTillItRuns(jobs)
+
+					controller.ScaleControllerDeployment(ctx, frameWork.DeploymentManager, 0)
+
+					By("getting the job pods")
+					pods, err := frameWork.PodManager.GetPodsWithLabel(ctx, namespace, jobPodLabelKey,
+						jobPodLabelVal)
+					Expect(err).ToNot(HaveOccurred())
+
+					DeleteJobAndPodAndWaitTillDeleted(jobs)
+
+					controller.ScaleControllerDeployment(ctx, frameWork.DeploymentManager, 2)
+
+					By("waiting till controller inits and removes deleted pod networking")
+					time.Sleep(ControllerInitWaitPeriod) // This account for 30 seconds cool down period too
+
+					By("verifying the pod ENI are deleted when controller comes back up")
+					for _, pod := range pods {
+						verify.VerifyPodENIDeleted(pod)
+					}
+				})
+			})
+		})
+	})
+})
+
+func CreateJobAndWaitTillItRuns(jobs map[string][]*batchV1.Job) {
+	By("creating job and waiting till it runs")
+	for _, nodeJobs := range jobs {
+		for _, job := range nodeJobs {
+			job, err = frameWork.JobManager.CreateJobAndWaitForJobToRun(ctx, job)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	}
+}
+func DeleteJobAndPodAndWaitTillDeleted(jobs map[string][]*batchV1.Job) {
+	By("deleting job and waiting till its deleted")
+	for _, nodeJobs := range jobs {
+		for _, job := range nodeJobs {
+			err := frameWork.JobManager.DeleteAndWaitTillJobIsDeleted(ctx, job)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	}
+}
+
+func VerifyJobNetworkingRemovedOnCompletion(jobs map[string][]*batchV1.Job,
+	namespace string, podLabelKey string, podLabelVal string) {
+	CreateAndWaitForJobsInParallel(jobs)
+
+	By("waiting for the ENI to be cooled down and deleted")
+	// Need to account for actual deletion of ENI + Cool down Period
+	time.Sleep(config.CoolDownPeriod * 2)
+
+	By("verifying the deleted Pod have their ENI deleted")
+	verify.VerifyPodENIDeletedForAllPods(namespace, podLabelKey, podLabelVal)
+}
+
+func CreateAndWaitForJobsInParallel(jobs map[string][]*batchV1.Job) {
+	var wg sync.WaitGroup
+	for nodeName, jobs := range jobs {
+		wg.Add(1)
+		// Parallelize the job creation and validation on each node. This
+		// will help stress the controller and possibly catch regressions
+		go func(nodeName string, jobs []*batchV1.Job) {
+			defer GinkgoRecover()
+			defer wg.Done()
+			// On each node create job with parallelization count equal to
+			// the capacity of pod eni on the node. Once the first job succeeds,
+			// launch the second job and so on. If the networking for the older
+			// Pod is not released by controller we will observer that the new
+			// Job has failed to start up.
+			for i, job := range jobs {
+				By(fmt.Sprintf("creating job %d on node %s", i, nodeName))
+				_, err := frameWork.JobManager.CreateAndWaitForJobToComplete(ctx, job)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		}(nodeName, jobs)
+	}
+	// Wait for Pods to be Completed on all of the Nodes
+	wg.Wait()
+}

--- a/test/integration/perpodsg/perpodsg_suite_test.go
+++ b/test/integration/perpodsg/perpodsg_suite_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 )
 
 var frameWork *framework.Framework
@@ -32,6 +33,7 @@ var securityGroupID1 string
 var securityGroupID2 string
 var ctx context.Context
 var err error
+var nodeList *v1.NodeList
 
 func TestPerPodGG(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -39,14 +41,15 @@ func TestPerPodGG(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	By("creating a framework")
 	frameWork = framework.New(framework.GlobalOptions)
 	ctx = context.Background()
 	verify = verifier.NewPodVerification(frameWork, ctx)
 
-	securityGroupID1, err = frameWork.EC2Manager.CreateSecurityGroup(utils.ResourceNamePrefix + "sg-1")
-	Expect(err).ToNot(HaveOccurred())
+	securityGroupID1 = reCreateSGIfAlreadyExists(utils.ResourceNamePrefix + "sg-1")
+	securityGroupID2 = reCreateSGIfAlreadyExists(utils.ResourceNamePrefix + "sg-2")
 
-	securityGroupID2, err = frameWork.EC2Manager.CreateSecurityGroup(utils.ResourceNamePrefix + "sg-2")
+	nodeList, err = frameWork.NodeManager.GetNodesWithOS("linux")
 	Expect(err).ToNot(HaveOccurred())
 })
 
@@ -60,3 +63,22 @@ var _ = AfterSuite(func() {
 	frameWork.EC2Manager.DeleteSecurityGroup(securityGroupID2)
 	Expect(err).ToNot(HaveOccurred())
 })
+
+func reCreateSGIfAlreadyExists(securityGroupName string) string {
+	groupID, err := frameWork.EC2Manager.GetSecurityGroupID(securityGroupName)
+	// If the security group already exists, no error will be returned
+	// We need to delete the security Group in this case so ingres/egress
+	// rules from last run don't interfere with the current test
+	if err == nil {
+		By("deleting the older security group" + groupID)
+		err = frameWork.EC2Manager.DeleteSecurityGroup(groupID)
+		Expect(err).ToNot(HaveOccurred())
+	}
+	// If error is not nil, then the Security Group doesn't exists, we need
+	// to create new rule
+	By("creating a new security group with name " + securityGroupName)
+	groupID, err = frameWork.EC2Manager.CreateSecurityGroup(securityGroupName)
+	Expect(err).ToNot(HaveOccurred())
+
+	return groupID
+}


### PR DESCRIPTION
*Issue #, if available:* #33

*Description of changes:*

Removes networking for Pods in the phase `Succeeded` or `Failed` for Both Windows(Not enabled yet) and Linux Pods. [See](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/)

List of Changes
- Add code for bug fix
- Add new integration tests to test the same
- Run integration test in CI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
