### PR TITLE
support labeling node with not-supported for CNI managing events

### DIFF
--- a/controllers/core/event_controller.go
+++ b/controllers/core/event_controller.go
@@ -165,7 +165,9 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				return ctrl.Result{}, nil
 			} else {
 				if r.isEventToManageNode(event) && r.isValidEventForSGP(event) {
-					labelled, err := r.K8sAPI.AddLabelToManageNode(node, config.HasTrunkAttachedLabel, config.BooleanTrue)
+					// make the label value to false that indicates the node is ok to be proceeded by providers
+					// provider will decide if the node can be attached with trunk interface
+					labelled, err := r.K8sAPI.AddLabelToManageNode(node, config.HasTrunkAttachedLabel, config.BooleanFalse)
 					if err != nil {
 						// by returning an error, we request that our controller will get Reconcile() called again
 						// we use the GetNode() as a safeguard to avoid repeating reconciling on deleted nodes
@@ -174,7 +176,7 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 					}
 					if labelled {
 						eventControllerSGPEventsCount.WithLabelValues(SGPEventsCountMetrics).Inc()
-						r.Log.Info("Label node with trunk label as true", "Node", node.Name, "Label", config.HasTrunkAttachedLabel)
+						r.Log.V(1).Info("Label node with trunk label", "Node", node.Name, "Label", config.HasTrunkAttachedLabel)
 					}
 				}
 				if r.isValidEventForCustomNetworking(event) {
@@ -189,7 +191,7 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 						}
 						if labelled {
 							eventControllerCNEventsCount.WithLabelValues(CNEventsCountMetrics).Inc()
-							r.Log.Info("Label node with eniconfig label with configured name", "Node", node.Name, "Label", config.CustomNetworkingLabel)
+							r.Log.V(1).Info("Label node with eniconfig label with configured name", "Node", node.Name, "Label", config.CustomNetworkingLabel)
 						}
 					}
 				}

