### PR TITLE
adding cache for event controller querying node instances

### DIFF
--- a/controllers/core/event_controller_test.go
+++ b/controllers/core/event_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/allegro/bigcache/v3"
 	mock_k8s "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/golang/mock/gomock"
@@ -36,7 +37,9 @@ import (
 var (
 	mockSGPEventName         = "node-sgp-event"
 	mockCNEventName          = "node-custom-networking-event"
-	mockEventNodeName        = "ip-0-0-0-0.us-west-2.compute.internal"
+	mockEventNodeNameOne     = "ip-0-0-0-1.us-west-2.compute.internal"
+	mockEventNodeNameTwo     = "ip-0-0-0-2.us-west-2.compute.internal"
+	mockEventNodeNameThree   = "ip-0-0-0-3.us-west-2.compute.internal"
 	sgpEventReconcileRequest = reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Name:      mockSGPEventName,
@@ -58,14 +61,15 @@ var (
 		},
 		Regarding: corev1.ObjectReference{
 			Kind: EventRegardingKind,
-			Name: mockEventNodeName,
+			Name: mockEventNodeNameOne,
+			UID:  types.UID("i-00000000000000001"),
 		},
 		ReportingController: config.VpcCNIReportingAgent,
 		Reason:              config.VpcCNINodeEventReason,
 		Note:                config.TrunkNotAttached,
 		Action:              config.VpcCNINodeEventActionForTrunk,
 	}
-	newSgpEvent = &eventsv1.Event{
+	newSgpEventOne = &eventsv1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              mockSGPEventName,
 			Namespace:         config.KubeSystemNamespace,
@@ -73,7 +77,24 @@ var (
 		},
 		Regarding: corev1.ObjectReference{
 			Kind: EventRegardingKind,
-			Name: mockEventNodeName,
+			Name: mockEventNodeNameTwo,
+			UID:  types.UID("i-00000000000000002"),
+		},
+		ReportingController: config.VpcCNIReportingAgent,
+		Reason:              config.VpcCNINodeEventReason,
+		Note:                config.TrunkNotAttached,
+		Action:              config.VpcCNINodeEventActionForTrunk,
+	}
+	newSgpEventTwo = &eventsv1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              mockSGPEventName,
+			Namespace:         config.KubeSystemNamespace,
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Minute * 1)},
+		},
+		Regarding: corev1.ObjectReference{
+			Kind: EventRegardingKind,
+			Name: mockEventNodeNameThree,
+			UID:  types.UID("i-00000000000000003"),
 		},
 		ReportingController: config.VpcCNIReportingAgent,
 		Reason:              config.VpcCNINodeEventReason,
@@ -88,14 +109,15 @@ var (
 		},
 		Regarding: corev1.ObjectReference{
 			Kind: EventRegardingKind,
-			Name: mockEventNodeName,
+			Name: mockEventNodeNameOne,
+			UID:  types.UID("i-00000000000000001"),
 		},
 		ReportingController: config.VpcCNIReportingAgent,
 		Reason:              config.VpcCNINodeEventReason,
 		Action:              config.VpcCNINodeEventActionForEniConfig,
 		Note:                config.CustomNetworkingLabel + "=testConfig",
 	}
-	newEniConfigEvent = &eventsv1.Event{
+	newEniConfigEventOne = &eventsv1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              mockCNEventName,
 			Namespace:         config.KubeSystemNamespace,
@@ -103,21 +125,33 @@ var (
 		},
 		Regarding: corev1.ObjectReference{
 			Kind: EventRegardingKind,
-			Name: mockEventNodeName,
+			Name: mockEventNodeNameTwo,
+			UID:  types.UID("i-00000000000000002"),
 		},
 		ReportingController: config.VpcCNIReportingAgent,
 		Reason:              config.VpcCNINodeEventReason,
 		Action:              config.VpcCNINodeEventActionForEniConfig,
 		Note:                config.CustomNetworkingLabel + "=testConfig",
 	}
-
-	eventNode = &corev1.Node{
-		TypeMeta: metav1.TypeMeta{},
+	newEniConfigEventTwo = &eventsv1.Event{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   mockEventNodeName,
-			Labels: map[string]string{config.NodeLabelOS: config.OSLinux, config.HasTrunkAttachedLabel: "true"},
+			Name:              mockCNEventName,
+			Namespace:         config.KubeSystemNamespace,
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Minute * 1)},
 		},
