### PR TITLE
tuning workers count and QPS limiter

### DIFF
--- a/controllers/core/node_controller.go
+++ b/controllers/core/node_controller.go
@@ -30,8 +30,10 @@ import (
 
 // MaxConcurrentReconciles is the number of go routines that can invoke
 // Reconcile in parallel. Since Node Reconciler, performs local operation
-// on cache only a single go routine is sufficient
-const MaxConcurrentReconciles = 1
+// on cache only a single go routine should be sufficient. Using more than
+// one routines to help high rate churn and larger nodes groups restarting
+// when the controller has to be restarted for various reasons.
+const MaxConcurrentReconciles = 3
 
 // NodeReconciler reconciles a Node object
 type NodeReconciler struct {

--- a/main.go
+++ b/main.go
@@ -278,7 +278,7 @@ func main() {
 		ctrl.Log.WithName("controller conditions"), k8sApi)
 
 	nodeManagerWorkers := asyncWorkers.NewDefaultWorkerPool("node async workers",
-		3, 1, ctrl.Log.WithName("node async workers"), ctx)
+		10, 1, ctrl.Log.WithName("node async workers"), ctx)
 	nodeManager, err := manager.NewNodeManager(ctrl.Log.WithName("node manager"), resourceManager,
 		apiWrapper, nodeManagerWorkers, controllerConditions)
 	if err != nil {

--- a/pkg/aws/ec2/api/wrapper.go
+++ b/pkg/aws/ec2/api/wrapper.go
@@ -354,6 +354,7 @@ func NewEC2Wrapper(roleARN string, log logr.Logger) (EC2Wrapper, error) {
 	// Role ARN is passed, assume the role ARN to make EC2 API Calls
 	if roleARN != "" {
 		// Create the instance service client with low QPS, it will be only used fro associate branch to trunk calls
+		log.Info("Creating INSTANCE service client with configured QPS", "QPS", config.InstanceServiceClientQPS, "Burst", config.InstanceServiceClientBurst)
 		instanceServiceClient, err := ec2Wrapper.getInstanceServiceClient(config.InstanceServiceClientQPS,
 			config.InstanceServiceClientBurst, instanceSession)
 		if err != nil {
@@ -362,6 +363,7 @@ func NewEC2Wrapper(roleARN string, log logr.Logger) (EC2Wrapper, error) {
 		ec2Wrapper.instanceServiceClient = instanceServiceClient
 
 		// Create the user service client with higher QPS, this will be used to make rest of the EC2 API Calls
+		log.Info("Creating USER service client with configured QPS", "QPS", config.UserServiceClientQPS, "Burst", config.UserServiceClientQPSBurst)
 		userServiceClient, err := ec2Wrapper.getClientUsingAssumedRole(*instanceSession.Config.Region, roleARN,
 			config.UserServiceClientQPS, config.UserServiceClientQPSBurst)
 		if err != nil {
@@ -371,6 +373,7 @@ func NewEC2Wrapper(roleARN string, log logr.Logger) (EC2Wrapper, error) {
 	} else {
 		// Role ARN is not provided, assuming that instance service client is whitelisted for ENI branching and use
 		// the instance service client as the user service client with higher QPS.
+		log.Info("Creating INSTANCE service client with configured USER Service QPS", "QPS", config.InstanceServiceClientQPS, "Burst", config.InstanceServiceClientBurst)
 		instanceServiceClient, err := ec2Wrapper.getInstanceServiceClient(config.UserServiceClientQPS,
 			config.UserServiceClientQPSBurst, instanceSession)
 		if err != nil {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -14,10 +14,12 @@
 package config
 
 const (
+	// TODO: Should we always do this max retry no matter why it fails
+	// such deleted pods will also be retried 5 times, which could be an issue for large pods loads and high churning rate.
 	WorkQueueDefaultMaxRetries = 5
 
 	// Default Configuration for Pod ENI resource type
-	PodENIDefaultWorker = 2
+	PodENIDefaultWorker = 7
 
 	// Default Configuration for IPv4 resource type
 	IPv4DefaultWorker  = 2
@@ -26,12 +28,16 @@ const (
 	IPv4DefaultResSize = 0
 
 	// EC2 API QPS for user service client
-	UserServiceClientQPS      = 6
+	// Tested: 15 + 20 limits
+	// Tested: 15 + 8 limits (not seeing significant degradation from 15+20)
+	// Tested: 12 + 8 limits (not seeing significant degradation from 15+8)
+	// Larger number seems not make latency better than 12+8
+	UserServiceClientQPS      = 12
 	UserServiceClientQPSBurst = 8
 
 	// EC2 API QPS for instance service client
-	InstanceServiceClientQPS   = 2
-	InstanceServiceClientBurst = 3
+	InstanceServiceClientQPS   = 5
+	InstanceServiceClientBurst = 7
 
 	// API Server QPS
 	DefaultAPIServerQPS   = 10

--- a/pkg/utils/httpClient.go
+++ b/pkg/utils/httpClient.go
@@ -23,6 +23,7 @@ import (
 // NewRateLimitedClient returns a new HTTP client with rate limiter.
 func NewRateLimitedClient(qps int, burst int) (*http.Client, error) {
 	if qps == 0 {
+		fmt.Printf("Creating a default rate limited http client with QPS = %d, Burst = %d\n", qps, burst)
 		return http.DefaultClient, nil
 	}
 	if burst < 1 {

--- a/pkg/utils/httpClient.go
+++ b/pkg/utils/httpClient.go
@@ -23,7 +23,6 @@ import (
 // NewRateLimitedClient returns a new HTTP client with rate limiter.
 func NewRateLimitedClient(qps int, burst int) (*http.Client, error) {
 	if qps == 0 {
-		fmt.Printf("Creating a default rate limited http client with QPS = %d, Burst = %d\n", qps, burst)
 		return http.DefaultClient, nil
 	}
 	if burst < 1 {


### PR DESCRIPTION
*Issue #, if available:*
#104 #124 
*Description of changes:*
We should increase the workers and QPS limit on client and user calling to EC2 API to help minimize the delay/latency when large cluster/node groups churning and restarting the vpc resource controller for various reasons (such as control plane updates, control plane scaling, the controller update).

Tests have been done with clusters scale of 100 nodes, 500 nodes, and 1000 nodes. Pods using the security group for pods feature have been tested with scale from 500 up to 20k.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
