### PR TITLE
add readme for latest supported instances in limit file

### DIFF
--- a/pkg/aws/vpc/README.md
+++ b/pkg/aws/vpc/README.md
@@ -1,0 +1,5 @@
+# supported EC2 instance types by amazon-vpc-resource-controller-k8s
+
+The limit.go file in master branch provides the latest supported EC2 instance types by the controller for [Security Group for Pods feature](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html). In this file, you will find if your EC2 instance is supported (`IsTrunkingCompatible`) and how many pods using the feature (`BranchInterface`) can be created per instance when the next version of the controller is released. 
+
+Note: If you want to check EC2 instance types currently supported by the controller, you should check the limit.go file in the release branch instead. Thank you!


### PR DESCRIPTION
*Issue #, if available:*
#129 
*Description of changes:*
Due to divergence, we want to add a README for limit file in master branch. The other PR for release branch has been created as well (https://github.com/aws/amazon-vpc-resource-controller-k8s/pull/131).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
