### PR TITLE
Fix regression in custom controller

### DIFF
--- a/controllers/custom/custom_controller.go
+++ b/controllers/custom/custom_controller.go
@@ -14,23 +14,18 @@
 package custom
 
 import (
-	"fmt"
-	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 // Converter for converting k8s object and object list used in watches and list operation
-// to the desired format.
 type Converter interface {
 	// ConvertObject takes an object and returns the modified object which will be
 	// stored in the data store
@@ -47,10 +42,6 @@ type Converter interface {
 	Indexer(obj interface{}) (string, error)
 }
 
-type Reconciler interface {
-	Reconcile(request Request) (ctrl.Result, error)
-}
-
 // Options contains the configurable parameters of the Custom Controller
 type Options struct {
 	// Name of the controller used for creating named work queues
@@ -61,8 +52,6 @@ type Options struct {
 	Namespace string
 	// ResyncPeriod how often to sync using list with the API Server
 	ResyncPeriod time.Duration
-	// MaxConcurrentReconciles to parallelize processing of worker queue
-	MaxConcurrentReconciles int
 }
 
 // This Controller can be used for any type of K8s object, but is used for Pod Objects
@@ -79,79 +68,39 @@ type Options struct {
 // In future, we may be able to switch to upstream controller for reconciling Pods if the
 // long term solutions are in place
 type CustomController struct {
-	// workQueue to store create/update/delete events
-	workQueue workqueue.RateLimitingInterface
-	// mu is the mutex to allow the controller to sync before
-	// other controller start
-	mu sync.Mutex
-	// log for custom controller
 	log logr.Logger
-	// Reconciler will be called on all the K8s object events
-	Do Reconciler
-	// config to create a new client-go controller
+	// Controller is the K8s Controller
+	controller cache.Controller
+	// dataStoreSynced when set to true indicates the data store is synced and ready to access
+	dataStoreSynced *bool
+	// config for creating low level controller
 	config *cache.Config
-	// options is the configurable parameters for creating
-	// the controller
-	options  Options
-	syncFlag *bool
-}
-
-// Request for Add/Update only contains the Namespace/Name
-// Request for Delete contains the Pod Object as by the time
-// Delete Request is reconciled the cache will not have it
-type Request struct {
-	// Add/Update Request will contain the Namespaced Name only. The
-	// item can be retrieved from the indexer for add/update events
-	NamespacedName types.NamespacedName
-	// Delete Event will contain the DeletedObject only.
-	DeletedObject interface{}
 }
 
 // Starts the low level controller
 func (c *CustomController) Start(stop <-chan struct{}) error {
-	// This is important to allow the data store to be synced
-	// Before the other controller starts
-	c.mu.Lock()
-	// Shut down the queue so the worker can stop
-	defer c.workQueue.ShutDown()
+	c.log.Info("starting custom controller")
+	c.controller = cache.New(c.config)
 
-	err := func() error {
-		defer c.mu.Unlock()
-
-		coreController := cache.New(c.config)
-
-		c.log.Info("starting custom controller")
-		go coreController.Run(stop)
-
-		// Wait till cache sync
-		c.WaitForCacheSync(coreController)
-
-		c.log.Info("Starting Workers", "worker count",
-			c.options.MaxConcurrentReconciles)
-		for i := 0; i < c.options.MaxConcurrentReconciles; i++ {
-			go wait.Until(c.worker, time.Second, stop)
-		}
-
-		return nil
+	go func() {
+		c.MarkDataStoreSynced()
+		c.log.Info("data store has synced")
 	}()
-	if err != nil {
-		return err
-	}
 
-	<-stop
-	c.log.Info("stopping workers")
+	// Run the controller
+	c.controller.Run(stop)
+
 	return nil
 }
 
-// WaitForCacheSync tills the cache has synced, this must be done under
-// mutex lock to prevent other controllers from starting at same time
-func (c *CustomController) WaitForCacheSync(controller cache.Controller) {
-	for !controller.HasSynced() && controller.LastSyncResourceVersion() == "" {
+// MarkDataStoreSynced sets the dataStoreSynced variable to true when controller has
+// successfully synced with API Server
+func (c *CustomController) MarkDataStoreSynced() {
+	for c.controller == nil || (!c.controller.HasSynced() && c.controller.LastSyncResourceVersion() == "") {
 		c.log.Info("waiting for controller to sync")
 		time.Sleep(time.Second * 5)
 	}
-	*c.syncFlag = true
-	c.log.Info("cache has synced successfully")
+	*c.dataStoreSynced = true
 }
 
 // newOptimizedListWatcher returns a list watcher with a custom list function that converts the
@@ -193,69 +142,15 @@ func newOptimizedListWatcher(restClient cache.Getter, resource string, namespace
 	return &cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
 }
 
-func (c *CustomController) worker() {
-	for c.processNextWorkItem() {
+// notifyChannelOnEvent notifies the event on receiving an update on Process Event
+func notifyChannelOnEvent(obj interface{}, eventNotificationChannel chan event.GenericEvent) error {
+	meta, err := apimeta.Accessor(obj)
+	if err != nil {
+		return err
 	}
-}
-
-func (c *CustomController) processNextWorkItem() bool {
-	obj, shutdown := c.workQueue.Get()
-	if shutdown {
-		// Stop working
-		return false
+	eventNotificationChannel <- event.GenericEvent{
+		Meta:   meta,
+		Object: obj.(runtime.Object),
 	}
-
-	// We call Done here so the workqueue knows we have finished
-	// processing this item. We also must remember to call Forget if we
-	// do not want this work item being re-queued. For example, we do
-	// not call Forget if a transient error occurs, instead the item is
-	// put back on the workqueue and attempted again after a back-off
-	// period.
-	defer c.workQueue.Done(obj)
-
-	// The item from the workqueue will be forgotten in the handler, when
-	// it's successfully processed.
-	return c.reconcileHandler(obj)
-}
-
-func (c *CustomController) reconcileHandler(obj interface{}) bool {
-	var req Request
-	var ok bool
-	if req, ok = obj.(Request); !ok {
-		// As the item in the workqueue is actually invalid, we call
-		// Forget here else we'd go into a loop of attempting to
-		// process a work item that is invalid.
-		c.workQueue.Forget(obj)
-		c.log.Error(nil, "Queue item was not a Request",
-			"type", fmt.Sprintf("%T", obj), "value", obj)
-		// Return true, don't take a break
-		return true
-	}
-	// RunInformersAndControllers the syncHandler, passing it the namespace/Name string of the
-	// resource to be synced.
-	if result, err := c.Do.Reconcile(req); err != nil {
-		c.workQueue.AddRateLimited(req)
-		c.log.Error(err, "Reconciler error", "request", req)
-		return false
-	} else if result.RequeueAfter > 0 {
-		// The result.RequeueAfter request will be lost, if it is returned
-		// along with a non-nil error. But this is intended as
-		// We need to drive to stable reconcile loops before queuing due
-		// to result.RequestAfter
-		c.workQueue.Forget(obj)
-		c.workQueue.AddAfter(req, result.RequeueAfter)
-		return true
-	} else if result.Requeue {
-		c.workQueue.AddRateLimited(req)
-		return true
-	}
-
-	// Finally, if no error occurs we Forget this item so it does not
-	// get queued again until another change happens.
-	c.workQueue.Forget(obj)
-
-	c.log.V(1).Info("Successfully Reconciled", "request", req)
-
-	// Return true, don't take a break
-	return true
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -222,6 +222,7 @@ func main() {
 	// accessed only after the Pod Reconciler has started
 	podConverter := pod.PodConverter{}
 	dataStore := cache.NewIndexer(podConverter.Indexer, pod.NodeNameIndexer())
+	deleteDataStore := cache.NewIndexer(podConverter.Indexer, pod.NodeNameIndexer())
 
 	apiWrapper := api.Wrapper{
 		EC2API: ec2APIHelper,
@@ -253,11 +254,12 @@ func main() {
 	// IMPORTANT: The Pod Reconciler must be the first controller to Run. The controller
 	// will not allow any other controller to run till the cache has synced.
 	if err = (&corecontroller.PodReconciler{
-		Log:             ctrl.Log.WithName("controllers").WithName("Pod Reconciler"),
-		ResourceManager: resourceManager,
-		NodeManager:     nodeManager,
-		DataStore:       dataStore,
-		DataStoreSynced: hasPodDataStoreSynced,
+		Log:                 ctrl.Log.WithName("controllers").WithName("Pod Reconciler"),
+		ResourceManager:     resourceManager,
+		NodeManager:         nodeManager,
+		DataStore:           dataStore,
+		DeletedObjDataStore: deleteDataStore,
+		DataStoreSynced:     hasPodDataStoreSynced,
 	}).SetupWithManager(mgr, clientSet, listPageLimit, syncPeriod); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "pod")
 		os.Exit(1)


### PR DESCRIPTION
*Description of changes:*

With the #44 a regression was introduced where `Delete` and `Update` events were being processed by Pod reconciler at same time. 

**Why were the events being processed at same time?**
The Delete Request had the Pod Object, whereas the Add/Update request had Namespace/Name. Since these two requests won't hash to same value. The `workqueue` will consider these as different objects and send their events in parallel. 

**How was regression detected?**
It was detected while writing the stress test for enabling Windows. The test observed some leaked IP Resources because the Delete event was processed before the Update event.

**How do we fix it?**
Reverting back to the old way of doing things, where we don't modify the request but store the delete object in cache. And delete it once event is processed. Previously we were doing it using two different channels for Add/Update Event and Delete Events making code a little hard to read. Now switched to using a single channel.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
