### PR TITLE
refactor node validation webhook test cases

### DIFF
--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/pod"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/rbac"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/service"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/serviceaccount"
 	sgpManager "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/sgp"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -46,6 +47,7 @@ type Framework struct {
 	DeploymentManager deployment.Manager
 	PodManager        pod.Manager
 	EC2Manager        ec2Manager.Manager
+	SAManager         serviceaccount.Manager
 	NSManager         namespace.Manager
 	SGPManager        sgpManager.Manager
 	SVCManager        service.Manager
@@ -97,6 +99,7 @@ func New(options Options) *Framework {
 		PodManager:        pod.NewManager(k8sClient, k8sSchema, config),
 		DeploymentManager: deployment.NewManager(k8sClient),
 		EC2Manager:        ec2Manager.NewManager(ec2, options.AWSVPCID),
+		SAManager:         serviceaccount.NewManager(k8sClient, config),
 		NSManager:         namespace.NewManager(k8sClient),
 		SGPManager:        sgpManager.NewManager(k8sClient),
 		SVCManager:        service.NewManager(k8sClient),

--- a/test/framework/resource/k8s/serviceaccount/manager.go
+++ b/test/framework/resource/k8s/serviceaccount/manager.go
@@ -1,0 +1,47 @@
+package serviceaccount
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Manager interface {
+	// BuildRestConfigWithServiceAccount will build a new rest config with credentials from service account.
+	BuildRestConfigWithServiceAccount(ctx context.Context, saKey types.NamespacedName) (*rest.Config, error)
+}
+
+type defaultManager struct {
+	k8sClient client.Client
+	restCfg   *rest.Config
+}
+
+func NewManager(k8sClient client.Client, restCfg *rest.Config) Manager {
+	return &defaultManager{k8sClient: k8sClient, restCfg: restCfg}
+}
+
+func (m *defaultManager) BuildRestConfigWithServiceAccount(ctx context.Context, saKey types.NamespacedName) (*rest.Config, error) {
+	sa := &corev1.ServiceAccount{}
+	if err := m.k8sClient.Get(ctx, saKey, sa); err != nil {
+		return nil, err
+	}
+	if len(sa.Secrets) == 0 {
+		return nil, errors.Errorf("serviceAccount %s have no secrets", saKey.String())
+	}
+	saTokenSecretName := sa.Secrets[0].Name
+	saTokenSecretKey := types.NamespacedName{Namespace: saKey.Namespace, Name: saTokenSecretName}
+	saTokenSecret := &corev1.Secret{}
+	if err := m.k8sClient.Get(ctx, saTokenSecretKey, saTokenSecret); err != nil {
+		return nil, err
+	}
+	bearerToken := string(saTokenSecret.Data["token"])
+	tlsClientConfig := rest.TLSClientConfig{CAData: saTokenSecret.Data["ca.crt"]}
+	return &rest.Config{
+		Host:            m.restCfg.Host,
+		TLSClientConfig: tlsClientConfig,
+		BearerToken:     bearerToken,
+	}, nil
+}


### PR DESCRIPTION
*Issue #, if available:*
The original node validation webhook test case don't work against v1.23 as there is no shells available in v1.23 kube-proxy.(we switched to use minimal kube-proxy image by default)

*Description of changes:*
1. refactor the node validation webhook to use credentials from aws-node SA instead of exec inside pod.
2. added more test cases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
