### PR TITLE
create event controller, its tests, and RBAC for sgp feature

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,8 +12,10 @@ rules:
   - events
   verbs:
   - create
+  - list
   - patch
   - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,10 +12,8 @@ rules:
   - events
   verbs:
   - create
-  - list
   - patch
   - update
-  - watch
 - apiGroups:
   - ""
   resources:
@@ -55,6 +53,16 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - vpcresources.k8s.aws

--- a/controllers/core/event_controller.go
+++ b/controllers/core/event_controller.go
@@ -174,7 +174,7 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 					}
 					if labelled {
 						eventControllerSGPEventsCount.WithLabelValues(SGPEventsCountMetrics).Inc()
-						r.Log.Info("Lable node with trunk label as true", "Node", node.Name, "Label", config.HasTrunkAttachedLabel)
+						r.Log.Info("Label node with trunk label as true", "Node", node.Name, "Label", config.HasTrunkAttachedLabel)
 					}
 				}
 				if r.isValidEventForCustomNetworking(event) {

--- a/controllers/core/event_controller.go
+++ b/controllers/core/event_controller.go
@@ -1,0 +1,207 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/k8s"
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	MaxEventConcurrentReconciles = 4
+	EventCreatedPastMinutes      = 2
+	EventFilterKey               = "reportingComponent"
+)
+
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;update;patch;list;watch
+
+type EventReconciler struct {
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+	K8sAPI k8s.K8sWrapper
+}
+
+var (
+	eventControllerTotalEventsCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "total_events_reconciled_by_event_controller",
+			Help: "The number of events that were reconcile by the controller",
+		},
+		[]string{"operation"},
+	)
+
+	eventControllerSGPEventsCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "security_group_pod_events_reconciled_by_event_controller",
+			Help: "The number of SGP events that were reconcile by the controller",
+		},
+		[]string{"operation"},
+	)
+
+	eventControllerCNEventsCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "custom_networking_events_reconciled_by_event_controller",
+			Help: "The number of custom networking events that were reconcile by the controller",
+		},
+		[]string{"operation"},
+	)
+
+	eventControllerEventFailureCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "failed_get_events__by_event_controller",
+			Help: "The number of failures on getting events by the controller",
+		},
+		[]string{"operation"},
+	)
+
+	eventReconcileOperationLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "event_reconcile_operation_latency",
+			Help: "Event controller reconcile events latency in ms",
+		},
+		[]string{"time"},
+	)
+
+	prometheusRegistered = false
+	reconcileEvents      = "reconcile_events"
+)
+
+func PrometheusRegister() {
+	if !prometheusRegistered {
+		metrics.Registry.MustRegister(eventControllerTotalEventsCount)
+		metrics.Registry.MustRegister(eventControllerSGPEventsCount)
+		metrics.Registry.MustRegister(eventControllerEventFailureCount)
+		metrics.Registry.MustRegister(eventControllerCNEventsCount)
+		metrics.Registry.MustRegister(eventReconcileOperationLatency)
+		prometheusRegistered = true
+	}
+}
+
+func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	start := time.Now()
+	var err error
+
+	logger := r.Log.WithValues("event", req.Name)
+
+	eventControllerTotalEventsCount.WithLabelValues("reconcile").Inc()
+
+	ops := []client.ListOption{
+		client.MatchingFields{
+			EventFilterKey: config.VpcCNIReportingAgent,
+		},
+	}
+
+	events, err := r.K8sAPI.ListEvents(ops)
+	if err != nil {
+		logger.Error(err, "List events failed")
+		eventControllerEventFailureCount.WithLabelValues("failing_list").Inc()
+		return ctrl.Result{}, err
+	}
+
+	for _, event := range events.Items {
+		// only check and process events were created in the past EventCreatedPastMinutes minutes
+		if !event.GetCreationTimestamp().After(time.Now().Add(-time.Minute * EventCreatedPastMinutes)) {
+			continue
+		}
+		if r.isValidEventForSGP(event) || r.isValidEventForCustomNetworking(event) {
+			nodeName := string(event.InvolvedObject.UID)
+
+			if node, err := r.K8sAPI.GetNode(nodeName); err != nil {
+				// if not found the node, we don't requeue and just wait VPC CNI to send another request
+				r.Log.V(1).Info("Event reconciler didn't find the node and wait for next request for the node", "Node", node.Name)
+				return ctrl.Result{}, nil
+			} else {
+				if r.isEventToManageNode(event) && r.isValidEventForSGP(event) {
+					r.K8sAPI.AddLabelToManageNode(node, config.HasTrunkAttachedLabel, "true")
+					eventControllerSGPEventsCount.WithLabelValues("trunk_labelled").Inc()
+					r.Log.Info("Lable node with trunk label as true", "Node", node.Name, "Label", config.HasTrunkAttachedLabel)
+				}
+				if r.isValidEventForCustomNetworking(event) {
+					configKey, configName := parseEventMsg(event.Message)
+					if configKey == config.CustomNetworkingLabel {
+						r.K8sAPI.AddLabelToManageNode(node, config.CustomNetworkingLabel, configName)
+						eventControllerCNEventsCount.WithLabelValues("eniconfig_labelled").Inc()
+						r.Log.Info("Label node with eniconfig label with configured name", "Node", node.Name, "Label", config.CustomNetworkingLabel)
+					}
+				}
+			}
+		}
+	}
+	eventReconcileOperationLatency.WithLabelValues(reconcileEvents).Observe(float64(time.Since(start).Milliseconds()))
+	return ctrl.Result{}, nil
+}
+
+func (r *EventReconciler) isValidEventForSGP(event corev1.Event) bool {
+	return event.ReportingController == config.VpcCNIReportingAgent &&
+		event.Reason == config.VpcCNINodeEventReason && event.Action == config.VpcCNINodeEventActionForTrunk
+}
+
+func (r *EventReconciler) isValidEventForCustomNetworking(event corev1.Event) bool {
+	return event.ReportingController == config.VpcCNIReportingAgent &&
+		event.Reason == config.VpcCNINodeEventReason && event.Action == config.VpcCNINodeEventActionForEniConfig
+}
+
+func (r *EventReconciler) isEventToManageNode(event corev1.Event) bool {
+	return event.Message == config.TrunkNotAttached || event.Message == config.TrunkAttached
+}
+
+func (r *EventReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Event{}, EventFilterKey, func(raw client.Object) []string {
+		event := raw.(*corev1.Event)
+		return []string{event.ReportingController}
+	}); err != nil {
+		return err
+	}
+
+	r.Log.Info("Event manager is using settings", "ConcurrentReconciles", MaxEventConcurrentReconciles, "MinutesInPast", EventCreatedPastMinutes)
+	PrometheusRegister()
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Event{}).
+		WithEventFilter(predicate.Funcs{
+			DeleteFunc:  func(de event.DeleteEvent) bool { return false },
+			UpdateFunc:  func(ue event.UpdateEvent) bool { return false },
+			GenericFunc: func(ge event.GenericEvent) bool { return false },
+			CreateFunc: func(ce event.CreateEvent) bool {
+				now := time.Now()
+				then := now.Add(-time.Minute * EventCreatedPastMinutes)
+				return ce.Object.GetCreationTimestamp().After(then)
+			},
+		}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: MaxEventConcurrentReconciles}).Complete(r)
+}
+
+func parseEventMsg(msg string) (string, string) {
+	splittedMsg := strings.Split(msg, "=")
+	if len(splittedMsg) != 2 {
+		return "", ""
+	}
+	key := splittedMsg[0]
+	value := splittedMsg[1]
+	return key, value
+}