--- a/controllers/core/event_controller_test.go
+++ b/controllers/core/event_controller_test.go
@@ -185,9 +185,9 @@ func TestEventReconciler_Reconcile_SGPEvent(t *testing.T) {
 			// if the event is older, these func are not expected to be called.
 			mock.MockK8sAPI.EXPECT().GetNode(mockEventNodeName).Return(eventNode, nil).AnyTimes()
 			if e.successfullyLabelNode {
-				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.HasTrunkAttachedLabel, "true").Return(true, nil)
+				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.HasTrunkAttachedLabel, config.BooleanFalse).Return(true, nil)
 			} else {
-				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.HasTrunkAttachedLabel, "true").Return(false, errors.New("sgp-test"))
+				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.HasTrunkAttachedLabel, config.BooleanFalse).Return(false, errors.New("sgp-test"))
 			}
 		}
 		res, err := mock.Reconciler.Reconcile(context.TODO(), sgpEventReconcileRequest)

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -37,8 +37,10 @@ const (
 	HasTrunkAttachedLabel = "vpc.amazonaws.com/has-trunk-attached"
 	// CustomNetworkingLabel is the label with the name of ENIConfig to be used by the node for custom networking
 	CustomNetworkingLabel = "vpc.amazonaws.com/eniConfig"
-	BooleanTrue           = "true"
-	BooleanFalse          = "false"
+	// Trunk attaching status value
+	BooleanTrue         = "true"
+	BooleanFalse        = "false"
+	NotSupportedEc2Type = "not-supported"
 	// NodeLabelOS is the Kubernetes Operating System label
 	NodeLabelOS = "kubernetes.io/os"
 	// NodeLabelOS is the Kubernetes Operating System label used before k8s version 1.16

--- a/pkg/k8s/wrapper.go
+++ b/pkg/k8s/wrapper.go
@@ -24,7 +24,7 @@ import (
 	appv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
-  "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -464,19 +464,29 @@ func (b *branchENIProvider) IsInstanceSupported(instance ec2.EC2Instance) bool {
 	limits, found := vpc.Limits[instance.Type()]
 	supported := found && instance.Os() == config.OSLinux && limits.IsTrunkingCompatible
 
-	if !supported {
-		// since VPC CNI will not send events for nodes that are labelled as notsupported, this API will not be called too many times.
-		if node, err := b.apiWrapper.K8sAPI.GetNode(instance.Name()); err != nil {
-			b.log.Error(err, "couldn't get the node when checking if the node is supported for trunk interface", "NodeName", instance.Name())
-		} else {
-			if node.Labels != nil {
-				if _, ok := node.Labels[config.HasTrunkAttachedLabel]; ok {
-					updated, err := b.apiWrapper.K8sAPI.AddLabelToManageNode(node, config.HasTrunkAttachedLabel, config.NotSupportedEc2Type)
-					if !updated || err != nil {
-						b.log.Info("failed to update unsupported node label to non-supported", "NodeName", instance.Name(), "Error", err)
-					}
+	// 1, since VPC CNI will not send events for nodes that are labelled as not-supported
+	// 2, since VPC CNI will not keep sending events if nodes have been labelled as true and trunk has been attached
+	// here calling GetNode API will not cause large call volume
+	if node, err := b.apiWrapper.K8sAPI.GetNode(instance.Name()); err != nil {
+		b.log.Error(err, "couldn't get the node when checking if the node is supported for trunk interface", "NodeName", instance.Name())
+	} else {
+		if node.Labels != nil {
+			if _, ok := node.Labels[config.HasTrunkAttachedLabel]; ok {
+				labelValue := config.BooleanTrue
+				if !supported {
+					labelValue = config.NotSupportedEc2Type
+				}
+				updated, err := b.apiWrapper.K8sAPI.AddLabelToManageNode(node, config.HasTrunkAttachedLabel, labelValue)
+				if err != nil {
+					b.log.Error(err, "failed to update node label", "NodeName", instance.Name(), "LabelKey", config.HasTrunkAttachedLabel, "ExpectedLabelValue", labelValue)
+				} else if !updated {
+					b.log.V(1).Info("unable to update node with the existing label key/value pair", "NodeName", instance.Name(), "LabelKey", config.HasTrunkAttachedLabel, "ExpectedLabelValue", labelValue)
 				}
 			}
+		} else {
+			// at this point, the label map shouldn't be nil
+			// TODO: https://github.com/aws/amazon-vpc-resource-controller-k8s/issues/163
+			b.log.Error(err, "unexpected nil map for node labels", "NodeName", instance.Name())
 		}
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In order to let VPC CNI better manage event broadcasting, VPC resource controller should label unsupported nodes as `not-supported`. When VPC CNI finds this label value, CNI should stop sending events from these nodes.

Tests
logs from the controller
```
{"level":"info","timestamp":"2023-01-10T20:11:38.643Z","logger":"branch eni provider","msg":"failed to update unsupported node label to non-supported","NodeName":"ip-192-168-154-254.us-west-2.compute.internal","Error":null}
{"level":"info","timestamp":"2023-01-10T20:13:08.999Z","logger":"branch eni provider","msg":"failed to update unsupported node label to non-supported","NodeName":"ip-192-168-214-180.us-west-2.compute.internal","Error":null}
```

Nodes
```
      node.kubernetes.io/instance-type: c5.4xlarge
      vpc.amazonaws.com/has-trunk-attached: "true"
      node.kubernetes.io/instance-type: t3.medium
      vpc.amazonaws.com/has-trunk-attached: not-supported
      node.kubernetes.io/instance-type: c5.4xlarge
      vpc.amazonaws.com/has-trunk-attached: "true"
      node.kubernetes.io/instance-type: t3.medium
      vpc.amazonaws.com/has-trunk-attached: not-supported
      node.kubernetes.io/instance-type: c5.4xlarge
      vpc.amazonaws.com/has-trunk-attached: "true"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
