### PR TITLE
Clean up leaked ENI by aws-vpc-cni

### DIFF
--- a/pkg/aws/ec2/api/eni_cleanup.go
+++ b/pkg/aws/ec2/api/eni_cleanup.go
@@ -87,8 +87,9 @@ func (e *ENICleaner) cleanUpAvailableENIs() {
 				Values: []*string{aws.String(config.ClusterNameTagValue)},
 			},
 			{
-				Name:   aws.String("tag:" + config.NetworkInterfaceOwnerTagKey),
-				Values: []*string{aws.String(config.NetworkInterfaceOwnerTagValue)},
+				Name: aws.String("tag:" + config.NetworkInterfaceOwnerTagKey),
+				Values: aws.StringSlice([]string{config.NetworkInterfaceOwnerTagValue,
+					config.NetworkInterfaceOwnerVPCCNITagValue}),
 			},
 		},
 	}

--- a/pkg/aws/ec2/api/eni_cleanup_test.go
+++ b/pkg/aws/ec2/api/eni_cleanup_test.go
@@ -48,8 +48,9 @@ var (
 				Values: []*string{aws.String(config.ClusterNameTagValue)},
 			},
 			{
-				Name:   aws.String("tag:" + config.NetworkInterfaceOwnerTagKey),
-				Values: []*string{aws.String(config.NetworkInterfaceOwnerTagValue)},
+				Name: aws.String("tag:" + config.NetworkInterfaceOwnerTagKey),
+				Values: aws.StringSlice([]string{config.NetworkInterfaceOwnerTagValue,
+					config.NetworkInterfaceOwnerVPCCNITagValue}),
 			},
 		},
 	}

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -56,8 +56,9 @@ const (
 	ClusterNameTagKeyFormat = "kubernetes.io/cluster/%s"
 	ClusterNameTagValue     = "owned"
 
-	NetworkInterfaceOwnerTagKey   = "eks:eni:owner"
-	NetworkInterfaceOwnerTagValue = "eks-vpc-resource-controller"
+	NetworkInterfaceOwnerTagKey         = "eks:eni:owner"
+	NetworkInterfaceOwnerTagValue       = "eks-vpc-resource-controller"
+	NetworkInterfaceOwnerVPCCNITagValue = "amazon-vpc-cni"
 )
 
 const (


### PR DESCRIPTION
*Description of changes:* Cleanup leaked ENIs from VPC CNI Plugin as along with ENI leaked by the controller.

Testing 
1. Created two ENIs with following set of tags
```
kubernetes.io/cluster/abhipth-ci-setup-test-12: owned
eks:eni:owner: eks-vpc-resource-controller
```

```
kubernetes.io/cluster/abhipth-ci-setup-test-12: owned
eks:eni:owner: amazon-vpc-cni
```

Both ENIs were cleaned up.
 
```
{"level":"info","timestamp":"2021-09-28T17:33:03.703Z","logger":"eni cleaner","msg":"deleted dangling ENI successfully","eni id":"eni-0998f776a16204dc1"}
{"level":"info","timestamp":"2021-09-28T17:33:04.117Z","logger":"eni cleaner","msg":"deleted dangling ENI successfully","eni id":"eni-0ae08c52674bc47dd"}

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
