### PR TITLE
move to lease based resource lock

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -30,7 +30,7 @@ rules:
   verbs:
   - create
 - apiGroups:
-    - ""
+    - coordination.k8s.io
   resources:
     - leases
   verbs:

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -30,13 +30,17 @@ rules:
   verbs:
   - create
 - apiGroups:
-    - coordination.k8s.io
+  - coordination.k8s.io
   resources:
-    - leases
+  - leases
   verbs:
-    - get
-    - list
-    - watch
-    - create
-    - update
-    - patch
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - cp-vpc-resource-controller
+  resources:
+  - leases
+  verbs:
+  - get
+  - update

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -29,3 +29,14 @@ rules:
   - events
   verbs:
   - create
+- apiGroups:
+    - ""
+  resources:
+    - leases
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch

--- a/main.go
+++ b/main.go
@@ -216,7 +216,7 @@ func main() {
 		RetryPeriod:                &retryPeriod,
 		LeaderElectionID:           config.LeaderElectionKey,
 		LeaderElectionNamespace:    config.LeaderElectionNamespace,
-		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
+		LeaderElectionResourceLock: resourcelock.ConfigMapsLeasesResourceLock,
 		HealthProbeBindAddress:     ":61779", // the liveness endpoint is default to "/healthz"
 		NewCache:                   newCache,
 	})

--- a/main.go
+++ b/main.go
@@ -216,7 +216,7 @@ func main() {
 		RetryPeriod:                &retryPeriod,
 		LeaderElectionID:           config.LeaderElectionKey,
 		LeaderElectionNamespace:    config.LeaderElectionNamespace,
-		LeaderElectionResourceLock: resourcelock.ConfigMapsResourceLock,
+		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		HealthProbeBindAddress:     ":61779", // the liveness endpoint is default to "/healthz"
 		NewCache:                   newCache,
 	})

--- a/main.go
+++ b/main.go
@@ -78,6 +78,9 @@ func init() {
 // +kubebuilder:rbac:groups=crd.k8s.amazonaws.com,resources=eniconfigs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=vpcresources.k8s.aws,resources=securitygrouppolicies,verbs=get;list;watch
 
+// Migration to leases based leader election
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,namespace=kube-system,verbs=create
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,namespace=kube-system,resourceNames=cp-vpc-resource-controller,verbs=get;update
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Kubernetes contains a MultiLock based lock in `coordination/v1` api. 
We will take the change through multiple iterations. In the first iteration, we're moving to multi lock, that allows safe migration. In a future version, we will move multilock into lease lock and complete the migration.

Guidance: https://github.com/kubernetes/kubernetes/issues/107454

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
