### PR TITLE
Refactoring Describe ENI API calls to paginated version

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,7 +123,7 @@ func main() {
 	flag.StringVar(&introspectBindAddr, "introspect-bind-addr", ":22775",
 		"Port for serving the introspection API")
 	flag.IntVar(&describeENIPageSize, "describe-eni-page-size", 100,
-		"The page size limiting the number of every page returned from paginated EC2 describe ENI API calls")
+		"The page size limiting the number of items included in the output of EC2 DescribeNetworkInterface per page")
 
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -87,6 +87,7 @@ func main() {
 	var logLevel string
 	var clusterName string
 	var listPageLimit int
+	var describeENIPageSize int
 	var leaderLeaseDurationSeconds int
 	var leaderLeaseRenewDeadline int
 	var leaderLeaseRetryPeriod int
@@ -121,6 +122,8 @@ func main() {
 	flag.StringVar(&outputPath, "log-file", "stderr", "The path to redirect controller logs")
 	flag.StringVar(&introspectBindAddr, "introspect-bind-addr", ":22775",
 		"Port for serving the introspection API")
+	flag.IntVar(&describeENIPageSize, "describe-eni-page-size", 100,
+		"The page size limiting the number of every page returned from paginated EC2 describe ENI API calls")
 
 	flag.Parse()
 
@@ -240,7 +243,8 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "unable to create ec2 wrapper")
 	}
