### PR TITLE
add endpoint flag for beta test

### DIFF
--- a/scripts/test/lib/cluster.sh
+++ b/scripts/test/lib/cluster.sh
@@ -4,6 +4,10 @@ LIB_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 source "$LIB_DIR"/k8s.sh
 
+if [[ -n "${ENDPOINT}" ]]; then
+  ENDPOINT_FLAG="--endpoint $ENDPOINT"
+fi
+
 function load_cluster_details() {
   CLUSTER_INFO=$(aws eks describe-cluster --name $CLUSTER_NAME --region $REGION $ENDPOINT_FLAG)
   VPC_ID=$(echo $CLUSTER_INFO | jq -r '.cluster.resourcesVpcConfig.vpcId')

--- a/scripts/test/run-canary-test.sh
+++ b/scripts/test/run-canary-test.sh
@@ -20,10 +20,6 @@ KUBE CONFIG: $KUBE_CONFIG_PATH
 CLUSTER_NAME: $CLUSTER_NAME
 REGION: $REGION"
 
-if [[ -n "${ENDPOINT}" ]]; then
-  ENDPOINT_FLAG="--endpoint $ENDPOINT"
-fi
-
 # Default Proxy is not allowed in China Region
 if [[ $REGION == "cn-north-1" || $REGION == "cn-northwest-1" ]]; then
   go env -w GOPROXY=https://goproxy.cn,direct


### PR DESCRIPTION
*Description of changes:*
1. Add missing endpoint flag to fix beta prow job failures.
2. Fix regression test error- Use```eksctl``` to scale nodegroup. The test cluster creates unmanaged nodegroups and ```aws eks``` does not know about unmanaged nodegroups. 
```
An error occurred (ResourceNotFoundException) when calling the DescribeNodegroup operation: No node group found for name: None.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.