### PR TITLE
check pointer before dereference

### DIFF
--- a/pkg/aws/ec2/instance.go
+++ b/pkg/aws/ec2/instance.go
@@ -123,7 +123,7 @@ func (i *ec2Instance) LoadDetails(ec2APIHelper api.EC2APIHelper) error {
 		i.deviceIndexes[*index] = true
 
 		// Load the Security group of the primary network interface
-		if i.instanceSecurityGroups == nil && *nwInterface.PrivateIpAddress == *instance.PrivateIpAddress {
+		if i.instanceSecurityGroups == nil && (nwInterface.PrivateIpAddress != nil && instance.PrivateIpAddress != nil && *nwInterface.PrivateIpAddress == *instance.PrivateIpAddress) {
 			i.primaryENIID = *nwInterface.NetworkInterfaceId
 			// TODO: Group can change, should be refreshed each time we want to use this
 			for _, group := range nwInterface.Groups {


### PR DESCRIPTION
*Issue #, if available:*
#116 

*Description of changes:*
We need check the pointers before dereference them for in case they were not properly populated.

*Test*
```
[AfterSuite] PASSED [110.725 seconds]
[AfterSuite] 
/home/zhuhz/go/src/amazon-vpc-resource-controller-k8s/test/integration/webhook/validating_webhook_suite_test.go:83

  Begin Captured GinkgoWriter Output >>
    STEP: deleting the pod 08/19/22 19:14:47.716
    STEP: deleting the security group policy 08/19/22 19:14:59.726
    STEP: deleting the namespace 08/19/22 19:15:01.838
    STEP: waiting for all the ENIs to be deleted after being cooled down 08/19/22 19:15:07.848
    STEP: deleting the security group from ec2 08/19/22 19:16:37.849
  << End Captured GinkgoWriter Output
------------------------------

Ran 11 of 11 Specs in 142.736 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 2m39.053980754s
Test Suite Passed

[AfterSuite] 
/home/zhuhz/go/src/amazon-vpc-resource-controller-k8s/test/integration/perpodsg/perpodsg_suite_test.go:58
STEP: waiting for all the ENIs to be deleted after being cooled down 08/19/22 19:42:10.618
------------------------------
[AfterSuite] PASSED [91.114 seconds]
[AfterSuite] 
/home/zhuhz/go/src/amazon-vpc-resource-controller-k8s/test/integration/perpodsg/perpodsg_suite_test.go:58

  Begin Captured GinkgoWriter Output >>
    STEP: waiting for all the ENIs to be deleted after being cooled down 08/19/22 19:42:10.618
  << End Captured GinkgoWriter Output
------------------------------

Ran 18 of 22 Specs in 1534.044 seconds
SUCCESS! -- 18 Passed | 0 Failed | 0 Pending | 4 Skipped
PASS

Ginkgo ran 1 suite in 25m36.947848543s
Test Suite Passed
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