+		Regarding: corev1.ObjectReference{
+			Kind: EventRegardingKind,
+			Name: mockEventNodeNameThree,
+			UID:  types.UID("i-00000000000000003"),
+		},
+		ReportingController: config.VpcCNIReportingAgent,
+		Reason:              config.VpcCNINodeEventReason,
+		Action:              config.VpcCNINodeEventActionForEniConfig,
+		Note:                config.CustomNetworkingLabel + "=testConfig",
 	}
+	testCacheExpiry    = 2 * time.Second
+	testWaitCacheEvict = 3 * time.Second
+	testCacheMiss      = "Entry not found"
 )
 
 type EventMock struct {
@@ -129,12 +163,14 @@ func NewEventControllerMock(ctrl *gomock.Controller, mockObjects ...runtime.Obje
 	scheme := runtime.NewScheme()
 	_ = eventsv1.AddToScheme(scheme)
 	mockK8sAPI := mock_k8s.NewMockK8sWrapper(ctrl)
+	testCache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(testCacheExpiry))
 	return EventMock{
 		MockK8sAPI: mockK8sAPI,
 		Reconciler: EventReconciler{
 			Scheme: scheme,
 			Log:    zap.New(),
 			K8sAPI: mockK8sAPI,
+			cache:  testCache,
 		},
 	}
 }
@@ -144,6 +180,12 @@ func TestEventReconciler_Reconcile_SGPEvent(t *testing.T) {
 		eventList             *eventsv1.EventList
 		isValidEventForSGP    bool
 		successfullyLabelNode bool
+		testNodeName          string
+		testNodeKey           string
+		msg                   string
+		hitCache              bool
+		missCache             bool
+		evictCache            bool
 	}{
 		{
 			eventList: &eventsv1.EventList{
@@ -151,20 +193,90 @@ func TestEventReconciler_Reconcile_SGPEvent(t *testing.T) {
 			},
 			isValidEventForSGP:    false,
 			successfullyLabelNode: false,
+			testNodeName:          mockEventNodeNameOne,
+			testNodeKey:           string(oldSgpEvent.Regarding.UID),
+			msg:                   "SGP Cache Test: Expired event is not valid event",
+			hitCache:              false,
+			missCache:             true,
+			evictCache:            false,
 		},
 		{
 			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newSgpEvent),
+				Items: append([]eventsv1.Event{}, *newSgpEventOne),
 			},
 			isValidEventForSGP:    true,
 			successfullyLabelNode: true,
+			testNodeName:          mockEventNodeNameTwo,
+			testNodeKey:           string(newSgpEventOne.Regarding.UID),
+			msg:                   "SGP Cache Test: Valid event one, label node",
+			hitCache:              false,
+			missCache:             true,
+			evictCache:            false,
 		},
 		{
 			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newSgpEvent),
+				Items: append([]eventsv1.Event{}, *newSgpEventTwo),
 			},
 			isValidEventForSGP:    true,
 			successfullyLabelNode: false,
+			testNodeName:          mockEventNodeNameThree,
+			testNodeKey:           string(newSgpEventTwo.Regarding.UID),
+			msg:                   "SGP Cache Test: Valid event two, fail labelling node",
+			hitCache:              false,
+			missCache:             true,
+			evictCache:            false,
+		},
+		{
+			eventList: &eventsv1.EventList{
+				Items: append([]eventsv1.Event{}, *newSgpEventTwo),
+			},
+			isValidEventForSGP:    true,
+			successfullyLabelNode: true,
+			testNodeName:          mockEventNodeNameThree,
+			testNodeKey:           string(newSgpEventTwo.Regarding.UID),
+			msg:                   "SGP Cache Test: Valid event two, label node",
+			hitCache:              false,
+			missCache:             true,
+			evictCache:            false,
+		},
+		{
+			eventList: &eventsv1.EventList{
+				Items: append([]eventsv1.Event{}, *newSgpEventTwo),
+			},
+			isValidEventForSGP:    true,
+			successfullyLabelNode: true,
+			testNodeName:          mockEventNodeNameThree,
+			testNodeKey:           string(newSgpEventTwo.Regarding.UID),
+			msg:                   "SGP Cache Test: Valid event two, label node, cache hit",
+			hitCache:              true,
+			missCache:             false,
+			evictCache:            false,
+		},
+		{
+			eventList: &eventsv1.EventList{
+				Items: append([]eventsv1.Event{}, *newSgpEventTwo),
+			},
+			isValidEventForSGP:    true,
+			successfullyLabelNode: true,
+			testNodeName:          mockEventNodeNameThree,
+			testNodeKey:           string(newSgpEventTwo.Regarding.UID),
+			msg:                   "SGP Cache Test: Valid event, label node, cache expired and should be miss",
+			hitCache:              false,
+			missCache:             true,
+			evictCache:            true,
+		},
+		{
+			eventList: &eventsv1.EventList{
+				Items: append([]eventsv1.Event{}, *newSgpEventTwo),
+			},
+			isValidEventForSGP:    true,
+			successfullyLabelNode: true,
+			testNodeName:          mockEventNodeNameThree,
+			testNodeKey:           string(newSgpEventTwo.Regarding.UID),
+			msg:                   "SGP Cache Test: Valid event, label node, cache expired and should be miss",
+			hitCache:              false,
+			missCache:             true,
+			evictCache:            true,
 		},
 	}
 
