### PR TITLE
update troubleshooting for using PSP with User authentication

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -230,12 +230,15 @@ If the Pod is still stuck in `ContainerCreating` you can,
 ## List of Common Issues  
 
 ### PSP Blocking Controller Annotations
-If you have a PSP that blocks annotation to Pod, you will have to allow annotation from the following Service Account
+If you have a PSP that blocks annotation to Pod, you will have to allow annotation from the following User `eks:vpc-resource-controller`
 ```
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: system:authenticated
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: eks:vpc-resource-controller
   - kind: ServiceAccount
     name: eks-vpc-resource-controller
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -236,9 +236,9 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: system:authenticated
-  - apiGroup: rbac.authorization.k8s.io
-    kind: User
+  - kind: User
     name: eks:vpc-resource-controller
+    apiGroup: rbac.authorization.k8s.io
   - kind: ServiceAccount
     name: eks-vpc-resource-controller
 ```


### PR DESCRIPTION
*Issue #, if available:*
#134 
*Description of changes:*
EKS recently switched authentication from service account to User for VPC resource controller. This could be a breaking change. We need call this out in our doc. A PR was also created to update [amazon-eks-user-guide](https://github.com/awsdocs/amazon-eks-user-guide/pull/612)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
