### PR TITLE
Block Windows IPAM till Old Controller Deployment is deleted

### DIFF
--- a/config/controller/controller.yaml
+++ b/config/controller/controller.yaml
@@ -1,10 +1,3 @@
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: controller
-  namespace: system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -12,7 +5,7 @@ metadata:
   namespace: system
   labels:
     control-plane: controller
-    app: eks-vpc-resource-controller
+    app: vpc-resource-controller
 spec:
   selector:
     matchLabels:
@@ -22,9 +15,9 @@ spec:
     metadata:
       labels:
         control-plane: controller
-        app: eks-vpc-resource-controller
+        app: vpc-resource-controller
     spec:
-      serviceAccountName: eks-vpc-resource-controller
+      serviceAccountName: vpc-resource-controller
       containers:
       - command:
         - /controller

--- a/config/controller/controller.yaml
+++ b/config/controller/controller.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: system
   labels:
     control-plane: controller
-    app: vpc-resource-controller
+    app: eks-vpc-resource-controller
 spec:
   selector:
     matchLabels:
@@ -22,9 +22,9 @@ spec:
     metadata:
       labels:
         control-plane: controller
-        app: vpc-resource-controller
+        app: eks-vpc-resource-controller
     spec:
-      serviceAccountName: vpc-resource-controller
+      serviceAccountName: eks-vpc-resource-controller
       containers:
       - command:
         - /controller

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -2,6 +2,10 @@ resources:
 - controller.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namePrefix: local-
+# Adding additional prefix as a workaround, because the controller will fail running locally
+# for Windows test, as it checks the same deployment name should not be deployed to enable Windows
+# IPAM
 images:
 - name: controller
   newName: controller

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: kube-system
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: vpc-resource-
+namePrefix: eks-vpc-resource-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: kube-system
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: eks-vpc-resource-
+namePrefix: vpc-resource-
 
 # Labels to add to all resources and selectors.
 #commonLabels:
@@ -15,6 +15,7 @@ namePrefix: eks-vpc-resource-
 bases:
 - ../crd
 - ../rbac
+- ../sa
 - ../controller
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
 # crd/kustomization.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -72,6 +72,16 @@ metadata:
   namespace: kube-system
 rules:
 - apiGroups:
+  - apps
+  resourceNames:
+  - vpc-resource-controller
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resourceNames:
   - amazon-vpc-cni

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -10,3 +10,17 @@ subjects:
 - kind: ServiceAccount
   name: controller
   namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-role
+subjects:
+  - kind: ServiceAccount
+    name: controller
+    namespace: system
+

--- a/config/sa/kustomization.yaml
+++ b/config/sa/kustomization.yaml
@@ -1,0 +1,3 @@
+
+resources:
+  - sa.yaml

--- a/config/sa/sa.yaml
+++ b/config/sa/sa.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller
+  namespace: system

--- a/controllers/apps/deployment_controller.go
+++ b/controllers/apps/deployment_controller.go
@@ -1,0 +1,70 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package apps
+
+import (
+	"context"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/controllers/core"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/condition"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/k8s"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/node/manager"
+
+	"github.com/go-logr/logr"
+	appV1 "k8s.io/api/apps/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type DeploymentReconciler struct {
+	Log                      logr.Logger
+	NodeManager              manager.Manager
+	K8sAPI                   k8s.K8sWrapper
+	Condition                condition.Conditions
+	wasOldControllerDeployed bool
+}
+
+func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var isOldControllerDeployed bool
+	// Only process old controller deployment events
+	if req.Name != config.OldVPCControllerDeploymentName ||
+		req.Namespace != config.OldVPCControllerDeploymentNS {
+		return ctrl.Result{}, nil
+	}
+
+	isOldControllerDeployed = r.Condition.IsOldVPCControllerDeploymentPresent()
+
+	// State didn't change, no ops
+	if isOldControllerDeployed == r.wasOldControllerDeployed {
+		return ctrl.Result{}, nil
+	}
+
+	r.wasOldControllerDeployed = isOldControllerDeployed
+
+	r.Log.Info("condition changed", "was deployment present before",
+		r.wasOldControllerDeployed, "is deployment present now", isOldControllerDeployed)
+
+	err := controllers.UpdateNodesOnConfigMapChanges(r.K8sAPI, r.NodeManager)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *DeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appV1.Deployment{}).
+		Complete(r)
+}