--- a/controllers/core/event_controller_test.go
+++ b/controllers/core/event_controller_test.go
@@ -1,0 +1,226 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	mock_k8s "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var (
+	mockSGPEventName         = "node-sgp-event"
+	mockCNEventName          = "node-custom-networking-event"
+	mockEventNodeName        = "ip-0-0-0-0.us-west-2.compute.internal"
+	sgpEventReconcileRequest = reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      mockSGPEventName,
+			Namespace: config.KubeSystemNamespace,
+		},
+	}
+	eniConfigEventReconcileRequest = reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      mockCNEventName,
+			Namespace: config.KubeSystemNamespace,
+		},
+	}
+
+	oldSgpEvent = &corev1.Event{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              mockSGPEventName,
+			Namespace:         config.KubeSystemNamespace,
+			CreationTimestamp: v1.Time{Time: time.Now().Add(-time.Minute * 3)},
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Name: mockEventNodeName,
+			UID:  types.UID(mockEventNodeName),
+		},
+		ReportingController: config.VpcCNIReportingAgent,
+		Reason:              config.VpcCNINodeEventReason,
+		Message:             config.TrunkNotAttached,
+		Action:              config.VpcCNINodeEventActionForTrunk,
+	}
+	newSgpEvent = &corev1.Event{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              mockSGPEventName,
+			Namespace:         config.KubeSystemNamespace,
+			CreationTimestamp: v1.Time{Time: time.Now().Add(-time.Minute * 1)},
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Name: mockEventNodeName,
+			UID:  types.UID(mockEventNodeName),
+		},
+		ReportingController: config.VpcCNIReportingAgent,
+		Reason:              config.VpcCNINodeEventReason,
+		Message:             config.TrunkNotAttached,
+		Action:              config.VpcCNINodeEventActionForTrunk,
+	}
+	oldEniConfigEvent = &corev1.Event{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              mockCNEventName,
+			Namespace:         config.KubeSystemNamespace,
+			CreationTimestamp: v1.Time{Time: time.Now().Add(-time.Minute * 3)},
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Name: mockEventNodeName,
+			UID:  types.UID(mockEventNodeName),
+		},
+		ReportingController: config.VpcCNIReportingAgent,
+		Reason:              config.VpcCNINodeEventReason,
+		Action:              config.VpcCNINodeEventActionForEniConfig,
+		Message:             config.CustomNetworkingLabel + "=testConfig",
+	}
+	newEniConfigEvent = &corev1.Event{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              mockCNEventName,
+			Namespace:         config.KubeSystemNamespace,
+			CreationTimestamp: v1.Time{Time: time.Now().Add(-time.Minute * 1)},
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Name: mockEventNodeName,
+			UID:  types.UID(mockEventNodeName),
+		},
+		ReportingController: config.VpcCNIReportingAgent,
+		Reason:              config.VpcCNINodeEventReason,
+		Action:              config.VpcCNINodeEventActionForEniConfig,
+		Message:             config.CustomNetworkingLabel + "=testConfig",
+	}
+
+	eventNode = &corev1.Node{
+		TypeMeta: v1.TypeMeta{},
+		ObjectMeta: v1.ObjectMeta{
+			Name:   mockEventNodeName,
+			Labels: map[string]string{config.NodeLabelOS: config.OSLinux, config.HasTrunkAttachedLabel: "true"},
+		},
+	}
+)
+
+type EventMock struct {
+	MockK8sAPI *mock_k8s.MockK8sWrapper
+	Reconciler EventReconciler
+}
+
+func NewEventControllerMock(ctrl *gomock.Controller, mockObjects ...runtime.Object) EventMock {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	mockK8sAPI := mock_k8s.NewMockK8sWrapper(ctrl)
+	return EventMock{
+		MockK8sAPI: mockK8sAPI,
+		Reconciler: EventReconciler{
+			Scheme: scheme,
+			Log:    zap.New(),
+			K8sAPI: mockK8sAPI,
+		},
+	}
+}
+
+func TestEventReconciler_Reconcile_SGPEvent(t *testing.T) {
+	var events = []struct {
+		eventList          *corev1.EventList
+		isValidEventForSGP bool
+	}{
+		{
+			eventList: &corev1.EventList{
+				Items: append([]corev1.Event{}, *oldSgpEvent),
+			},
+			isValidEventForSGP: false,
+		},
+		{
+			eventList: &corev1.EventList{
+				Items: append([]corev1.Event{}, *newSgpEvent),
+			},
+			isValidEventForSGP: true,
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := NewEventControllerMock(ctrl)
+	ops := []client.ListOption{
+		client.MatchingFields{
+			EventFilterKey: config.VpcCNIReportingAgent,
+		},
+	}
+
+	for _, e := range events {
+		mock.MockK8sAPI.EXPECT().ListEvents(ops).Return(e.eventList, nil)
+
+		if e.isValidEventForSGP {
+			// if the event is older, these func are not expected to be called.
+			mock.MockK8sAPI.EXPECT().GetNode(mockEventNodeName).Return(eventNode, nil).AnyTimes()
+			mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.HasTrunkAttachedLabel, "true").Return(nil)
+		}
+		res, err := mock.Reconciler.Reconcile(context.TODO(), sgpEventReconcileRequest)
+
+		assert.NoError(t, err)
+		assert.Equal(t, res, reconcile.Result{})
+	}
+}
+
+func TestEventReconciler_Reconcile_ENIConfigLabelNodeEvent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ops := []client.ListOption{
+		client.MatchingFields{
+			EventFilterKey: config.VpcCNIReportingAgent,
+		},
+	}
+
+	var events = []struct {
+		eventList                       *corev1.EventList
+		isValidEventForCustomNetworking bool
+	}{
+		{
+			eventList: &corev1.EventList{
+				Items: append([]corev1.Event{}, *oldEniConfigEvent),
+			},
+			isValidEventForCustomNetworking: false,
+		},
+		{
+			eventList: &corev1.EventList{
+				Items: append([]corev1.Event{}, *newEniConfigEvent),
+			},
+			isValidEventForCustomNetworking: true,
+		},
+	}
+
+	for _, e := range events {
+		mock := NewEventControllerMock(ctrl)
+		mock.MockK8sAPI.EXPECT().ListEvents(ops).Return(e.eventList, nil)
+
+		if e.isValidEventForCustomNetworking {
+			// if the event is older, these func are not expected to be called.
+			mock.MockK8sAPI.EXPECT().GetNode(mockEventNodeName).Return(eventNode, nil)
+			mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.CustomNetworkingLabel, "testConfig").Return(nil)
+		}
+
+		res, err := mock.Reconciler.Reconcile(context.TODO(), eniConfigEventReconcileRequest)
+
+		assert.NoError(t, err)
+		assert.Equal(t, res, reconcile.Result{})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -345,6 +345,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&corecontroller.EventReconciler{
+		Log:    ctrl.Log.WithName("Controllers").WithName("Event"),
+		Scheme: mgr.GetScheme(),
+		K8sAPI: k8sApi,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Event")
+		os.Exit(1)
+	}
+
 	if err = (&resource.IntrospectHandler{
 		Log:             ctrl.Log.WithName("introspect"),
 		BindAddress:     introspectBindAddr,

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/mock_k8swrapper.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/mock_k8swrapper.go
@@ -24,6 +24,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/apps/v1"
 	v10 "k8s.io/api/core/v1"
+	v11 "k8s.io/api/events/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -52,11 +53,12 @@ func (m *MockK8sWrapper) EXPECT() *MockK8sWrapperMockRecorder {
 }
 
 // AddLabelToManageNode mocks base method.
-func (m *MockK8sWrapper) AddLabelToManageNode(arg0 *v10.Node, arg1, arg2 string) error {
+func (m *MockK8sWrapper) AddLabelToManageNode(arg0 *v10.Node, arg1, arg2 string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddLabelToManageNode", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // AddLabelToManageNode indicates an expected call of AddLabelToManageNode.
@@ -167,10 +169,10 @@ func (mr *MockK8sWrapperMockRecorder) GetNode(arg0 interface{}) *gomock.Call {
 }
 
 // ListEvents mocks base method.
-func (m *MockK8sWrapper) ListEvents(arg0 []client.ListOption) (*v10.EventList, error) {
+func (m *MockK8sWrapper) ListEvents(arg0 []client.ListOption) (*v11.EventList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListEvents", arg0)
-	ret0, _ := ret[0].(*v10.EventList)
+	ret0, _ := ret[0].(*v11.EventList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/mock_k8swrapper.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/mock_k8swrapper.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	v10 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // MockK8sWrapper is a mock of K8sWrapper interface.
@@ -48,6 +49,20 @@ func NewMockK8sWrapper(ctrl *gomock.Controller) *MockK8sWrapper {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockK8sWrapper) EXPECT() *MockK8sWrapperMockRecorder {
 	return m.recorder
+}
+
+// AddLabelToManageNode mocks base method.
+func (m *MockK8sWrapper) AddLabelToManageNode(arg0 *v10.Node, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddLabelToManageNode", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddLabelToManageNode indicates an expected call of AddLabelToManageNode.
+func (mr *MockK8sWrapperMockRecorder) AddLabelToManageNode(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddLabelToManageNode", reflect.TypeOf((*MockK8sWrapper)(nil).AddLabelToManageNode), arg0, arg1, arg2)
 }
 
 // AdvertiseCapacityIfNotSet mocks base method.
@@ -149,6 +164,21 @@ func (m *MockK8sWrapper) GetNode(arg0 string) (*v10.Node, error) {
 func (mr *MockK8sWrapperMockRecorder) GetNode(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockK8sWrapper)(nil).GetNode), arg0)
+}
+
+// ListEvents mocks base method.
+func (m *MockK8sWrapper) ListEvents(arg0 []client.ListOption) (*v10.EventList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListEvents", arg0)
+	ret0, _ := ret[0].(*v10.EventList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListEvents indicates an expected call of ListEvents.
+func (mr *MockK8sWrapperMockRecorder) ListEvents(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEvents", reflect.TypeOf((*MockK8sWrapper)(nil).ListEvents), arg0)
 }
 
 // ListNodes mocks base method.

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -37,6 +37,8 @@ const (
 	HasTrunkAttachedLabel = "vpc.amazonaws.com/has-trunk-attached"
 	// CustomNetworkingLabel is the label with the name of ENIConfig to be used by the node for custom networking
 	CustomNetworkingLabel = "vpc.amazonaws.com/eniConfig"
+	BooleanTrue           = "true"
+	BooleanFalse          = "false"
 	// NodeLabelOS is the Kubernetes Operating System label
 	NodeLabelOS = "kubernetes.io/os"
 	// NodeLabelOS is the Kubernetes Operating System label used before k8s version 1.16

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -29,7 +29,7 @@ const (
 	ResourceNameIPAddress = VPCResourcePrefix + "PrivateIPv4Address"
 )
 
-// K8s Pod Labels
+// K8s Labels
 const (
 	// ControllerName is the name of the VPC Resource Controller
 	ControllerName = "vpc-resource-controller"
@@ -70,6 +70,17 @@ const (
 	KubeSystemNamespace            = "kube-system"
 	VpcCNIDaemonSetName            = "aws-node"
 	OldVPCControllerDeploymentName = "vpc-resource-controller"
+)
+
+// Events metadata
+// They are used to identify valid events emitted from authorized agents
+const (
+	VpcCNINodeEventReason             = "AwsNodeNotificationToRc"
+	VpcCNIReportingAgent              = "aws-node"
+	VpcCNINodeEventActionForTrunk     = "NeedTrunk"
+	VpcCNINodeEventActionForEniConfig = "NeedEniConfig"
+	TrunkNotAttached                  = "vpc.amazonaws.com/has-trunk-attached=false"
+	TrunkAttached                     = "vpc.amazonaws.com/has-trunk-attached=true"
 )
 
 var (

--- a/pkg/k8s/wrapper.go
+++ b/pkg/k8s/wrapper.go
@@ -21,9 +21,9 @@ import (
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/prometheus/client_golang/prometheus"
 
-	appV1 "k8s.io/api/apps/v1"
-	apiv1 "k8s.io/api/core/v1"
+	appv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -65,16 +65,16 @@ func prometheusRegister() {
 
 // K8sWrapper represents an interface with all the common operations on K8s objects
 type K8sWrapper interface {
-	GetDaemonSet(namespace, name string) (*appV1.DaemonSet, error)
+	GetDaemonSet(namespace, name string) (*appv1.DaemonSet, error)
 	GetNode(nodeName string) (*v1.Node, error)
 	AdvertiseCapacityIfNotSet(nodeName string, resourceName string, capacity int) error
 	GetENIConfig(eniConfigName string) (*v1alpha1.ENIConfig, error)
-	GetDeployment(namespace string, name string) (*appV1.Deployment, error)
+	GetDeployment(namespace string, name string) (*appv1.Deployment, error)
 	BroadcastEvent(obj runtime.Object, reason string, message string, eventType string)
 	GetConfigMap(configMapName string, configMapNamespace string) (*v1.ConfigMap, error)
 	ListNodes() (*v1.NodeList, error)
-	AddLabelToManageNode(node *v1.Node, labelKey string, labelValue string) error
-	ListEvents(ops []client.ListOption) (*apiv1.EventList, error)
+	AddLabelToManageNode(node *v1.Node, labelKey string, labelValue string) (bool, error)
+	ListEvents(ops []client.ListOption) (*eventsv1.EventList, error)
 }
 
 // k8sWrapper is the wrapper object with the client
@@ -100,8 +100,8 @@ func NewK8sWrapper(client client.Client, coreV1 corev1.CoreV1Interface, ctx cont
 	return &k8sWrapper{cacheClient: client, eventRecorder: recorder, context: ctx}
 }
 
-func (k *k8sWrapper) GetDaemonSet(name, namespace string) (*appV1.DaemonSet, error) {
-	ds := &appV1.DaemonSet{}
+func (k *k8sWrapper) GetDaemonSet(name, namespace string) (*appv1.DaemonSet, error) {
+	ds := &appv1.DaemonSet{}
 	err := k.cacheClient.Get(k.context, types.NamespacedName{
 		Namespace: namespace,
 		Name:      name,
@@ -109,8 +109,8 @@ func (k *k8sWrapper) GetDaemonSet(name, namespace string) (*appV1.DaemonSet, err
 	return ds, err
 }
 
-func (k *k8sWrapper) GetDeployment(namespace string, name string) (*appV1.Deployment, error) {
-	deployment := &appV1.Deployment{}
+func (k *k8sWrapper) GetDeployment(namespace string, name string) (*appv1.Deployment, error) {
+	deployment := &appv1.Deployment{}
 	err := k.cacheClient.Get(k.context, types.NamespacedName{
 		Namespace: namespace,
 		Name:      name,
@@ -188,18 +188,19 @@ func (k *k8sWrapper) ListNodes() (*v1.NodeList, error) {
 	return nodeList, err
 }
 
-func (k *k8sWrapper) AddLabelToManageNode(node *v1.Node, labelKey string, labelValue string) error {
+func (k *k8sWrapper) AddLabelToManageNode(node *v1.Node, labelKey string, labelValue string) (bool, error) {
 	if node.Labels[labelKey] == labelValue {
-		return nil
+		return false, nil
 	} else {
 		newNode := node.DeepCopy()
 		newNode.Labels[labelKey] = labelValue
-		return k.cacheClient.Status().Patch(k.context, newNode, client.MergeFrom(node))
+		err := k.cacheClient.Status().Patch(k.context, newNode, client.MergeFrom(node))
+		return err == nil, err
 	}
 }
 
-func (k *k8sWrapper) ListEvents(ops []client.ListOption) (*apiv1.EventList, error) {
-	events := &apiv1.EventList{}
+func (k *k8sWrapper) ListEvents(ops []client.ListOption) (*eventsv1.EventList, error) {
+	events := &eventsv1.EventList{}
 	if err := k.cacheClient.List(k.context, events, ops...); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We want to change how the controller knows to enable nodes with ENI trunking. The new strategy is VPC CNI broadcasting events and the controller consumes the events and then initialize network resources.
The workflow should be like 

1. user turns on the feature of Security Group for Pods
2. VPC CNI broadcasts event asking for trunk interface
3. the controller watches events and label nodes if events are valid
4. the controller initializes resources
5. VPC CNI finishes network setup on node

#### Tests
Since this change focus on how node gets initialized, we tested scale node to 1000 with the feature turned on.
Test Environment settings -> EKS v1.22, VPC CNI v1.11.4 or new version with the regarding changes on top of v1.11.4

Latest released controller v1.1.4
Scaling started at `Fri Nov 11 20:45:42 UTC 2022`
All nodes were Ready at `Fri Nov 11 20:47:53 UTC 2022`
All nodes were initialized with RNI trunking at `Fri Nov 11 20:58:08 UTC 2022`
Used time ~ 13 minutes

This change on top of v1.1.4
Scaling started at `Fri Nov 11 18:54:18 UTC 2022`
All nodes were Ready at `Fri Nov 11 18:57:32 UTC 2022`
All nodes were initialized with RNI trunking at `Fri Nov 11 19:07:15 UTC 2022`
Used time ~ 13 minutes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
