### PR TITLE
avoid requeuing not found pods

### DIFF
--- a/pkg/k8s/pod/client_wrapper.go
+++ b/pkg/k8s/pod/client_wrapper.go
@@ -19,7 +19,9 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -185,7 +187,7 @@ func (p *podClientAPIWrapper) GetPod(namespace string, name string) (*v1.Pod, er
 		return nil, err
 	}
 	if !exists {
-		return nil, fmt.Errorf("failed to find pod %s", nsName)
+		return nil, apierrors.NewNotFound(schema.GroupResource{}, nsName)
 	}
 	return obj.(*v1.Pod), nil
 }


### PR DESCRIPTION
*Issue #, if available:*
#128 
*Description of changes:*
If the pod is not found, the call returns k8s API errors NotFound. If the job doesn't find the pod, worker will forget the item. If the pod has update, cache client will fetch the event and create another job for queuing.

Test result
```
{"level":"error","timestamp":"2022-10-05T00:52:26.642Z","logger":"vpc.amazonaws.com/pod-eni-worker","msg":"won't requeue a not found errored job","job":{"Operation":"Create","UID":"","PodName":"hello-world-5d97946fc7-8sgvz","PodNamespace":"default","RequestCount":1,"NodeName":""},"job":{"Operation":"Create","UID":"","PodName":"hello-world-5d97946fc7-8sgvz","PodNamespace":"default","RequestCount":1,"NodeName":""},"error":" \"default/hello-world-5d97946fc7-8sgvz\" not found","stacktrace":"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/worker.(*worker).processNextItem\n\t/workspace/pkg/worker/worker.go:164\ngithub.com/aws/amazon-vpc-resource-controller-k8s/pkg/worker.(*worker).runWorker\n\t/workspace/pkg/worker/worker.go:141"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
