### PR TITLE
Use go get to install binaries for backwards compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ ifeq (, $(findstring v0.6.2,$(shell controller-gen --version)))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen


### PR DESCRIPTION
*Description of changes:*
Fix build errors- Use go get to install controller-gen for backwards compatibility.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