@@ -179,34 +291,60 @@ func TestEventReconciler_Reconcile_SGPEvent(t *testing.T) {
 	}
 
 	for _, e := range events {
+		if e.evictCache {
+			time.Sleep(testCacheExpiry + testWaitCacheEvict)
+		}
 		mock.MockK8sAPI.EXPECT().ListEvents(ops).Return(e.eventList, nil)
 
+		_, cacheErr := mock.Reconciler.cache.Get(e.testNodeKey)
+
+		// the same instance was added already but waited for expiry + 1 second, we should see cache miss error
+		if e.missCache && e.evictCache && !e.hitCache {
+			assert.Error(t, cacheErr, e.msg)
+			assert.EqualError(t, cacheErr, testCacheMiss, e.msg)
+		} else if e.hitCache {
+			assert.NoError(t, cacheErr, e.msg)
+		} else if e.missCache && !e.evictCache {
+			assert.Error(t, cacheErr, e.msg)
+		}
+
 		if e.isValidEventForSGP {
-			// if the event is older, these func are not expected to be called.
-			mock.MockK8sAPI.EXPECT().GetNode(mockEventNodeName).Return(eventNode, nil).AnyTimes()
-			if e.successfullyLabelNode {
-				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.HasTrunkAttachedLabel, config.BooleanFalse).Return(true, nil)
+			eventNode := &corev1.Node{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   e.testNodeName,
+					Labels: map[string]string{config.NodeLabelOS: config.OSLinux},
+				},
+			}
+			mock.MockK8sAPI.EXPECT().GetNode(e.testNodeName).Return(eventNode, nil).AnyTimes()
+			if cacheErr == nil || e.successfullyLabelNode {
+				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.HasTrunkAttachedLabel, config.BooleanFalse).Return(true, nil).AnyTimes()
 			} else {
 				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.HasTrunkAttachedLabel, config.BooleanFalse).Return(false, errors.New("sgp-test"))
 			}
 		}
 		res, err := mock.Reconciler.Reconcile(context.TODO(), sgpEventReconcileRequest)
 
-		if e.successfullyLabelNode {
-			assert.NoError(t, err)
+		if cacheErr == nil || e.successfullyLabelNode {
+			assert.NoError(t, err, e.msg)
 		} else if e.isValidEventForSGP && !e.successfullyLabelNode {
-			assert.Error(t, err)
-			assert.EqualError(t, err, "sgp-test")
+			assert.Error(t, err, e.msg)
+			assert.EqualError(t, err, "sgp-test", e.msg)
+		} else if !e.isValidEventForSGP {
+			assert.NoError(t, err, e.msg)
 		} else {
-			assert.NoError(t, err)
+			assert.FailNow(t, "Unexpected test case, need to fail test as safeguard")
 		}
-		assert.Equal(t, res, reconcile.Result{})
+
+		assert.Equal(t, res, reconcile.Result{}, e.msg)
 	}
 }
 
 func TestEventReconciler_Reconcile_ENIConfigLabelNodeEvent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+	mock := NewEventControllerMock(ctrl)
