### PR TITLE
use go install to fix integration test error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ ifeq (, $(findstring v0.6.2,$(shell controller-gen --version)))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/scripts/test/test-with-eksctl.sh
+++ b/scripts/test/test-with-eksctl.sh
@@ -143,7 +143,7 @@ function run_inegration_test() {
 
   # Windows Test
   (cd test/integration/windows && \
-  CGO_ENABLED=0 ginkgo "$additional_gingko_params" -v -timeout 70m -- \
+  CGO_ENABLED=0 ginkgo "$additional_gingko_params" -v -timeout 85m -- \
   -cluster-kubeconfig=$KUBE_CONFIG_PATH \
   -cluster-name=$CLUSTER_NAME \
   --aws-region=$AWS_REGION \


### PR DESCRIPTION
*Description of changes:*

Since upgrading to Go 1.17, we need to switch to 'go install' to install controller-gen. 
From go docs:
```Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.```

This is to resolve the following error while running integration test cases:
```
make: controller-gen: Command not found
/bin/sh: /home/github-runner/go/bin/controller-gen: No such file or directory
make: *** [generate] Error 127
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.