-	ec2APIHelper := ec2API.NewEC2APIHelper(ec2Wrapper, clusterName)
+	setupLog.V(1).Info("setting up page size for describe interfaces API calls", "max page size", describeENIPageSize)
+	ec2APIHelper := ec2API.NewEC2APIHelper(ec2Wrapper, clusterName, describeENIPageSize)
 
 	sgpAPI := utils.NewSecurityGroupForPodsAPI(
 		mgr.GetClient(),
@@ -298,7 +302,7 @@ func main() {
 		EC2Wrapper:  ec2Wrapper,
 		ClusterName: clusterName,
 		Log:         ctrl.Log.WithName("eni cleaner"),
-	}).SetupWithManager(ctx, mgr); err != nil {
+	}).SetupWithManager(ctx, mgr, describeENIPageSize); err != nil {
 		setupLog.Error(err, "unable to start eni cleaner")
 		os.Exit(1)
 	}

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/api/mock_ec2_wrapper.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/api/mock_ec2_wrapper.go
@@ -18,35 +18,36 @@
 package mock_api
 
 import (
+	reflect "reflect"
+
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
-// MockEC2Wrapper is a mock of EC2Wrapper interface
+// MockEC2Wrapper is a mock of EC2Wrapper interface.
 type MockEC2Wrapper struct {
 	ctrl     *gomock.Controller
 	recorder *MockEC2WrapperMockRecorder
 }
 
-// MockEC2WrapperMockRecorder is the mock recorder for MockEC2Wrapper
+// MockEC2WrapperMockRecorder is the mock recorder for MockEC2Wrapper.
 type MockEC2WrapperMockRecorder struct {
 	mock *MockEC2Wrapper
 }
 
-// NewMockEC2Wrapper creates a new mock instance
+// NewMockEC2Wrapper creates a new mock instance.
 func NewMockEC2Wrapper(ctrl *gomock.Controller) *MockEC2Wrapper {
 	mock := &MockEC2Wrapper{ctrl: ctrl}
 	mock.recorder = &MockEC2WrapperMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEC2Wrapper) EXPECT() *MockEC2WrapperMockRecorder {
 	return m.recorder
 }
 
-// AssignPrivateIPAddresses mocks base method
+// AssignPrivateIPAddresses mocks base method.
 func (m *MockEC2Wrapper) AssignPrivateIPAddresses(arg0 *ec2.AssignPrivateIpAddressesInput) (*ec2.AssignPrivateIpAddressesOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignPrivateIPAddresses", arg0)
@@ -55,13 +56,13 @@ func (m *MockEC2Wrapper) AssignPrivateIPAddresses(arg0 *ec2.AssignPrivateIpAddre
 	return ret0, ret1
 }
 
-// AssignPrivateIPAddresses indicates an expected call of AssignPrivateIPAddresses
+// AssignPrivateIPAddresses indicates an expected call of AssignPrivateIPAddresses.
 func (mr *MockEC2WrapperMockRecorder) AssignPrivateIPAddresses(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignPrivateIPAddresses", reflect.TypeOf((*MockEC2Wrapper)(nil).AssignPrivateIPAddresses), arg0)
 }
 
-// AssociateTrunkInterface mocks base method
+// AssociateTrunkInterface mocks base method.
 func (m *MockEC2Wrapper) AssociateTrunkInterface(arg0 *ec2.AssociateTrunkInterfaceInput) (*ec2.AssociateTrunkInterfaceOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateTrunkInterface", arg0)
@@ -70,13 +71,13 @@ func (m *MockEC2Wrapper) AssociateTrunkInterface(arg0 *ec2.AssociateTrunkInterfa
 	return ret0, ret1
 }
 
-// AssociateTrunkInterface indicates an expected call of AssociateTrunkInterface
+// AssociateTrunkInterface indicates an expected call of AssociateTrunkInterface.
 func (mr *MockEC2WrapperMockRecorder) AssociateTrunkInterface(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateTrunkInterface", reflect.TypeOf((*MockEC2Wrapper)(nil).AssociateTrunkInterface), arg0)
 }
 
-// AttachNetworkInterface mocks base method
+// AttachNetworkInterface mocks base method.
 func (m *MockEC2Wrapper) AttachNetworkInterface(arg0 *ec2.AttachNetworkInterfaceInput) (*ec2.AttachNetworkInterfaceOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachNetworkInterface", arg0)
@@ -85,13 +86,13 @@ func (m *MockEC2Wrapper) AttachNetworkInterface(arg0 *ec2.AttachNetworkInterface
 	return ret0, ret1
 }
 
-// AttachNetworkInterface indicates an expected call of AttachNetworkInterface
+// AttachNetworkInterface indicates an expected call of AttachNetworkInterface.
 func (mr *MockEC2WrapperMockRecorder) AttachNetworkInterface(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachNetworkInterface", reflect.TypeOf((*MockEC2Wrapper)(nil).AttachNetworkInterface), arg0)
 }
 
-// CreateNetworkInterface mocks base method
+// CreateNetworkInterface mocks base method.
 func (m *MockEC2Wrapper) CreateNetworkInterface(arg0 *ec2.CreateNetworkInterfaceInput) (*ec2.CreateNetworkInterfaceOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNetworkInterface", arg0)
@@ -100,13 +101,13 @@ func (m *MockEC2Wrapper) CreateNetworkInterface(arg0 *ec2.CreateNetworkInterface
 	return ret0, ret1
 }
 
-// CreateNetworkInterface indicates an expected call of CreateNetworkInterface
+// CreateNetworkInterface indicates an expected call of CreateNetworkInterface.
 func (mr *MockEC2WrapperMockRecorder) CreateNetworkInterface(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkInterface", reflect.TypeOf((*MockEC2Wrapper)(nil).CreateNetworkInterface), arg0)
 }
 
-// CreateNetworkInterfacePermission mocks base method
+// CreateNetworkInterfacePermission mocks base method.
 func (m *MockEC2Wrapper) CreateNetworkInterfacePermission(arg0 *ec2.CreateNetworkInterfacePermissionInput) (*ec2.CreateNetworkInterfacePermissionOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNetworkInterfacePermission", arg0)
@@ -115,13 +116,13 @@ func (m *MockEC2Wrapper) CreateNetworkInterfacePermission(arg0 *ec2.CreateNetwor
 	return ret0, ret1
 }
 
-// CreateNetworkInterfacePermission indicates an expected call of CreateNetworkInterfacePermission
+// CreateNetworkInterfacePermission indicates an expected call of CreateNetworkInterfacePermission.
 func (mr *MockEC2WrapperMockRecorder) CreateNetworkInterfacePermission(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkInterfacePermission", reflect.TypeOf((*MockEC2Wrapper)(nil).CreateNetworkInterfacePermission), arg0)
 }
 
-// CreateTags mocks base method
+// CreateTags mocks base method.
 func (m *MockEC2Wrapper) CreateTags(arg0 *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTags", arg0)
@@ -130,13 +131,13 @@ func (m *MockEC2Wrapper) CreateTags(arg0 *ec2.CreateTagsInput) (*ec2.CreateTagsO
 	return ret0, ret1
 }
 
-// CreateTags indicates an expected call of CreateTags
+// CreateTags indicates an expected call of CreateTags.
 func (mr *MockEC2WrapperMockRecorder) CreateTags(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTags", reflect.TypeOf((*MockEC2Wrapper)(nil).CreateTags), arg0)
 }
 
-// DeleteNetworkInterface mocks base method
+// DeleteNetworkInterface mocks base method.
 func (m *MockEC2Wrapper) DeleteNetworkInterface(arg0 *ec2.DeleteNetworkInterfaceInput) (*ec2.DeleteNetworkInterfaceOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteNetworkInterface", arg0)
@@ -145,13 +146,13 @@ func (m *MockEC2Wrapper) DeleteNetworkInterface(arg0 *ec2.DeleteNetworkInterface
 	return ret0, ret1
 }
 
-// DeleteNetworkInterface indicates an expected call of DeleteNetworkInterface
+// DeleteNetworkInterface indicates an expected call of DeleteNetworkInterface.
 func (mr *MockEC2WrapperMockRecorder) DeleteNetworkInterface(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkInterface", reflect.TypeOf((*MockEC2Wrapper)(nil).DeleteNetworkInterface), arg0)
 }
 
-// DescribeInstances mocks base method
+// DescribeInstances mocks base method.
 func (m *MockEC2Wrapper) DescribeInstances(arg0 *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstances", arg0)
@@ -160,13 +161,13 @@ func (m *MockEC2Wrapper) DescribeInstances(arg0 *ec2.DescribeInstancesInput) (*e
 	return ret0, ret1
 }
 
-// DescribeInstances indicates an expected call of DescribeInstances
+// DescribeInstances indicates an expected call of DescribeInstances.
 func (mr *MockEC2WrapperMockRecorder) DescribeInstances(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstances", reflect.TypeOf((*MockEC2Wrapper)(nil).DescribeInstances), arg0)
 }
 
-// DescribeNetworkInterfaces mocks base method
+// DescribeNetworkInterfaces mocks base method.
 func (m *MockEC2Wrapper) DescribeNetworkInterfaces(arg0 *ec2.DescribeNetworkInterfacesInput) (*ec2.DescribeNetworkInterfacesOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeNetworkInterfaces", arg0)
@@ -175,13 +176,27 @@ func (m *MockEC2Wrapper) DescribeNetworkInterfaces(arg0 *ec2.DescribeNetworkInte
 	return ret0, ret1
 }
 
-// DescribeNetworkInterfaces indicates an expected call of DescribeNetworkInterfaces
+// DescribeNetworkInterfaces indicates an expected call of DescribeNetworkInterfaces.
 func (mr *MockEC2WrapperMockRecorder) DescribeNetworkInterfaces(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfaces", reflect.TypeOf((*MockEC2Wrapper)(nil).DescribeNetworkInterfaces), arg0)
 }
 
-// DescribeSubnets mocks base method
+// DescribeNetworkInterfacesPages mocks base method.
+func (m *MockEC2Wrapper) DescribeNetworkInterfacesPages(arg0 *ec2.DescribeNetworkInterfacesInput, arg1 func(*ec2.DescribeNetworkInterfacesOutput, bool) bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeNetworkInterfacesPages", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeNetworkInterfacesPages indicates an expected call of DescribeNetworkInterfacesPages.
+func (mr *MockEC2WrapperMockRecorder) DescribeNetworkInterfacesPages(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacesPages", reflect.TypeOf((*MockEC2Wrapper)(nil).DescribeNetworkInterfacesPages), arg0, arg1)
+}
+
+// DescribeSubnets mocks base method.
 func (m *MockEC2Wrapper) DescribeSubnets(arg0 *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSubnets", arg0)
@@ -190,13 +205,13 @@ func (m *MockEC2Wrapper) DescribeSubnets(arg0 *ec2.DescribeSubnetsInput) (*ec2.D
 	return ret0, ret1
 }
 
-// DescribeSubnets indicates an expected call of DescribeSubnets
+// DescribeSubnets indicates an expected call of DescribeSubnets.
 func (mr *MockEC2WrapperMockRecorder) DescribeSubnets(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubnets", reflect.TypeOf((*MockEC2Wrapper)(nil).DescribeSubnets), arg0)
 }
 
-// DescribeTrunkInterfaceAssociations mocks base method
+// DescribeTrunkInterfaceAssociations mocks base method.
 func (m *MockEC2Wrapper) DescribeTrunkInterfaceAssociations(arg0 *ec2.DescribeTrunkInterfaceAssociationsInput) (*ec2.DescribeTrunkInterfaceAssociationsOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTrunkInterfaceAssociations", arg0)
@@ -205,13 +220,13 @@ func (m *MockEC2Wrapper) DescribeTrunkInterfaceAssociations(arg0 *ec2.DescribeTr
 	return ret0, ret1
 }
 
-// DescribeTrunkInterfaceAssociations indicates an expected call of DescribeTrunkInterfaceAssociations
+// DescribeTrunkInterfaceAssociations indicates an expected call of DescribeTrunkInterfaceAssociations.
 func (mr *MockEC2WrapperMockRecorder) DescribeTrunkInterfaceAssociations(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTrunkInterfaceAssociations", reflect.TypeOf((*MockEC2Wrapper)(nil).DescribeTrunkInterfaceAssociations), arg0)
 }
 
-// DetachNetworkInterface mocks base method
+// DetachNetworkInterface mocks base method.
 func (m *MockEC2Wrapper) DetachNetworkInterface(arg0 *ec2.DetachNetworkInterfaceInput) (*ec2.DetachNetworkInterfaceOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachNetworkInterface", arg0)
@@ -220,13 +235,13 @@ func (m *MockEC2Wrapper) DetachNetworkInterface(arg0 *ec2.DetachNetworkInterface
 	return ret0, ret1
 }
 
-// DetachNetworkInterface indicates an expected call of DetachNetworkInterface
+// DetachNetworkInterface indicates an expected call of DetachNetworkInterface.
 func (mr *MockEC2WrapperMockRecorder) DetachNetworkInterface(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachNetworkInterface", reflect.TypeOf((*MockEC2Wrapper)(nil).DetachNetworkInterface), arg0)
 }
 
-// ModifyNetworkInterfaceAttribute mocks base method
+// ModifyNetworkInterfaceAttribute mocks base method.
 func (m *MockEC2Wrapper) ModifyNetworkInterfaceAttribute(arg0 *ec2.ModifyNetworkInterfaceAttributeInput) (*ec2.ModifyNetworkInterfaceAttributeOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyNetworkInterfaceAttribute", arg0)
@@ -235,13 +250,13 @@ func (m *MockEC2Wrapper) ModifyNetworkInterfaceAttribute(arg0 *ec2.ModifyNetwork
 	return ret0, ret1
 }
 
-// ModifyNetworkInterfaceAttribute indicates an expected call of ModifyNetworkInterfaceAttribute
+// ModifyNetworkInterfaceAttribute indicates an expected call of ModifyNetworkInterfaceAttribute.
 func (mr *MockEC2WrapperMockRecorder) ModifyNetworkInterfaceAttribute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyNetworkInterfaceAttribute", reflect.TypeOf((*MockEC2Wrapper)(nil).ModifyNetworkInterfaceAttribute), arg0)
 }
 
-// UnassignPrivateIPAddresses mocks base method
+// UnassignPrivateIPAddresses mocks base method.
 func (m *MockEC2Wrapper) UnassignPrivateIPAddresses(arg0 *ec2.UnassignPrivateIpAddressesInput) (*ec2.UnassignPrivateIpAddressesOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnassignPrivateIPAddresses", arg0)
@@ -250,7 +265,7 @@ func (m *MockEC2Wrapper) UnassignPrivateIPAddresses(arg0 *ec2.UnassignPrivateIpA
 	return ret0, ret1
 }
 
-// UnassignPrivateIPAddresses indicates an expected call of UnassignPrivateIPAddresses
+// UnassignPrivateIPAddresses indicates an expected call of UnassignPrivateIPAddresses.
 func (mr *MockEC2WrapperMockRecorder) UnassignPrivateIPAddresses(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnassignPrivateIPAddresses", reflect.TypeOf((*MockEC2Wrapper)(nil).UnassignPrivateIPAddresses), arg0)

--- a/pkg/aws/ec2/api/eni_cleanup.go
+++ b/pkg/aws/ec2/api/eni_cleanup.go
@@ -92,49 +92,45 @@ func (e *ENICleaner) cleanUpAvailableENIs() {
 					config.NetworkInterfaceOwnerVPCCNITagValue}),
 			},
 		},
+		MaxResults: aws.Int64(50),
 	}
 
 	availableENIs := make(map[string]struct{})
 
-	for {
-		describeNetworkInterfaceOp, err := e.EC2Wrapper.DescribeNetworkInterfaces(describeNetworkInterfaceIp)
-		if err != nil {
-			e.Log.Error(err, "failed to describe network interfaces, will retry")
-			return
+	pageFn := func(output *ec2.DescribeNetworkInterfacesOutput, lastPage bool) (nextPage bool) {
+		e.Log.V(2).Info("Paginated Describe ENI call to return pages", "current page size", len(output.NetworkInterfaces))
+		for _, eni := range output.NetworkInterfaces {
+			e.deleteNetworkInterface(availableENIs, eni)
 		}
+		return true
+	}
 
-		for _, networkInterface := range describeNetworkInterfaceOp.NetworkInterfaces {
-			if _, exists := e.availableENIs[*networkInterface.NetworkInterfaceId]; exists {
-				// The ENI in available state has been sitting for at least the eni clean up interval and it should
-				// be removed
-				_, err := e.EC2Wrapper.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
-					NetworkInterfaceId: networkInterface.NetworkInterfaceId,
-				})
-				if err != nil {
-					// Log and continue, if the ENI is still present it will be cleaned up in next 2 cycles
-					e.Log.Error(err, "failed to delete the dangling network interface",
-						"id", *networkInterface.NetworkInterfaceId)
-					continue
-				}
-				e.Log.Info("deleted dangling ENI successfully",
-					"eni id", networkInterface.NetworkInterfaceId)
-			} else {
-				// Seeing the ENI for the first time, add it to the new list of available network interfaces
-				availableENIs[*networkInterface.NetworkInterfaceId] = struct{}{}
-				e.Log.V(1).Info("adding eni to to the map of available ENIs, will be removed if present in "+
-					"next run too", "id", *networkInterface.NetworkInterfaceId)
-			}
-		}
-
-		if describeNetworkInterfaceOp.NextToken == nil {
-			break
-		}
-
-		describeNetworkInterfaceIp = &ec2.DescribeNetworkInterfacesInput{
-			NextToken: describeNetworkInterfaceOp.NextToken,
-		}
+	if err := e.EC2Wrapper.DescribeNetworkInterfacesPages(describeNetworkInterfaceIp, pageFn); err != nil {
+		return
 	}
 
 	// Set the available ENIs to the list of ENIs seen in the current cycle
 	e.availableENIs = availableENIs
+}
+
+func (e *ENICleaner) deleteNetworkInterface(availableENIs map[string]struct{}, networkInterface *ec2.NetworkInterface) {
+	if _, exists := e.availableENIs[*networkInterface.NetworkInterfaceId]; exists {
+		// The ENI in available state has been sitting for at least the eni clean up interval and it should
+		// be removed
+		_, err := e.EC2Wrapper.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
+			NetworkInterfaceId: networkInterface.NetworkInterfaceId,
+		})
+		if err != nil {
+			// Log and continue, if the ENI is still present it will be cleaned up in next 2 cycles
+			e.Log.Error(err, "failed to delete the dangling network interface",
+				"id", *networkInterface.NetworkInterfaceId, "error", err)
+		}
+		e.Log.Info("deleted dangling ENI successfully",
+			"eni id", networkInterface.NetworkInterfaceId)
+	} else {
+		// Seeing the ENI for the first time, add it to the new list of available network interfaces
+		availableENIs[*networkInterface.NetworkInterfaceId] = struct{}{}
+		e.Log.V(1).Info("adding eni to to the map of available ENIs, will be removed if present in "+
+			"next run too", "id", *networkInterface.NetworkInterfaceId)
+	}
 }

--- a/pkg/aws/ec2/api/eni_cleanup_test.go
+++ b/pkg/aws/ec2/api/eni_cleanup_test.go
@@ -85,11 +85,21 @@ func TestENICleaner_cleanUpAvailableENIs(t *testing.T) {
 
 	gomock.InOrder(
 		// Return network interface 1 and 2 in first cycle
-		mockWrapper.EXPECT().DescribeNetworkInterfaces(mockDescribeNetworkInterfaceIp).
-			Return(mockDescribeInterfaceOpWith1And2, nil),
+		mockWrapper.EXPECT().DescribeNetworkInterfacesPages(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ *ec2.DescribeNetworkInterfacesInput, fn func(*ec2.DescribeNetworkInterfacesOutput, bool) bool) error {
+				assert.Equal(t, true, fn(&ec2.DescribeNetworkInterfacesOutput{
+					NetworkInterfaces: mockDescribeInterfaceOpWith1And2.NetworkInterfaces,
+				}, true))
+				return nil
+			}),
 		// Return network interface 1 and 3 in the second cycle
-		mockWrapper.EXPECT().DescribeNetworkInterfaces(mockDescribeNetworkInterfaceIp).
-			Return(mockDescribeInterfaceOpWith1And3, nil),
+		mockWrapper.EXPECT().DescribeNetworkInterfacesPages(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ *ec2.DescribeNetworkInterfacesInput, fn func(*ec2.DescribeNetworkInterfacesOutput, bool) bool) error {
+				assert.Equal(t, true, fn(&ec2.DescribeNetworkInterfacesOutput{
+					NetworkInterfaces: mockDescribeInterfaceOpWith1And3.NetworkInterfaces,
+				}, true))
+				return nil
+			}),
 		// Expect to delete the network interface 1
 		mockWrapper.EXPECT().DeleteNetworkInterface(
 			&ec2.DeleteNetworkInterfaceInput{NetworkInterfaceId: &mockNetworkInterfaceId1}).Return(nil, nil),

--- a/pkg/aws/ec2/api/helper.go
+++ b/pkg/aws/ec2/api/helper.go
@@ -60,17 +60,18 @@ var (
 )
 
 type ec2APIHelper struct {
-	ec2Wrapper EC2Wrapper
+	ec2Wrapper  EC2Wrapper
+	eniPageSize int
 }
 
-func NewEC2APIHelper(ec2Wrapper EC2Wrapper, clusterName string) EC2APIHelper {
+func NewEC2APIHelper(ec2Wrapper EC2Wrapper, clusterName string, pageSize int) EC2APIHelper {
 	// Set the key and value of the cluster name tag which will be used to tag all the network interfaces created by
 	// the controller
 	clusterNameTag = &ec2.Tag{
 		Key:   aws.String(fmt.Sprintf(config.ClusterNameTagKeyFormat, clusterName)),
 		Value: aws.String(config.ClusterNameTagValue),
 	}
-	return &ec2APIHelper{ec2Wrapper: ec2Wrapper}
+	return &ec2APIHelper{ec2Wrapper: ec2Wrapper, eniPageSize: pageSize}
 }
 
 type EC2APIHelper interface {
@@ -519,7 +520,7 @@ func (h *ec2APIHelper) GetBranchNetworkInterface(trunkID *string) ([]*ec2.Networ
 
 	describeNetworkInterfacesInput := &ec2.DescribeNetworkInterfacesInput{
 		Filters:    filters,
-		MaxResults: aws.Int64(50), //using the same page size as in eni cleaner
+		MaxResults: aws.Int64(int64(h.eniPageSize)), //using the flagged page size
 	}
 	var nwInterfaces []*ec2.NetworkInterface
 

--- a/pkg/aws/ec2/api/helper_test.go
+++ b/pkg/aws/ec2/api/helper_test.go
@@ -313,7 +313,7 @@ func getMockWrapper(ctrl *gomock.Controller) (EC2APIHelper, *mock_api.MockEC2Wra
 	}
 
 	mockWrapper := mock_api.NewMockEC2Wrapper(ctrl)
-	ec2ApiHelper := NewEC2APIHelper(mockWrapper, clusterName)
+	ec2ApiHelper := NewEC2APIHelper(mockWrapper, clusterName, 100)
 
 	return ec2ApiHelper, mockWrapper
 }

--- a/pkg/aws/ec2/api/helper_test.go
+++ b/pkg/aws/ec2/api/helper_test.go
@@ -1019,8 +1019,13 @@ func TestEc2APIHelper_GetBranchNetworkInterface_PaginatedResults(t *testing.T) {
 
 	ec2ApiHelper, mockWrapper := getMockWrapper(ctrl)
 
-	mockWrapper.EXPECT().DescribeNetworkInterfaces(describeTrunkInterfaceInput1).Return(describeTrunkInterfaceOutput1, nil)
-	mockWrapper.EXPECT().DescribeNetworkInterfaces(describeTrunkInterfaceInput2).Return(describeTrunkInterfaceOutput2, nil)
+	mockWrapper.EXPECT().DescribeNetworkInterfacesPages(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ *ec2.DescribeNetworkInterfacesInput, fn func(*ec2.DescribeNetworkInterfacesOutput, bool) bool) error {
+			assert.Equal(t, true, fn(&ec2.DescribeNetworkInterfacesOutput{
+				NetworkInterfaces: append(describeTrunkInterfaceOutput1.NetworkInterfaces, describeTrunkInterfaceOutput2.NetworkInterfaces...),
+			}, true))
+			return nil
+		})
 
 	branchInterfaces, err := ec2ApiHelper.GetBranchNetworkInterface(&trunkInterfaceId)
 	assert.NoError(t, err)

--- a/pkg/aws/ec2/api/wrapper.go
+++ b/pkg/aws/ec2/api/wrapper.go
@@ -55,6 +55,7 @@ type EC2Wrapper interface {
 	DescribeTrunkInterfaceAssociations(input *ec2.DescribeTrunkInterfaceAssociationsInput) (*ec2.DescribeTrunkInterfaceAssociationsOutput, error)
 	ModifyNetworkInterfaceAttribute(input *ec2.ModifyNetworkInterfaceAttributeInput) (*ec2.ModifyNetworkInterfaceAttributeOutput, error)
 	CreateNetworkInterfacePermission(input *ec2.CreateNetworkInterfacePermissionInput) (*ec2.CreateNetworkInterfacePermissionOutput, error)
+	DescribeNetworkInterfacesPages(input *ec2.DescribeNetworkInterfacesInput, fn func(*ec2.DescribeNetworkInterfacesOutput, bool) bool) error
 }
 
 var (
@@ -290,6 +291,20 @@ var (
 		},
 	)
 
+	ec2DescribeNetworkInterfacesPagesAPICallCnt = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "ec2_describe_network_interfaces_pages_api_req_count",
+			Help: "The number of calls made to ec2 for describing a network interface with pagination",
+		},
+	)
+
+	ec2DescribeNetworkInterfacesPagesAPIErrCnt = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "ec2_describe_network_interfaces_pages_api_err_count",
+			Help: "The number of errors encountered while describing a network interface with pagination",
+		},
+	)
+
 	prometheusRegistered = false
 )
 
@@ -325,7 +340,10 @@ func prometheusRegister() {
 			ec2describeTrunkInterfaceAssociationAPIErrCnt,
 			ec2modifyNetworkInterfaceAttributeAPICallCnt,
 			ec2modifyNetworkInterfaceAttributeAPIErrCnt,
-			ec2APICallLatencies)
+			ec2APICallLatencies,
+			ec2DescribeNetworkInterfacesPagesAPICallCnt,
+			ec2DescribeNetworkInterfacesPagesAPIErrCnt,
+		)
 
 		prometheusRegistered = true
 	}
@@ -725,4 +743,22 @@ func (e *ec2Wrapper) CreateNetworkInterfacePermission(input *ec2.CreateNetworkIn
 	}
 
 	return output, err
+}
+
+func (e *ec2Wrapper) DescribeNetworkInterfacesPages(input *ec2.DescribeNetworkInterfacesInput, fn func(*ec2.DescribeNetworkInterfacesOutput, bool) bool) error {
+	start := time.Now()
+	// describeNetworkInterfacesOutput, err := e.userServiceClient.DescribeNetworkInterfaces(input)
+	err := e.userServiceClient.DescribeNetworkInterfacesPages(input, fn)
+	ec2APICallLatencies.WithLabelValues("describe_network_interfaces_pages").Observe(timeSinceMs(start))
+
+	// Metric updates
+	ec2APICallCnt.Inc()
+	ec2DescribeNetworkInterfacesPagesAPICallCnt.Inc()
+
+	if err != nil {
+		ec2APIErrCnt.Inc()
+		ec2DescribeNetworkInterfacesPagesAPIErrCnt.Inc()
+	}
+
+	return err
 }


### PR DESCRIPTION
*Issue #, if available:*
Unpaginated API call DescribeNetworkInterface could put throttling on EC2. We should use DescribeNetworkInterfacePages if not specifying interface ID as parameter.

*Description of changes:*
Refactoring the API call to paginated version.

*Tests:*

1. e2e tests focus on security group for pods with the setting 4 parallelism/3 nodes as stress (Passed 
```
perpodsg % CGO_ENABLED=0 GOOS=$OS ginkgo -v -timeout 40m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id $VPC_ID --ginkgo.skip=LOCAL
```
```
Ran 18 of 22 Specs in 1553.904 seconds
SUCCESS! -- 18 Passed | 0 Failed | 0 Pending | 4 Skipped
PASS

Ginkgo ran 1 suite in 25m59.650309764s
Test Suite Passed
```
2. performance/soak tests with 100 nodes and 0 - 1000 pods (SGPP) every 15 minutes for 10 hours (No leaked ENI)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