+
 	ops := []client.ListOption{
 		client.MatchingFields{
 			EventFilterKey: config.VpcCNIReportingAgent,
@@ -217,6 +355,12 @@ func TestEventReconciler_Reconcile_ENIConfigLabelNodeEvent(t *testing.T) {
 		eventList                       *eventsv1.EventList
 		isValidEventForCustomNetworking bool
 		successfullyLabelNode           bool
+		testNodeName                    string
+		testNodeKey                     string
+		msg                             string
+		hitCache                        bool
+		missCache                       bool
+		evictCache                      bool
 	}{
 		{
 			eventList: &eventsv1.EventList{
@@ -224,32 +368,110 @@ func TestEventReconciler_Reconcile_ENIConfigLabelNodeEvent(t *testing.T) {
 			},
 			isValidEventForCustomNetworking: false,
 			successfullyLabelNode:           false,
+			testNodeName:                    mockEventNodeNameOne,
+			testNodeKey:                     string(oldEniConfigEvent.Regarding.UID),
+			msg:                             "Custom Networking Cache Test: Expired event is not valid event",
+			hitCache:                        false,
+			missCache:                       true,
+			evictCache:                      false,
 		},
 		{
 			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newEniConfigEvent),
+				Items: append([]eventsv1.Event{}, *newEniConfigEventOne),
 			},
 			isValidEventForCustomNetworking: true,
 			successfullyLabelNode:           true,
+			testNodeName:                    mockEventNodeNameTwo,
+			testNodeKey:                     string(newEniConfigEventOne.Regarding.UID),
+			msg:                             "Custom Networking Cache Test: Valid event one, label node",
+			hitCache:                        false,
+			missCache:                       true,
+			evictCache:                      false,
 		},
 		{
 			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newEniConfigEvent),
+				Items: append([]eventsv1.Event{}, *newEniConfigEventTwo),
 			},
 			isValidEventForCustomNetworking: true,
 			successfullyLabelNode:           false,
+			testNodeName:                    mockEventNodeNameThree,
+			testNodeKey:                     string(newEniConfigEventTwo.Regarding.UID),
+			msg:                             "Custom Networking Cache Test: Valid event two, fail labelling node",
+			hitCache:                        false,
+			missCache:                       true,
+			evictCache:                      false,
+		},
+		{
+			eventList: &eventsv1.EventList{
+				Items: append([]eventsv1.Event{}, *newEniConfigEventTwo),
+			},
+			isValidEventForCustomNetworking: true,
+			successfullyLabelNode:           true,
+			testNodeName:                    mockEventNodeNameThree,
+			testNodeKey:                     string(newEniConfigEventTwo.Regarding.UID),
+			msg:                             "Custom Networking Cache Test: Valid event two, label node",
+			hitCache:                        false,
+			missCache:                       true,
+			evictCache:                      false,
+		},
+		{
+			eventList: &eventsv1.EventList{
+				Items: append([]eventsv1.Event{}, *newEniConfigEventTwo),
+			},
+			isValidEventForCustomNetworking: true,
+			successfullyLabelNode:           true,
+			testNodeName:                    mockEventNodeNameThree,
+			testNodeKey:                     string(newEniConfigEventTwo.Regarding.UID),
+			msg:                             "Custom Networking Cache Test: Valid event two, label node, cache hit",
+			hitCache:                        true,
+			missCache:                       false,
+			evictCache:                      false,
+		},
+		{
+			eventList: &eventsv1.EventList{
+				Items: append([]eventsv1.Event{}, *newEniConfigEventTwo),
+			},
+			isValidEventForCustomNetworking: true,
+			successfullyLabelNode:           true,
+			testNodeName:                    mockEventNodeNameThree,
+			testNodeKey:                     string(newEniConfigEventTwo.Regarding.UID),
+			msg:                             "Custom Networking Cache Test: Valid event, label node, cache expired and should be miss",
+			hitCache:                        false,
+			missCache:                       true,
+			evictCache:                      true,
 		},
 	}
 
 	for _, e := range events {
-		mock := NewEventControllerMock(ctrl)
+		if e.evictCache {
+			time.Sleep(testCacheExpiry + testWaitCacheEvict)
+		}
 		mock.MockK8sAPI.EXPECT().ListEvents(ops).Return(e.eventList, nil)
+
+		_, cacheErr := mock.Reconciler.cache.Get(e.testNodeKey)
+
+		// the same instance was added already but waited for expiry + 1 second, we should see cache miss error
+		if e.missCache && e.evictCache && !e.hitCache {
+			assert.Error(t, cacheErr, e.msg)
+			assert.EqualError(t, cacheErr, testCacheMiss, e.msg)
+		} else if e.hitCache {
+			assert.NoError(t, cacheErr, e.msg)
+		} else if e.missCache && !e.evictCache {
+			assert.Error(t, cacheErr, e.msg)
+		}
 
 		if e.isValidEventForCustomNetworking {
 			// if the event is older, these func are not expected to be called.
-			mock.MockK8sAPI.EXPECT().GetNode(mockEventNodeName).Return(eventNode, nil)
-			if e.successfullyLabelNode {
-				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.CustomNetworkingLabel, "testConfig").Return(true, nil)
+			eventNode := &corev1.Node{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   e.testNodeName,
+					Labels: map[string]string{config.NodeLabelOS: config.OSLinux, config.HasTrunkAttachedLabel: "true"},
+				},
+			}
+			mock.MockK8sAPI.EXPECT().GetNode(e.testNodeName).Return(eventNode, nil).AnyTimes()
+			if cacheErr == nil || e.successfullyLabelNode {
+				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.CustomNetworkingLabel, "testConfig").Return(true, nil).AnyTimes()
 			} else {
 				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.CustomNetworkingLabel, "testConfig").Return(false, errors.New("custom-networking-test"))
 			}
