### PR TITLE
Add SKIP_WINDOWS_TEST environment variable to integration test scripts

### DIFF
--- a/scripts/test/README.md
+++ b/scripts/test/README.md
@@ -1,5 +1,6 @@
 ## Integration Script
 The Integration test script creates an eksctl cluster and runs the Ginkgo Integration tests on the current build from the repository.
+
 ### Usage
 The Integration test script will **fail to run** on accounts that is not allowlisted for ENI Trunking feature. The test script is currently used in **CI Setup** for the repository `amazon-vpc-resource-controller-k8s`.
 
@@ -31,6 +32,12 @@ K8S_VERSION=<k8s-Version>
   ```
   ./scripts/test/delete-cluster.sh
   ```
+
+### Integration Test Scripts
+`run-canary-test.sh` runs integration tests against an existing cluster with the "CANARY" focus.
+`run-integration-tests.sh` runs non-local integration tests against an existing cluster.
+
+To run the above scripts against a cluster without sufficient Windows nodes, the "SKIP_WINDOWS_TEST" environment variable can be passed.
 
 ### Design
 

--- a/scripts/test/run-canary-test.sh
+++ b/scripts/test/run-canary-test.sh
@@ -105,7 +105,11 @@ function run_canary_tests() {
   # per repository as these tests are run sequentially along with tests from other repositories
   # Currently the overall execution time is ~50 minutes and we will reduce it in future
   (CGO_ENABLED=0 ginkgo --no-color --focus="CANARY" $EXTRA_GINKGO_FLAGS -v --timeout 15m $GINKGO_TEST_BUILD_DIR/perpodsg.test -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID)
-  (CGO_ENABLED=0 ginkgo --no-color --focus="CANARY" $EXTRA_GINKGO_FLAGS -v --timeout 30m $GINKGO_TEST_BUILD_DIR/windows.test -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID)
+  if [[ -z "${SKIP_WINDOWS_TEST}" ]]; then
+    (CGO_ENABLED=0 ginkgo --no-color --focus="CANARY" $EXTRA_GINKGO_FLAGS -v --timeout 30m $GINKGO_TEST_BUILD_DIR/windows.test -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID)
+  else
+    echo "skipping Windows tests"
+  fi
   (CGO_ENABLED=0 ginkgo --no-color --focus="CANARY" $EXTRA_GINKGO_FLAGS -v --timeout 5m $GINKGO_TEST_BUILD_DIR/webhook.test -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID)
 }
 

--- a/scripts/test/run-integration-tests.sh
+++ b/scripts/test/run-integration-tests.sh
@@ -20,7 +20,11 @@ source "$SCRIPT_DIR"/lib/cluster.sh
 function run_integration_tests(){
   TEST_RESULT=success
   (cd $INTEGRATION_TEST_DIR/perpodsg && CGO_ENABLED=0 ginkgo --skip=LOCAL -v -timeout=40m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID) || TEST_RESULT=fail
-  (cd $INTEGRATION_TEST_DIR/windows && CGO_ENABLED=0 ginkgo --skip=LOCAL -v -timeout=80m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID) || TEST_RESULT=fail
+  if [[ -z "${SKIP_WINDOWS_TEST}" ]]; then
+    (cd $INTEGRATION_TEST_DIR/windows && CGO_ENABLED=0 ginkgo --skip=LOCAL -v -timeout=80m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID) || TEST_RESULT=fail
+  else
+    echo "skipping Windows tests"
+  fi
   (cd $INTEGRATION_TEST_DIR/webhook && CGO_ENABLED=0 ginkgo --skip=LOCAL -v -timeout=10m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID) || TEST_RESULT=fail
 
   if [[ "$TEST_RESULT" == fail ]]; then


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This PR allows for Windows tests to be skipped in integration test suites by passing the SKIP_WINDOWS_TEST environment variable. This approach was chosen rather than checking the environment variable directly in the test so that developers did not have to modify test code to run tests locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
