### PR TITLE
don't add orphaned pods back into pod queue

### DIFF
--- a/controllers/core/pod_controller_test.go
+++ b/controllers/core/pod_controller_test.go
@@ -14,13 +14,15 @@
 package controllers
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/controllers/custom"
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/handler"
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/node"
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/node/manager"
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/resource"
+	mock_handler "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/handler"
+	mock_k8s "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s"
+	mock_node "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/node"
+	mock_manager "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/node/manager"
+	mock_resource "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/resource"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/k8s/pod"
 
 	"github.com/golang/mock/gomock"
@@ -86,6 +88,7 @@ var (
 
 type Mock struct {
 	MockNodeManager     *mock_manager.MockManager
+	MockK8sAPI          *mock_k8s.MockK8sWrapper
 	MockResourceManager *mock_resource.MockResourceManager
 	MockNode            *mock_node.MockNode
 	PodReconciler       *PodReconciler
@@ -97,6 +100,7 @@ func NewMock(ctrl *gomock.Controller, mockPod *v1.Pod) Mock {
 	mockNodeManager := mock_manager.NewMockManager(ctrl)
 	mockResourceManager := mock_resource.NewMockResourceManager(ctrl)
 	mockNode := mock_node.NewMockNode(ctrl)
+	mockK8sWrapper := mock_k8s.NewMockK8sWrapper(ctrl)
 
 	converter := pod.PodConverter{}
 	mockIndexer := cache.NewIndexer(converter.Indexer, pod.NodeNameIndexer())
@@ -104,6 +108,7 @@ func NewMock(ctrl *gomock.Controller, mockPod *v1.Pod) Mock {
 
 	return Mock{
 		MockNodeManager:     mockNodeManager,
+		MockK8sAPI:          mockK8sWrapper,
 		MockResourceManager: mockResourceManager,
 		MockNode:            mockNode,
 		MockHandler:         mockHandler,
@@ -111,6 +116,7 @@ func NewMock(ctrl *gomock.Controller, mockPod *v1.Pod) Mock {
 			Log:             zap.New(),
 			ResourceManager: mockResourceManager,
 			NodeManager:     mockNodeManager,
+			K8sAPI:          mockK8sWrapper,
 			DataStore:       mockIndexer,
 		},
 	}
@@ -125,6 +131,7 @@ func TestPodReconciler_Reconcile_Create(t *testing.T) {
 	mock := NewMock(ctrl, mockPod)
 
 	mock.MockNodeManager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, true)
+	mock.MockK8sAPI.EXPECT().GetNode(mockNodeName).Return(nil, nil)
 	mock.MockNode.EXPECT().IsManaged().Return(true)
 	mock.MockNode.EXPECT().IsReady().Return(true)
 	mock.MockResourceManager.EXPECT().GetResourceHandler(mockResourceName).Return(mock.MockHandler, true)
@@ -146,7 +153,6 @@ func TestPodReconciler_Reconcile_Delete(t *testing.T) {
 
 	mock.MockNodeManager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, true)
 	mock.MockNode.EXPECT().IsManaged().Return(true)
-	mock.MockNode.EXPECT().IsReady().Return(true)
 	mock.MockResourceManager.EXPECT().GetResourceHandler(mockResourceName).Return(mock.MockHandler, true)
 	mock.MockHandler.EXPECT().HandleDelete(mockPod).Return(reconcile.Result{}, nil)
 	mock.MockResourceManager.EXPECT().GetResourceHandler(mockUnsupportedResourceName).Return(nil, false)
@@ -168,6 +174,7 @@ func TestPodReconciler_Reconcile_NonManaged(t *testing.T) {
 	mock := NewMock(ctrl, mockPod)
 
 	mock.MockNodeManager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, true)
+	mock.MockK8sAPI.EXPECT().GetNode(mockNodeName).Return(nil, nil)
 	mock.MockNode.EXPECT().IsManaged().Return(false)
 
 	result, err := mock.PodReconciler.Reconcile(mockReq)
@@ -199,6 +206,7 @@ func TestPodReconciler_Reconcile_NodeNotReady(t *testing.T) {
 	mock := NewMock(ctrl, mockPod)
 
 	mock.MockNodeManager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, true)
+	mock.MockK8sAPI.EXPECT().GetNode(mockNodeName).Return(nil, nil)
 	mock.MockNode.EXPECT().IsManaged().Return(true)
 	mock.MockNode.EXPECT().IsReady().Return(false)
 
@@ -214,8 +222,51 @@ func TestPodReconcile_Reconcile_NodeNotInitialized(t *testing.T) {
 	mock := NewMock(ctrl, mockPod)
 
 	mock.MockNodeManager.EXPECT().GetNode(mockNodeName).Return(nil, false)
+	mock.MockK8sAPI.EXPECT().GetNode(mockNodeName).Return(nil, nil)
 
 	result, err := mock.PodReconciler.Reconcile(mockReq)
 	assert.Equal(t, result, PodRequeueRequest)
 	assert.NoError(t, err)
+}
+
+func TestPodReconcile_Reconcile_NodeDeletedFromCache(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := NewMock(ctrl, mockPod)
+
+	mock.MockNodeManager.EXPECT().GetNode(mockNodeName).Return(nil, false)
+	mock.MockResourceManager.EXPECT().GetResourceHandler(mockResourceName).Return(mock.MockHandler, true)
+	mock.MockHandler.EXPECT().HandleDelete(mockPod).Return(reconcile.Result{}, nil)
+	mock.MockResourceManager.EXPECT().GetResourceHandler(mockUnsupportedResourceName).Return(nil, false)
+
+	delReq := custom.Request{
+		DeletedObject: mockPod,
+	}
+
+	result, err := mock.PodReconciler.Reconcile(delReq)
+	assert.NoError(t, err)
+	assert.Equal(t, result, controllerruntime.Result{})
+}
+
+func TestPodReconcile_Reconcile_NodeDeletedFromCluster(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := NewMock(ctrl, mockPod)
+
+	mock.MockNodeManager.EXPECT().GetNode(mockNodeName).Return(nil, false)
+	mock.MockK8sAPI.EXPECT().GetNode(mockNodeName).Return(nil, errors.New("Resource not found")).AnyTimes()
+	// mock.MockNode.EXPECT().IsManaged().Return(true)
+	mock.MockResourceManager.EXPECT().GetResourceHandler(mockResourceName).Return(mock.MockHandler, true)
+	mock.MockHandler.EXPECT().HandleDelete(mockPod).Return(reconcile.Result{}, nil)
+	mock.MockResourceManager.EXPECT().GetResourceHandler(mockUnsupportedResourceName).Return(nil, false)
+
+	// delReq := custom.Request{
+	// 	DeletedObject: mockPod,
+	// }
+
+	result, err := mock.PodReconciler.Reconcile(mockReq)
+	assert.NoError(t, err)
+	assert.Equal(t, result, controllerruntime.Result{})
 }

--- a/main.go
+++ b/main.go
@@ -292,6 +292,7 @@ func main() {
 		Log:             ctrl.Log.WithName("controllers").WithName("Pod Reconciler"),
 		ResourceManager: resourceManager,
 		NodeManager:     nodeManager,
+		K8sAPI:          k8sApi,
 		DataStore:       dataStore,
 		DataStoreSynced: hasPodDataStoreSynced,
 	}).SetupWithManager(ctx, mgr, clientSet, listPageLimit, syncPeriod); err != nil {


### PR DESCRIPTION
*Issue #, if available:*
#122 
*Description of changes:*
We shouldn't re-queue the pods which don't have nodes and no longer exist in the cluster. This issue could happen when the nodes are churning quickly and pods are queue due to events and the nodes are gone. Differentiating node-not-ready and node-is-gone is a must to avoid orphan pods stuck in queue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
