### PR TITLE
increase timeouts/retries for canary tests

### DIFF
--- a/scripts/test/run-canary-test.sh
+++ b/scripts/test/run-canary-test.sh
@@ -116,6 +116,9 @@ function set_env_aws_node() {
 }
 
 function run_canary_tests() {
+  # For each component, we want to cover the most important test cases. We also don't want to take more than 30 minutes
+  # per repository as these tests are run sequentially along with tests from other repositories
+  # Currently the overall execution time is ~50 minutes and we will reduce it in future
   (cd $INTEGRATION_TEST_DIR/perpodsg && CGO_ENABLED=0 ginkgo --focus="CANARY" -v -timeout 15m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID)
   (cd $INTEGRATION_TEST_DIR/windows && CGO_ENABLED=0 ginkgo --focus="CANARY" -v -timeout 27m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID)
   (cd $INTEGRATION_TEST_DIR/webhook && CGO_ENABLED=0 ginkgo --focus="CANARY" -v -timeout 5m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID)

--- a/scripts/test/test-with-eksctl.sh
+++ b/scripts/test/test-with-eksctl.sh
@@ -143,7 +143,7 @@ function run_inegration_test() {
 
   # Windows Test
   (cd test/integration/windows && \
-  CGO_ENABLED=0 ginkgo "$additional_gingko_params" -v -timeout 60m -- \
+  CGO_ENABLED=0 ginkgo "$additional_gingko_params" -v -timeout 70m -- \
   -cluster-kubeconfig=$KUBE_CONFIG_PATH \
   -cluster-name=$CLUSTER_NAME \
   --aws-region=$AWS_REGION \

--- a/test/framework/utils/poll.go
+++ b/test/framework/utils/poll.go
@@ -22,4 +22,7 @@ const (
 	// ResourceCreationTimeout is the number of seconds till the controller waits
 	// for the resource creation to complete
 	ResourceCreationTimeout = 120 * time.Second
+	// Windows Container Images are much larger in size and pulling them the first
+	// time takes much longer, so have higher timeout for Windows Pod to be Ready
+	WindowsPodsCreationTimeout = 240 * time.Second
 )

--- a/test/integration/windows/stress_test.go
+++ b/test/integration/windows/stress_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Windows Integration Stress Tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		serverPod, err = frameWork.PodManager.
-			CreateAndWaitTillPodIsRunning(ctx, serverPod, testUtils.ResourceCreationTimeout)
+			CreateAndWaitTillPodIsRunning(ctx, serverPod, testUtils.WindowsPodsCreationTimeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		clientContainer := manifest.NewWindowsContainerBuilder().

--- a/test/integration/windows/windows_test.go
+++ b/test/integration/windows/windows_test.go
@@ -440,7 +440,7 @@ func GetCommandToTestHostConnectivity(host string, port int32, retries int) stri
        Start-Sleep -s $RetryInterval
        $Retries -= 1
        # Limit RetryInterval to 20 seconds after it exceeds certain value
-       $RetryInterval = $RetryInterval -lt 20 ? ($RetryInterval*2) : 20
+       $RetryInterval = if ($RetryInterval -lt 20) {$RetryInterval*2} else {20}
      }
      Write-Output "connection from $env:COMPUTERNAME to $Server succeeded"`, host, port, retries)
 }


### PR DESCRIPTION
*Issue #, if available:*
Was seeing the following mode of failures in the Canary tests over multiple runs.

1. Rate Limiting Exceeded
   ```
    An error occurred (Throttling) when calling the AttachRolePolicy operation (reached max retries: 2): Rate exceeded
    ```
    **Cause:** If tests for all K8s version are triggered at same time we may have this issue.

    **Resolution:**  Increase the max retries and added jitter in the script that invokes the canary script.

2. Windows Pod timeout because of docker image pull
   ```
   Windows Integration Test
   /repository/vpc-resource-controller/test/integration/windows/windows_test.go:33
   configMap enable-windows-ipam tests
   /repository/vpc-resource-controller/test/integration/windows/windows_test.go:87
   when configmap created
   /repository/vpc-resource-controller/test/integration/windows/windows_test.go:97
   [CANARY] when enable-windows-ipam is True
   /repository/vpc-resource-controller/test/integration/windows/windows_test.go:113
   pod should be running and have resourceLimit injected [It]
   /repository/vpc-resource-controller/test/integration/windows/windows_test.go:114
  
   Unexpected error:
   <*errors.errorString | 0xc000365890>: {
   s: \"timed out waiting for the condition\",
   }
   timed out waiting for the condition
   occurred
   ```
    **Cause:** Windows Pod take more time to pull container image hence have higher pod startup latency.
    From audit logs saw, Create Event - 2021-11-29T08:37:59.586-08:00 and Update/Delete Event - 2021-11-29T08:40:10.398-08:00 where the Container was not started. This test fails only when it's executed the first time when the docker images are not pulled.

    **Resolution:**  Increase the wait duration for the Pod to become ready. 

3. Service test failing intermittently 
    ```
     Unexpected error:
     <*errors.errorString | 0xc000547ff0>: {
     s: \"failed to execute job :{[] 2021-11-18 16:42:47 +0000 UTC <nil> 30 0 1 }\",
     }
     failed to execute job :{[] 2021-11-18 16:42:47 +0000 UTC <nil> 30 0 1 }
     occurred
    ```
   **Possible Cause:**: Suspecting the service doesn't become ready.
    **Resolution:**: Increasing the timeout further.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
