### PR TITLE
Add ginkgo v2 back to integration tests

### DIFF
--- a/controllers/core/suite_test.go
+++ b/controllers/core/suite_test.go
@@ -17,14 +17,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	// +kubebuilder:scaffold:imports
@@ -40,9 +39,7 @@ var testEnv *envtest.Environment
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
-		[]Reporter{printer.NewlineReporter{}})
+	RunSpecs(t, "Controller Suite")
 }
 
 var _ = BeforeSuite(func(done Done) {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/go-logr/zapr v0.4.0
 	github.com/golang/mock v1.4.1
 	github.com/google/uuid v1.1.2
-	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/ginkgo/v2 v2.3.1
 	github.com/onsi/gomega v1.22.0
 	github.com/pkg/errors v0.9.1

--- a/scripts/test/run-canary-test.sh
+++ b/scripts/test/run-canary-test.sh
@@ -104,9 +104,9 @@ function run_canary_tests() {
   # For each component, we want to cover the most important test cases. We also don't want to take more than 30 minutes
   # per repository as these tests are run sequentially along with tests from other repositories
   # Currently the overall execution time is ~50 minutes and we will reduce it in future
-  (CGO_ENABLED=0 ginkgo --focus="CANARY" $EXTRA_GINKGO_FLAGS -v -timeout 15m $GINKGO_TEST_BUILD_DIR/perpodsg.test -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID)
-  (CGO_ENABLED=0 ginkgo --focus="CANARY" $EXTRA_GINKGO_FLAGS -v -timeout 27m $GINKGO_TEST_BUILD_DIR/windows.test -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID)
-  (CGO_ENABLED=0 ginkgo --focus="CANARY" $EXTRA_GINKGO_FLAGS -v -timeout 5m $GINKGO_TEST_BUILD_DIR/webhook.test -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name  =$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID)
+  (CGO_ENABLED=0 ginkgo --no-color --focus="CANARY" $EXTRA_GINKGO_FLAGS -v --timeout 15m $GINKGO_TEST_BUILD_DIR/perpodsg.test -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID)
+  (CGO_ENABLED=0 ginkgo --no-color --focus="CANARY" $EXTRA_GINKGO_FLAGS -v --timeout 30m $GINKGO_TEST_BUILD_DIR/windows.test -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID)
+  (CGO_ENABLED=0 ginkgo --no-color --focus="CANARY" $EXTRA_GINKGO_FLAGS -v --timeout 5m $GINKGO_TEST_BUILD_DIR/webhook.test -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID)
 }
 
 echo "Starting the ginkgo test suite"

--- a/test/README.md
+++ b/test/README.md
@@ -59,11 +59,11 @@ The Integration test suite provides the following focuses.
    ```
    cd test/integration
    echo "Running Validation Webhook Tests"
-   (cd webhook && CGO_ENABLED=0 GOOS=$OS ginkgo -v -timeout 10m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id $VPC_ID)
+   (cd webhook && CGO_ENABLED=0 GOOS=$OS ginkgo -v --timeout 10m -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID)
    echo "Running Security Group for Pods Integration Tests"
-   (cd perpodsg && CGO_ENABLED=0 GOOS=$OS ginkgo -v -timeout 40m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id $VPC_ID)
+   (cd perpodsg && CGO_ENABLED=0 GOOS=$OS ginkgo -v --timeout 40m -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID)
    echo "Running Windows Integration Tests"
-   (cd windows && CGO_ENABLED=0 GOOS=$OS ginkgo -v -timeout 40m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id $VPC_ID)
+   (cd windows && CGO_ENABLED=0 GOOS=$OS ginkgo -v --timeout 40m -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID)
    ```
 
 #### Running Integration tests on Controller running on EKS Control Plane

--- a/test/framework/resource/k8s/configmap/wrapper.go
+++ b/test/framework/resource/k8s/configmap/wrapper.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 )

--- a/test/framework/resource/k8s/controller/wrapper.go
+++ b/test/framework/resource/k8s/controller/wrapper.go
@@ -22,7 +22,7 @@ import (
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/pod"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/rbac"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/rbac/v1"
 )

--- a/test/framework/resource/k8s/deployment/wrapper.go
+++ b/test/framework/resource/k8s/deployment/wrapper.go
@@ -16,7 +16,7 @@ package deployment
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 )

--- a/test/framework/resource/k8s/node/wrapper.go
+++ b/test/framework/resource/k8s/node/wrapper.go
@@ -17,7 +17,7 @@ import (
 	"context"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/test/framework/resource/k8s/pod/wrapper.go
+++ b/test/framework/resource/k8s/pod/wrapper.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 )

--- a/test/framework/resource/k8s/sgp/wrapper.go
+++ b/test/framework/resource/k8s/sgp/wrapper.go
@@ -20,7 +20,7 @@ import (
 	"github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/test/framework/verify/pod.go
+++ b/test/framework/verify/pod.go
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 )

--- a/test/integration/perpodsg/job_test.go
+++ b/test/integration/perpodsg/job_test.go
@@ -26,7 +26,7 @@ import (
 	sgpWrapper "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/sgp"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	batchV1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"

--- a/test/integration/perpodsg/perpodsg_suite_test.go
+++ b/test/integration/perpodsg/perpodsg_suite_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
 	verifier "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/verify"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 )

--- a/test/integration/perpodsg/perpodsg_test.go
+++ b/test/integration/perpodsg/perpodsg_test.go
@@ -27,7 +27,7 @@ import (
 	sgpWrapper "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/sgp"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"

--- a/test/integration/webhook/validating_webhook_suite_test.go
+++ b/test/integration/webhook/validating_webhook_suite_test.go
@@ -25,7 +25,7 @@ import (
 	sgpWrapper "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/sgp"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 )

--- a/test/integration/webhook/validating_webhook_test.go
+++ b/test/integration/webhook/validating_webhook_test.go
@@ -15,19 +15,20 @@ package webhook
 
 import (
 	"fmt"
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/manifest"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 

--- a/test/integration/windows/stress_test.go
+++ b/test/integration/windows/stress_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsV1 "k8s.io/api/apps/v1"
 	batchV1 "k8s.io/api/batch/v1"

--- a/test/integration/windows/windows_suite_test.go
+++ b/test/integration/windows/windows_suite_test.go
@@ -28,7 +28,7 @@ import (
 	_ "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
 	verifier "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/verify"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 )

--- a/test/integration/windows/windows_test.go
+++ b/test/integration/windows/windows_test.go
@@ -23,7 +23,7 @@ import (
 	configMapWrapper "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/configmap"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsV1 "k8s.io/api/apps/v1"
 	batchV1 "k8s.io/api/batch/v1"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
In #141 , some ginkgo v2 imports were removed. This became an issue when ginkgo v2 was added back in #143 . The goal is to use ginkgo v2 (currently 2.3.1) throughout this repo, so this PR re-introduces just the ginkgo v2 support that was reverted.

I validated this PR by making sure that scripts/test/run-canary-test.sh passes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
