### PR TITLE
create secret to fix the no token error in webhook e2e for eks 1.24

### DIFF
--- a/test/framework/resource/k8s/serviceaccount/manager.go
+++ b/test/framework/resource/k8s/serviceaccount/manager.go
@@ -2,9 +2,14 @@ package serviceaccount
 
 import (
 	"context"
+	"time"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -19,8 +24,56 @@ type defaultManager struct {
 	restCfg   *rest.Config
 }
 
+var (
+	tokenTimeOut = time.Second * 10
+	awsNodeToken = types.NamespacedName{
+		Name:      "aws-node-token",
+		Namespace: "kube-system",
+	}
+	saUIDKey  = "kubernetes.io/service-account.uid"
+	saNameKey = "kubernetes.io/service-account.name"
+)
+
 func NewManager(k8sClient client.Client, restCfg *rest.Config) Manager {
 	return &defaultManager{k8sClient: k8sClient, restCfg: restCfg}
+}
+
+func (m *defaultManager) createServiceAccountToken(ctx context.Context, saKey types.NamespacedName, tokenKey types.NamespacedName) error {
+	token := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      tokenKey.Name,
+			Namespace: tokenKey.Namespace,
+			Annotations: map[string]string{
+				saNameKey: saKey.Name,
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+
+	if err := m.k8sClient.Create(ctx, token); err != nil {
+		return errors.Errorf("Creating service account aws-node's token failed, Error %s", err.Error())
+	}
+
+	err := wait.Poll(utils.PollIntervalShort, tokenTimeOut, func() (done bool, err error) {
+		sa := &corev1.ServiceAccount{}
+		err = m.k8sClient.Get(ctx, saKey, sa)
+		if err != nil {
+			return true, err
+		}
+		return m.hasTokenAssociatedToSA(ctx, sa, tokenKey), nil
+	})
+	return err
+}
+
+func (m *defaultManager) hasTokenAssociatedToSA(ctx context.Context, sa *corev1.ServiceAccount, tokenKey types.NamespacedName) bool {
+	return len(sa.Secrets) > 0 || m.isTokenCreatedForSA(ctx, sa, tokenKey)
+}
+
+func (m *defaultManager) isTokenCreatedForSA(ctx context.Context, sa *corev1.ServiceAccount, tokenKey types.NamespacedName) bool {
+	token := &corev1.Secret{}
+	err := m.k8sClient.Get(ctx, tokenKey, token)
+	result := err == nil && token.Annotations[saUIDKey] == string(sa.UID)
+	return result
 }
 
 func (m *defaultManager) BuildRestConfigWithServiceAccount(ctx context.Context, saKey types.NamespacedName) (*rest.Config, error) {
@@ -28,11 +81,24 @@ func (m *defaultManager) BuildRestConfigWithServiceAccount(ctx context.Context, 
 	if err := m.k8sClient.Get(ctx, saKey, sa); err != nil {
 		return nil, err
 	}
-	if len(sa.Secrets) == 0 {
-		return nil, errors.Errorf("serviceAccount %s have no secrets", saKey.String())
+
+	if !m.hasTokenAssociatedToSA(ctx, sa, awsNodeToken) {
+		if err := m.createServiceAccountToken(ctx, saKey, awsNodeToken); err != nil {
+			return nil, errors.Errorf("serviceAccount %s have no secrets with errors %s", saKey.String(), err.Error())
+		}
+
 	}
-	saTokenSecretName := sa.Secrets[0].Name
-	saTokenSecretKey := types.NamespacedName{Namespace: saKey.Namespace, Name: saTokenSecretName}
+
+	var saTokenSecretKey types.NamespacedName
+	if len(sa.Secrets) > 0 {
+		// < eks 1.24
+		saTokenSecretName := sa.Secrets[0].Name
+		saTokenSecretKey = types.NamespacedName{Namespace: saKey.Namespace, Name: saTokenSecretName}
+
+	} else {
+		// >= eks 1.24
+		saTokenSecretKey = awsNodeToken
+	}
 	saTokenSecret := &corev1.Secret{}
 	if err := m.k8sClient.Get(ctx, saTokenSecretKey, saTokenSecret); err != nil {
 		return nil, err


### PR DESCRIPTION
*Issue #, if available:*
Webhook e2e is failing with EKS 1.24 due to a major change in k8s 1.24. From 1.24, service account will be no longer created with token. In our test, we use SA token to authenticate. To fix this, we can create a secret assigning to the SA aws-node and use either SA token (< 1.24) or the created secrete to authenticate client (>= 1.24).

*Description of changes:*
1, if SA aws-node has no token associated, creating a secret that is assigned to aws-node service account
2, if SA has token, use its token, otherwise use the new secret

*Test*

Debug log
```
DEBUG: checking SA token &ServiceAccount{ObjectMeta:{aws-node  kube-system  c0503f33-05cc-4b12-8056-79aaaf58e87c 244 0 2022-10-27 01:20:03 +0000 UTC <nil> <nil> map[] map[kubectl.kubernetes.io/last-applied-configuration:{"apiVersion":"v1","kind":"ServiceAccount","metadata":{"annotations":{},"name":"aws-node","namespace":"kube-system"}}
] [] []  [{kubectl-client-side-apply Update v1 2022-10-27 01:20:03 +0000 UTC FieldsV1 {"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}}}}}]},Secrets:[]ObjectReference{},ImagePullSecrets:[]LocalObjectReference{},AutomountServiceAccountToken:nil,}, its secrets size is 0
DEBUG: do we have token created for the SA? false
DEBUG: Call creat SA token &Secret{ObjectMeta:{aws-node-token  kube-system    0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[kubernetes.io/service-account.name:aws-node] [] []  []},Data:map[string][]byte{},Type:kubernetes.io/service-account-token,StringData:map[string]string{},Immutable:nil,}
DEBUG: token created without error
DEBUG: polling sa token wiht error <nil>
DEBUG: checking SA token &ServiceAccount{ObjectMeta:{aws-node  kube-system  c0503f33-05cc-4b12-8056-79aaaf58e87c 244 0 2022-10-27 01:20:03 +0000 UTC <nil> <nil> map[] map[kubectl.kubernetes.io/last-applied-configuration:{"apiVersion":"v1","kind":"ServiceAccount","metadata":{"annotations":{},"name":"aws-node","namespace":"kube-system"}}
] [] []  [{kubectl-client-side-apply Update v1 2022-10-27 01:20:03 +0000 UTC FieldsV1 {"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}}}}}]},Secrets:[]ObjectReference{},ImagePullSecrets:[]LocalObjectReference{},AutomountServiceAccountToken:nil,}, its secrets size is 0
DEBUG: do we have token created for the SA? true
```
Webhook e2e tests passed
```
[AfterSuite] PASSED [110.726 seconds]
[AfterSuite] 
/home/zhuhz/go/src/amazon-vpc-resource-controller-k8s/test/integration/webhook/validating_webhook_suite_test.go:83

  Begin Captured GinkgoWriter Output >>
    STEP: deleting the pod 10/27/22 02:00:41.599
    STEP: deleting the security group policy 10/27/22 02:00:53.614
    STEP: deleting the namespace 10/27/22 02:00:55.829
    STEP: waiting for all the ENIs to be deleted after being cooled down 10/27/22 02:01:01.84
    STEP: deleting the security group from ec2 10/27/22 02:02:31.841
  << End Captured GinkgoWriter Output
------------------------------

Ran 11 of 11 Specs in 132.757 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
