### PR TITLE
Install latest vpc-cni in canary script and fix windows test flakiness

### DIFF
--- a/scripts/test/run-canary-test.sh
+++ b/scripts/test/run-canary-test.sh
@@ -2,7 +2,7 @@
 
 # This script run integration tests on the EKS VPC Resource Controller
 # This is not intended to run integration tests when controller is running
-# on the data plane for development and testing purposes. The scirpt expects
+# on the data plane for development and testing purposes. The script expects
 # an EKS Cluster with atlest 3 Windows and Linux Nodes to be pre-created to
 # run the Canary tests. This scrip is invoked from external sources.
 

--- a/scripts/test/run-canary-test.sh
+++ b/scripts/test/run-canary-test.sh
@@ -58,7 +58,7 @@ function wait_for_addon_status() {
   local expected_status=$1
 
   if [ "$expected_status" =  "DELETED" ]; then
-    while $(aws eks describe-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME); do
+    while $(aws eks describe-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME --region $REGION); do
       echo "addon is still not deleted"
       sleep 5
     done
@@ -68,7 +68,7 @@ function wait_for_addon_status() {
 
   while true
   do
-    STATUS=$(aws eks describe-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME | jq -r '.addon.status')
+    STATUS=$(aws eks describe-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME --region $REGION | jq -r '.addon.status')
     if [ "$STATUS" = "$expected_status" ]; then
       echo "addon status matches expected status"
       return
@@ -81,11 +81,11 @@ function wait_for_addon_status() {
 function install_add_on() {
   local new_addon_version=$1
 
-  if DESCRIBE_ADDON=$(aws eks describe-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME); then
+  if DESCRIBE_ADDON=$(aws eks describe-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME --region $REGION); then
     local current_addon_version=$(echo "$DESCRIBE_ADDON" | jq '.addon.addonVersion' -r)
     if [ "$new_addon_version" != "$current_addon_version" ]; then
       echo "deleting the $current_addon_version to install $new_addon_version"
-      aws eks delete-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name "$VPC_CNI_ADDON_NAME"
+      aws eks delete-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name "$VPC_CNI_ADDON_NAME" --region $$REGION
       wait_for_addon_status "DELETED"
     else
       echo "addon version $current_addon_version already installed"
@@ -94,7 +94,7 @@ function install_add_on() {
   fi
 
   echo "installing addon $new_addon_version"
-  aws eks create-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME --resolve-conflicts OVERWRITE --addon-version $new_addon_version
+  aws eks create-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME --resolve-conflicts OVERWRITE --addon-version $new_addon_version --region $REGION
   wait_for_addon_status "ACTIVE"
 }
 

--- a/test/integration/perpodsg/job_test.go
+++ b/test/integration/perpodsg/job_test.go
@@ -196,7 +196,8 @@ var _ = Describe("Security Group Per Pod", func() {
 					testNodeCount = 3
 				})
 
-				It("[CANARY] completed job's networking should be removed", func() {
+				// Add Canary focus once https://github.com/aws/amazon-vpc-cni-k8s/issues/1746 is resolved
+				It("completed job's networking should be removed", func() {
 					VerifyJobNetworkingRemovedOnCompletion(jobs, namespace,
 						jobPodLabelKey, jobPodLabelVal)
 				})


### PR DESCRIPTION
*Description of changes:*
- Install the latest version of add-on because of issue https://github.com/aws/amazon-vpc-cni-k8s/issues/1340.
- Disable tests on latest version of vpc-cni add-on due to issue https://github.com/aws/amazon-vpc-cni-k8s/issues/1746
- Fix flaky windows connectivity service tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