--- a/controllers/apps/deployment_controller_test.go
+++ b/controllers/apps/deployment_controller_test.go
@@ -1,0 +1,119 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package apps
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/condition"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/node"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/node/manager"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	mockNodeList = &v1.NodeList{
+		Items: []v1.Node{
+			{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name: "node",
+				},
+			},
+		},
+	}
+	request = controllerruntime.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: config.OldVPCControllerDeploymentNS,
+			Name:      config.OldVPCControllerDeploymentName,
+		},
+	}
+	ctx = context.TODO()
+)
+
+type Mock struct {
+	Conditions *mock_condition.MockConditions
+	Manager    *mock_manager.MockManager
+	K8sAPI     *mock_k8s.MockK8sWrapper
+	Node       *mock_node.MockNode
+	Reconciler DeploymentReconciler
+}
+
+func NewDeploymentMock(ctrl *gomock.Controller) Mock {
+	mockManager := mock_manager.NewMockManager(ctrl)
+	mockCondition := mock_condition.NewMockConditions(ctrl)
+	mockK8sAPI := mock_k8s.NewMockK8sWrapper(ctrl)
+	mockNode := mock_node.NewMockNode(ctrl)
+	return Mock{
+		Reconciler: DeploymentReconciler{
+			Log:         zap.New(),
+			NodeManager: mockManager,
+			Condition:   mockCondition,
+			K8sAPI:      mockK8sAPI,
+		},
+		Conditions: mockCondition,
+		Manager:    mockManager,
+		K8sAPI:     mockK8sAPI,
+		Node:       mockNode,
+	}
+}
+
+func TestDeploymentReconciler_Reconcile_WrongObject(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := NewDeploymentMock(ctrl)
+	_, err := mock.Reconciler.Reconcile(ctx, controllerruntime.Request{
+		NamespacedName: types.NamespacedName{
+			Name: config.OldVPCControllerDeploymentName,
+		},
+	})
+	assert.NoError(t, err)
+}
+
+func TestDeploymentReconciler_Reconcile_StateUnchanged(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := NewDeploymentMock(ctrl)
+
+	mock.Conditions.EXPECT().IsOldVPCControllerDeploymentPresent().Return(false)
+
+	_, err := mock.Reconciler.Reconcile(ctx, request)
+	assert.NoError(t, err)
+}
+
+func TestDeploymentReconciler_Reconcile_StateChanged(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := NewDeploymentMock(ctrl)
+
+	mock.Conditions.EXPECT().IsOldVPCControllerDeploymentPresent().Return(true)
+	mock.K8sAPI.EXPECT().ListNodes().Return(mockNodeList, nil)
+	mock.Manager.EXPECT().GetNode("node").Return(mock.Node, true)
+	mock.Manager.EXPECT().UpdateNode("node").Return(nil)
+
+	_, err := mock.Reconciler.Reconcile(ctx, request)
+	assert.NoError(t, err)
+}

--- a/controllers/core/configmap_controller.go
+++ b/controllers/core/configmap_controller.go
@@ -72,7 +72,7 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		logger.Info("updated configmap", config.EnableWindowsIPAMKey, r.curWinIPAMEnabledCond)
 
 		// Flag is updated, update all nodes