@@ -257,13 +479,15 @@ func TestEventReconciler_Reconcile_ENIConfigLabelNodeEvent(t *testing.T) {
 
 		res, err := mock.Reconciler.Reconcile(context.TODO(), eniConfigEventReconcileRequest)
 
-		if e.successfullyLabelNode {
+		if cacheErr == nil || e.successfullyLabelNode {
 			assert.NoError(t, err)
 		} else if e.isValidEventForCustomNetworking && !e.successfullyLabelNode {
 			assert.Error(t, err)
 			assert.EqualError(t, err, "custom-networking-test")
+		} else if !e.isValidEventForCustomNetworking {
+			assert.NoError(t, err, e.msg)
 		} else {
-			assert.NoError(t, err)
+			assert.FailNow(t, "Unexpected test case, need to fail test as safeguard")
 		}
 		assert.Equal(t, res, reconcile.Result{})
 	}

--- a/controllers/core/node_controller.go
+++ b/controllers/core/node_controller.go
@@ -70,8 +70,10 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	if err := r.Client.Get(ctx, req.NamespacedName, node); err != nil {
 		if errors.IsNotFound(err) {
 			cachedNode, found := r.Manager.GetNode(req.Name)
-			// delete the not found node instance id from node event cache for housekeeping
-			r.deleteNodeFromNodeEventCache(cachedNode.GetNodeInstanceID())
+			if cachedNode != nil {
+				// delete the not found node instance id from node event cache for housekeeping
+				r.deleteNodeFromNodeEventCache(cachedNode.GetNodeInstanceID())
+			}
 			if found {
 				err := r.Manager.DeleteNode(req.Name)
 				if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aws/amazon-vpc-resource-controller-k8s
 go 1.16
 
 require (
+	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/aws/amazon-vpc-cni-k8s v1.9.0
 	github.com/aws/aws-sdk-go v1.40.43
 	github.com/go-logr/logr v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
+github.com/allegro/bigcache/v3 v3.1.0 h1:H2Vp8VOvxcrB91o86fUSVJFqeuz8kpyyB02eH3bSzwk=
+github.com/allegro/bigcache/v3 v3.1.0/go.mod h1:aPyh7jEvrog9zAwx5N7+JUQX5dZTSGpxF1LAR4dr35I=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/node/mock_node.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/node/mock_node.go
@@ -62,6 +62,20 @@ func (mr *MockNodeMockRecorder) DeleteResources(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResources", reflect.TypeOf((*MockNode)(nil).DeleteResources), arg0, arg1)
 }
 
+// GetNodeInstanceID mocks base method.
+func (m *MockNode) GetNodeInstanceID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeInstanceID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetNodeInstanceID indicates an expected call of GetNodeInstanceID.
+func (mr *MockNodeMockRecorder) GetNodeInstanceID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeInstanceID", reflect.TypeOf((*MockNode)(nil).GetNodeInstanceID))
+}
+
 // InitResources mocks base method.
 func (m *MockNode) InitResources(arg0 resource.ResourceManager, arg1 api.EC2APIHelper) error {
 	m.ctrl.T.Helper()

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -87,6 +87,13 @@ const (
 	TrunkAttached                     = "vpc.amazonaws.com/has-trunk-attached=true"
 )
 
+// customized configurations for BigCache
+const (
+	InstancesCacheTTL     = 30 * time.Minute // scaling < 1k nodes should be under 20 minutes
+	InstancesCacheShards  = 32               // must be power of 2
+	InstancesCacheMaxSize = 2                // in MB
+)
+
 var (
 	// CoolDownPeriod is the time to let kube-proxy propagates IP tables rules before assigning the resource back to new pod
 	CoolDownPeriod = time.Second * 30

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -57,6 +57,8 @@ type Node interface {
 	UpdateCustomNetworkingSpecs(subnetID string, securityGroup []string)
 	IsReady() bool
 	IsManaged() bool
+
+	GetNodeInstanceID() string
 }
 
 // NewManagedNode returns node managed by the controller
@@ -200,4 +202,11 @@ func (n *node) IsManaged() bool {
 	defer n.lock.RUnlock()
 
 	return n.managed
+}
+
+func (n *node) GetNodeInstanceID() string {
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+
+	return n.instance.InstanceID()
 }

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -18,10 +18,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2"
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/api"
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/provider"
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/resource"
+	mock_ec2 "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2"
+	mock_api "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/api"
+	mock_provider "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/provider"
+	mock_resource "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/resource"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider"
 
 	"github.com/golang/mock/gomock"
@@ -149,14 +149,14 @@ func TestNode_InitResources_SecondProviderInitFails(t *testing.T) {
 	mock.MockResourceManager.EXPECT().GetResourceProviders().Return(mock.ResourceProvider)
 
 	// Second provider throws an error
-	mock.MockProviders["0"].EXPECT().IsInstanceSupported(mock.MockInstance).Return(true)
-	mock.MockProviders["0"].EXPECT().InitResource(mock.MockInstance).Return(nil)
+	mock.MockProviders["0"].EXPECT().IsInstanceSupported(mock.MockInstance).Return(true).AnyTimes()
+	mock.MockProviders["0"].EXPECT().InitResource(mock.MockInstance).Return(nil).AnyTimes()
 
-	mock.MockProviders["1"].EXPECT().IsInstanceSupported(mock.MockInstance).Return(true)
-	mock.MockProviders["1"].EXPECT().InitResource(mock.MockInstance).Return(mockError)
+	mock.MockProviders["1"].EXPECT().IsInstanceSupported(mock.MockInstance).Return(true).AnyTimes()
+	mock.MockProviders["1"].EXPECT().InitResource(mock.MockInstance).Return(mockError).AnyTimes()
 
 	// Expect first provider to be de initialized
-	mock.MockProviders["0"].EXPECT().DeInitResource(mock.MockInstance).Return(nil)
+	mock.MockProviders["0"].EXPECT().DeInitResource(mock.MockInstance).Return(nil).AnyTimes()
 
 	err := mock.NodeWithMock.InitResources(mock.MockResourceManager, mock.MockEC2API)
 	assert.NotNil(t, err)


### PR DESCRIPTION
make change to use const for cache config

add prometheus metrics on cache ops

*Issue #, if available:*
N/A
*Description of changes:*
For larger clusters, events emitted can be very large volume. In order to maintain the event controller performance under large load situation, we should avoid calling k8s and the controller's APIs for already processed nodes although the clients are cached. 
I am adding a [BigCache](https://github.com/allegro/bigcache) which is a TTL cache with configuration as following

- sharding: 32
- max size: 2 MB
- TTL in minutes: 30

The change has been tested with Security Group for Pods with/without custom networking enabled.
By monitoring the added prometheus metrics around the cache ops, we can tell the difference from a 500 nodes cluster scaling its nodes from 0 to 500.
```
# TYPE event_reconcile_node_cache_operations counter
event_reconcile_node_cache_operations{cache_hit="",cache_miss="NODE_NOT_CACHED",cache_set_error=""} 1296
event_reconcile_node_cache_operations{cache_hit="NODE_CACHED",cache_miss="",cache_set_error=""} 1.0047677e+07
# HELP event_reconcile_node_cache_size Event controller node cache size
# TYPE event_reconcile_node_cache_size gauge
event_reconcile_node_cache_size 500
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
