### PR TITLE
increase concurrent routines for pod controller

### DIFF
--- a/controllers/core/node_controller.go
+++ b/controllers/core/node_controller.go
@@ -28,12 +28,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
-// MaxConcurrentReconciles is the number of go routines that can invoke
+// MaxNodeConcurrentReconciles is the number of go routines that can invoke
 // Reconcile in parallel. Since Node Reconciler, performs local operation
 // on cache only a single go routine should be sufficient. Using more than
 // one routines to help high rate churn and larger nodes groups restarting
 // when the controller has to be restarted for various reasons.
-const MaxConcurrentReconciles = 3
+const MaxNodeConcurrentReconciles = 3
 
 // NodeReconciler reconciles a Node object
 type NodeReconciler struct {
@@ -92,6 +92,6 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Node{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: MaxConcurrentReconciles}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: MaxNodeConcurrentReconciles}).
 		Complete(r)
 }

--- a/controllers/core/pod_controller.go
+++ b/controllers/core/pod_controller.go
@@ -171,7 +171,7 @@ func getAggregateResources(pod *v1.Pod) map[string]int64 {
 // will be started and the Pod events will be sent to Reconcile function
 func (r *PodReconciler) SetupWithManager(ctx context.Context, manager ctrl.Manager,
 	clientSet *kubernetes.Clientset, pageLimit int, syncPeriod time.Duration) error {
-
+	r.Log.Info("The pod controller is using MaxConcurrentReconciles 4")
 	return custom.NewControllerManagedBy(ctx, manager).
 		WithLogger(r.Log.WithName("custom pod controller")).
 		UsingDataStore(r.DataStore).
@@ -183,6 +183,6 @@ func (r *PodReconciler) SetupWithManager(ctx context.Context, manager ctrl.Manag
 		Options(custom.Options{
 			PageLimit:               pageLimit,
 			ResyncPeriod:            syncPeriod,
-			MaxConcurrentReconciles: 2,
+			MaxConcurrentReconciles: 4,
 		}).Complete(r)
 }

--- a/controllers/core/pod_controller.go
+++ b/controllers/core/pod_controller.go
@@ -46,7 +46,10 @@ type PodReconciler struct {
 	DataStoreSynced *bool
 }
 
-var PodRequeueRequest = ctrl.Result{Requeue: true, RequeueAfter: time.Second}
+var (
+	PodRequeueRequest          = ctrl.Result{Requeue: true, RequeueAfter: time.Second}
+	MaxPodConcurrentReconciles = 4
+)
 
 // Reconcile handles create/update/delete event by delegating the request to the  handler
 // if the resource is supported by the controller.
@@ -171,7 +174,7 @@ func getAggregateResources(pod *v1.Pod) map[string]int64 {
 // will be started and the Pod events will be sent to Reconcile function
 func (r *PodReconciler) SetupWithManager(ctx context.Context, manager ctrl.Manager,
 	clientSet *kubernetes.Clientset, pageLimit int, syncPeriod time.Duration) error {
-	r.Log.Info("The pod controller is using MaxConcurrentReconciles 4")
+	r.Log.Info("The pod controller is using MaxConcurrentReconciles", "Routines", MaxPodConcurrentReconciles)
 	return custom.NewControllerManagedBy(ctx, manager).
 		WithLogger(r.Log.WithName("custom pod controller")).
 		UsingDataStore(r.DataStore).
@@ -183,6 +186,6 @@ func (r *PodReconciler) SetupWithManager(ctx context.Context, manager ctrl.Manag
 		Options(custom.Options{
 			PageLimit:               pageLimit,
 			ResyncPeriod:            syncPeriod,
-			MaxConcurrentReconciles: 4,
+			MaxConcurrentReconciles: MaxPodConcurrentReconciles,
 		}).Complete(r)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We increase concurrent routines in pod reconciling. This will help minimize pods creation latency, especially during high rate pods churn and restart of the controller.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