-		err := r.UpdateNodesOnConfigMapChanges()
+		err := UpdateNodesOnConfigMapChanges(r.K8sAPI, r.NodeManager)
 		if err != nil {
 			// Error in updating nodes
 			logger.Error(err, "Failed to update nodes on configmap changes")
@@ -90,16 +90,16 @@ func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *ConfigMapReconciler) UpdateNodesOnConfigMapChanges() error {
-	nodeList, err := r.K8sAPI.ListNodes()
+func UpdateNodesOnConfigMapChanges(k8sAPI k8s.K8sWrapper, nodeManager manager.Manager) error {
+	nodeList, err := k8sAPI.ListNodes()
 	if err != nil {
 		return err
 	}
 	var errList []error
 	for _, node := range nodeList.Items {
-		_, found := r.NodeManager.GetNode(node.Name)
+		_, found := nodeManager.GetNode(node.Name)
 		if found {
-			err = r.NodeManager.UpdateNode(node.Name)
+			err = nodeManager.UpdateNode(node.Name)
 			if err != nil {
 				errList = append(errList, err)
 			}

--- a/main.go
+++ b/main.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	crdv1alpha1 "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
-
 	vpcresourcesv1beta1 "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/controllers/apps"
 	corecontroller "github.com/aws/amazon-vpc-resource-controller-k8s/controllers/core"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/api"
 	ec2API "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2/api"
@@ -72,6 +72,9 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
+// To Watch for old controller deployments, windows IPAM will not be enabled till the old controller
+// deployments are deleted by users
+// +kubebuilder:rbac:groups=apps,resources=deployments,namespace=kube-system,resourceNames=vpc-resource-controller,verbs=get;list;watch
 // +kubebuilder:rbac:groups=crd.k8s.amazonaws.com,resources=eniconfigs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=vpcresources.k8s.aws,resources=securitygrouppolicies,verbs=get;list;watch
 
@@ -320,6 +323,16 @@ func main() {
 		Condition:   controllerConditions,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ConfigMap")
+		os.Exit(1)
+	}
+
+	if err = (&apps.DeploymentReconciler{
+		Log:         ctrl.Log.WithName("controllers").WithName("Deployment"),
+		NodeManager: nodeManager,
+		K8sAPI:      k8sApi,
+		Condition:   controllerConditions,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Deployment")
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/go-logr/zapr"
 	zapRaw "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -188,8 +189,11 @@ func main() {
 			&corev1.ConfigMap{}: {Field: fields.Set{
 				"metadata.name":      config.VpcCniConfigMapName,
 				"metadata.namespace": config.VpcCNIConfigMapNamespace,
-			}.AsSelector(),
-			},
+			}.AsSelector()},
+			&appsv1.Deployment{}: {Field: fields.Set{
+				"metadata.name":      config.OldVPCControllerDeploymentName,
+				"metadata.namespace": config.OldVPCControllerDeploymentNS,
+			}.AsSelector()},
 		},
 	})
 

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/condition/mock_condtion.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/condition/mock_condtion.go
@@ -45,6 +45,20 @@ func (m *MockConditions) EXPECT() *MockConditionsMockRecorder {
 	return m.recorder
 }
 
+// IsOldVPCControllerDeploymentPresent mocks base method
+func (m *MockConditions) IsOldVPCControllerDeploymentPresent() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsOldVPCControllerDeploymentPresent")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsOldVPCControllerDeploymentPresent indicates an expected call of IsOldVPCControllerDeploymentPresent
+func (mr *MockConditionsMockRecorder) IsOldVPCControllerDeploymentPresent() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOldVPCControllerDeploymentPresent", reflect.TypeOf((*MockConditions)(nil).IsOldVPCControllerDeploymentPresent))
+}
+
 // IsPodSGPEnabled mocks base method
 func (m *MockConditions) IsPodSGPEnabled() bool {
 	m.ctrl.T.Helper()

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/mock_k8swrapper.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/mock_k8swrapper.go
@@ -20,7 +20,8 @@ package mock_k8s
 import (
 	v1alpha1 "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	gomock "github.com/golang/mock/gomock"
-	v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/apps/v1"
+	v10 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	reflect "reflect"
 )
@@ -75,10 +76,10 @@ func (mr *MockK8sWrapperMockRecorder) BroadcastEvent(arg0, arg1, arg2, arg3 inte
 }
 
 // GetConfigMap mocks base method
-func (m *MockK8sWrapper) GetConfigMap(arg0, arg1 string) (*v1.ConfigMap, error) {
+func (m *MockK8sWrapper) GetConfigMap(arg0, arg1 string) (*v10.ConfigMap, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConfigMap", arg0, arg1)
-	ret0, _ := ret[0].(*v1.ConfigMap)
+	ret0, _ := ret[0].(*v10.ConfigMap)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -87,6 +88,21 @@ func (m *MockK8sWrapper) GetConfigMap(arg0, arg1 string) (*v1.ConfigMap, error) 
 func (mr *MockK8sWrapperMockRecorder) GetConfigMap(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigMap", reflect.TypeOf((*MockK8sWrapper)(nil).GetConfigMap), arg0, arg1)
+}
+
+// GetDeployment mocks base method
+func (m *MockK8sWrapper) GetDeployment(arg0, arg1 string) (*v1.Deployment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeployment", arg0, arg1)
+	ret0, _ := ret[0].(*v1.Deployment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeployment indicates an expected call of GetDeployment
+func (mr *MockK8sWrapperMockRecorder) GetDeployment(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeployment", reflect.TypeOf((*MockK8sWrapper)(nil).GetDeployment), arg0, arg1)
 }
 
 // GetENIConfig mocks base method
@@ -105,10 +121,10 @@ func (mr *MockK8sWrapperMockRecorder) GetENIConfig(arg0 interface{}) *gomock.Cal
 }
 
 // GetNode mocks base method
-func (m *MockK8sWrapper) GetNode(arg0 string) (*v1.Node, error) {
+func (m *MockK8sWrapper) GetNode(arg0 string) (*v10.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNode", arg0)
-	ret0, _ := ret[0].(*v1.Node)
+	ret0, _ := ret[0].(*v10.Node)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -120,10 +136,10 @@ func (mr *MockK8sWrapperMockRecorder) GetNode(arg0 interface{}) *gomock.Call {
 }
 
 // ListNodes mocks base method
-func (m *MockK8sWrapper) ListNodes() (*v1.NodeList, error) {
+func (m *MockK8sWrapper) ListNodes() (*v10.NodeList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListNodes")
-	ret0, _ := ret[0].(*v1.NodeList)
+	ret0, _ := ret[0].(*v10.NodeList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/condition/conditions_test.go
+++ b/pkg/condition/conditions_test.go
@@ -17,8 +17,35 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	deployment  = &appsv1.Deployment{}
+	notFoundErr = &errors.StatusError{
+		ErrStatus: metav1.Status{
+			Reason: metav1.StatusReasonNotFound,
+		},
+	}
+	otherErr = &errors.StatusError{
+		ErrStatus: metav1.Status{
+			Reason: metav1.StatusFailure,
+		},
+	}
+	vpcCNIConfig = &v1.ConfigMap{
+		Data: map[string]string{
+			config.EnableWindowsIPAMKey: "true",
+		},
+	}
 )
 
 func Test_WaitTillPodDataStoreSynced(t *testing.T) {
@@ -46,4 +73,107 @@ func Test_WaitTillPodDataStoreSynced(t *testing.T) {
 	// If the code was buggy, this execution would block and
 	// timeout the test
 	c.WaitTillPodDataStoreSynced()
+}
+
+func TestCondition_IsWindowsIPAMEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected bool
+		mock     func(mock *mock_k8s.MockK8sWrapper)
+	}{
+		{
+			name:     "old controller deployment not deleted",
+			expected: false,
+			mock: func(mock *mock_k8s.MockK8sWrapper) {
+				mock.EXPECT().GetDeployment(config.OldVPCControllerDeploymentNS,
+					config.OldVPCControllerDeploymentName).Return(deployment, nil)
+			},
+		},
+		{
+			name:     "getting old controller deployment returns error other than is not found",
+			expected: false,
+			mock: func(mock *mock_k8s.MockK8sWrapper) {
+				mock.EXPECT().GetDeployment(config.OldVPCControllerDeploymentNS,
+					config.OldVPCControllerDeploymentName).Return(nil, otherErr)
+			},
+		},
+		{
+			name:     "get configmap returns error",
+			expected: false,
+			mock: func(mock *mock_k8s.MockK8sWrapper) {
+				mock.EXPECT().GetDeployment(config.OldVPCControllerDeploymentNS,
+					config.OldVPCControllerDeploymentName).Return(nil, notFoundErr)
+
+				mock.EXPECT().GetConfigMap(config.VpcCniConfigMapName,
+					config.VpcCNIConfigMapNamespace).Return(nil, otherErr)
+			},
+		},
+		{
+			name:     "configmap with no data",
+			expected: false,
+			mock: func(mock *mock_k8s.MockK8sWrapper) {
+				mock.EXPECT().GetDeployment(config.OldVPCControllerDeploymentNS,
+					config.OldVPCControllerDeploymentName).Return(nil, notFoundErr)
+
+				noData := vpcCNIConfig.DeepCopy()
+				noData.Data = nil
+
+				mock.EXPECT().GetConfigMap(config.VpcCniConfigMapName,
+					config.VpcCNIConfigMapNamespace).Return(noData, nil)
+			},
+		},
+		{
+			name:     "configmap with flag set to false",
+			expected: false,
+			mock: func(mock *mock_k8s.MockK8sWrapper) {
+				mock.EXPECT().GetDeployment(config.OldVPCControllerDeploymentNS,
+					config.OldVPCControllerDeploymentName).Return(nil, notFoundErr)
+
+				falseData := vpcCNIConfig.DeepCopy()
+				falseData.Data[config.EnableWindowsIPAMKey] = "false"
+
+				mock.EXPECT().GetConfigMap(config.VpcCniConfigMapName,
+					config.VpcCNIConfigMapNamespace).Return(falseData, nil)
+			},
+		},
+		{
+			name:     "configmap with flag set to non boolean value",
+			expected: false,
+			mock: func(mock *mock_k8s.MockK8sWrapper) {
+				mock.EXPECT().GetDeployment(config.OldVPCControllerDeploymentNS,
+					config.OldVPCControllerDeploymentName).Return(nil, notFoundErr)
+
+				nonParsable := vpcCNIConfig.DeepCopy()
+				nonParsable.Data[config.EnableWindowsIPAMKey] = "trued"
+
+				mock.EXPECT().GetConfigMap(config.VpcCniConfigMapName,
+					config.VpcCNIConfigMapNamespace).Return(nonParsable, nil)
+			},
+		},
+		{
+			name:     "configmap with flag set to true",
+			expected: true,
+			mock: func(mock *mock_k8s.MockK8sWrapper) {
+				mock.EXPECT().GetDeployment(config.OldVPCControllerDeploymentNS,
+					config.OldVPCControllerDeploymentName).Return(nil, notFoundErr)
+
+				mock.EXPECT().GetConfigMap(config.VpcCniConfigMapName,
+					config.VpcCNIConfigMapNamespace).Return(vpcCNIConfig, nil)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockK8s := mock_k8s.NewMockK8sWrapper(ctrl)
+			conditions := NewControllerConditions(nil, zap.New(), mockK8s)
+
+			test.mock(mockK8s)
+
+			assert.Equal(t, conditions.IsWindowsIPAMEnabled(), test.expected)
+		})
+	}
 }

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -67,6 +67,9 @@ const (
 	EnableWindowsIPAMKey    = "enable-windows-ipam"
 	// Since LeaderElectionNamespace and VpcCniConfigMapName may be different in the future
 	VpcCNIConfigMapNamespace = "kube-system"
+
+	OldVPCControllerDeploymentNS   = "kube-system"
+	OldVPCControllerDeploymentName = "vpc-resource-controller"
 )
 
 var (

--- a/pkg/k8s/wrapper.go
+++ b/pkg/k8s/wrapper.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/prometheus/client_golang/prometheus"
 
+	appV1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -66,6 +67,7 @@ type K8sWrapper interface {
 	GetNode(nodeName string) (*v1.Node, error)
 	AdvertiseCapacityIfNotSet(nodeName string, resourceName string, capacity int) error
 	GetENIConfig(eniConfigName string) (*v1alpha1.ENIConfig, error)
+	GetDeployment(namespace string, name string) (*appV1.Deployment, error)
 	BroadcastEvent(obj runtime.Object, reason string, message string, eventType string)
 	GetConfigMap(configMapName string, configMapNamespace string) (*v1.ConfigMap, error)
 	ListNodes() (*v1.NodeList, error)
@@ -92,6 +94,15 @@ func NewK8sWrapper(client client.Client, coreV1 corev1.CoreV1Interface, ctx cont
 		Component: config.ControllerName,
 	})
 	return &k8sWrapper{cacheClient: client, eventRecorder: recorder, context: ctx}
+}
+
+func (k *k8sWrapper) GetDeployment(namespace string, name string) (*appV1.Deployment, error) {
+	deployment := &appV1.Deployment{}
+	err := k.cacheClient.Get(k.context, types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}, deployment)
+	return deployment, err
 }
 
 func (k *k8sWrapper) GetENIConfig(eniConfigName string) (*v1alpha1.ENIConfig, error) {

--- a/scripts/test/test-with-eksctl.sh
+++ b/scripts/test/test-with-eksctl.sh
@@ -105,7 +105,7 @@ function install_controller() {
   USER_ROLE_ARN=$VPC_RC_ROLE_ARN \
   make deploy
 
-  check_deployment_rollout eks-vpc-resource-controller kube-system 2m
+  check_deployment_rollout vpc-resource-local-controller kube-system 2m
 }
 
 function disable_eks_controller() {
@@ -160,7 +160,7 @@ function run_inegration_test() {
 
 function verify_controller_has_lease() {
   # Get the name of the VPC Resource Controller Pod
-  local controller_pod_names="$(kubectl get pods -n kube-system -l app=eks-vpc-resource-controller \
+  local controller_pod_names="$(kubectl get pods -n kube-system -l app=vpc-resource-controller \
   --no-headers -o custom-columns=":metadata.name")"
 
   # Wait till the new controller has acquired the leader lease
@@ -227,7 +227,7 @@ function redirect_vpc_controller_logs() {
   # The parent process will log the output of the file on exit
   while ps -p $BASHPID > /dev/null
   do
-    kubectl logs -n kube-system -l app=eks-vpc-resource-controller \
+    kubectl logs -n kube-system -l app=vpc-resource-controller \
     --tail -1 -f >> $CONTROLLER_LOG_FILE || echo "LOG COLLECTOR:existing controller killed, will retry"
     # Allow for the new controller to come up
     sleep 10

--- a/scripts/test/test-with-eksctl.sh
+++ b/scripts/test/test-with-eksctl.sh
@@ -160,7 +160,7 @@ function run_inegration_test() {
 
 function verify_controller_has_lease() {
   # Get the name of the VPC Resource Controller Pod
-  local controller_pod_names="$(kubectl get pods -n kube-system -l app=vpc-resource-controller \
+  local controller_pod_names="$(kubectl get pods -n kube-system -l app=eks-vpc-resource-controller \
   --no-headers -o custom-columns=":metadata.name")"
 
   # Wait till the new controller has acquired the leader lease
@@ -227,7 +227,7 @@ function redirect_vpc_controller_logs() {
   # The parent process will log the output of the file on exit
   while ps -p $BASHPID > /dev/null
   do
-    kubectl logs -n kube-system -l app=vpc-resource-controller \
+    kubectl logs -n kube-system -l app=eks-vpc-resource-controller \
     --tail -1 -f >> $CONTROLLER_LOG_FILE || echo "LOG COLLECTOR:existing controller killed, will retry"
     # Allow for the new controller to come up
     sleep 10

--- a/scripts/test/test-with-eksctl.sh
+++ b/scripts/test/test-with-eksctl.sh
@@ -290,9 +290,7 @@ sleep 60
 # Run Ginko Test for Security Group for Pods and skip all the local tests as
 # they require restarts and it will lead to leader lease being switched and the
 # next validation step failing
-# TODO: Remove after the fix for issue is present in latest Windows AMI
-# https://github.com/kubernetes/kubernetes/issues/100384
-run_inegration_test "--skip=(LOCAL|windows service test)"
+run_inegration_test "--skip=LOCAL"
 
 # Verify the leader lease didn't transition during the execution of test cases
 verify_leader_lease_didnt_change

--- a/scripts/test/test-with-eksctl.sh
+++ b/scripts/test/test-with-eksctl.sh
@@ -105,7 +105,7 @@ function install_controller() {
   USER_ROLE_ARN=$VPC_RC_ROLE_ARN \
   make deploy
 
-  check_deployment_rollout vpc-resource-controller kube-system 2m
+  check_deployment_rollout eks-vpc-resource-controller kube-system 2m
 }
 
 function disable_eks_controller() {

--- a/test/framework/resource/k8s/configmap/wrapper.go
+++ b/test/framework/resource/k8s/configmap/wrapper.go
@@ -31,7 +31,7 @@ func CreateConfigMap(manager Manager, ctx context.Context, configmap *v1.ConfigM
 	err := manager.CreateConfigMap(ctx, configmap)
 	Expect(err).NotTo(HaveOccurred())
 
-	time.Sleep(utils.PollIntervalLong)
+	time.Sleep(utils.PollIntervalMedium)
 }
 
 func DeleteConfigMap(manager Manager, ctx context.Context, configmap *v1.ConfigMap) {
@@ -39,7 +39,7 @@ func DeleteConfigMap(manager Manager, ctx context.Context, configmap *v1.ConfigM
 	err := manager.DeleteConfigMap(ctx, configmap)
 	Expect(err).NotTo(HaveOccurred())
 
-	time.Sleep(utils.PollIntervalLong)
+	time.Sleep(utils.PollIntervalMedium)
 }
 
 func UpdateConfigMap(manager Manager, ctx context.Context, configmap *v1.ConfigMap) {
@@ -47,5 +47,5 @@ func UpdateConfigMap(manager Manager, ctx context.Context, configmap *v1.ConfigM
 	err := manager.UpdateConfigMap(ctx, configmap)
 	Expect(err).NotTo(HaveOccurred())
 
-	time.Sleep(utils.PollIntervalLong)
+	time.Sleep(utils.PollIntervalMedium)
 }

--- a/test/framework/resource/k8s/controller/manager.go
+++ b/test/framework/resource/k8s/controller/manager.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	DeploymentName     = "vpc-resource-controller"
+	DeploymentName     = "vpc-resource-local-controller"
 	Namespace          = "kube-system"
 	LeaderLeaseMapName = "cp-vpc-resource-controller"
 


### PR DESCRIPTION
*Description of changes:*
Disable the new controller if the old Controller deployment is still active or becomes active afterwards. This will help prevent two controllers running together at the same which could lead to disruption of running Pods. 
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
