### PR TITLE
skip addon installation when addon info is not available

### DIFF
--- a/scripts/test/run-canary-test.sh
+++ b/scripts/test/run-canary-test.sh
@@ -75,6 +75,10 @@ function wait_for_addon_status() {
 
 function install_add_on() {
   local new_addon_version=$1
+  if [[ -z "$new_addon_version" || "$new_addon_version" == "null" ]]; then
+    echo "addon information for $VPC_CNI_ADDON_NAME not available, skipping EKS-managed addon installation. Tests will run against self-managed addon."
+    return
+  fi
 
   if DESCRIBE_ADDON=$(aws eks describe-addon $ENDPOINT_FLAG --cluster-name "$CLUSTER_NAME" --addon-name $VPC_CNI_ADDON_NAME --region $REGION); then
     local current_addon_version=$(echo "$DESCRIBE_ADDON" | jq '.addon.addonVersion' -r)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adding changes to handle canary test script failure when addon information is not available. In this case, we will skip installing the EKS-managed addon, and tests will be run against the default self-managed addon.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
