### PR TITLE
change boolean pointer to struct to sync DS status

### DIFF
--- a/controllers/core/node_controller.go
+++ b/controllers/core/node_controller.go
@@ -56,6 +56,7 @@ type NodeReconciler struct {
 // status accordingly
 func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	if !r.Conditions.GetPodDataStoreSyncStatus() {
+		// if pod cache is not ready, let's exponentially requeue the requests instead of letting routines wait
 		return ctrl.Result{Requeue: true}, goErr.New("pod datastore hasn't been synced, node controller need wait to retry")
 	}
 

--- a/controllers/core/node_controller.go
+++ b/controllers/core/node_controller.go
@@ -15,6 +15,7 @@ package controllers
 
 import (
 	"context"
+	goErr "errors"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/condition"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/node/manager"
@@ -54,7 +55,9 @@ type NodeReconciler struct {
 // from Un-Managed to Managed and vice-versa in which case the Node Manager updates it's
 // status accordingly
 func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Conditions.WaitTillPodDataStoreSynced()
+	if !r.Conditions.GetPodDataStoreSyncStatus() {
+		return ctrl.Result{Requeue: true}, goErr.New("pod datastore hasn't been synced, node controller need wait to retry")
+	}
 
 	node := &corev1.Node{}
 	var err error

--- a/controllers/core/node_controller_test.go
+++ b/controllers/core/node_controller_test.go
@@ -17,9 +17,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/condition"
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/node"
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/node/manager"
+	mock_condition "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/condition"
+	mock_node "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/node"
+	mock_manager "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/node/manager"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -81,7 +81,7 @@ func TestNodeReconciler_Reconcile_AddNode(t *testing.T) {
 
 	mock := NewNodeMock(ctrl, mockNodeObj)
 
-	mock.Conditions.EXPECT().WaitTillPodDataStoreSynced()
+	mock.Conditions.EXPECT().GetPodDataStoreSyncStatus().Return(true)
 	mock.Manager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, false)
 	mock.Manager.EXPECT().AddNode(mockNodeName).Return(nil)
 
@@ -96,7 +96,7 @@ func TestNodeReconciler_Reconcile_UpdateNode(t *testing.T) {
 
 	mock := NewNodeMock(ctrl, mockNodeObj)
 
-	mock.Conditions.EXPECT().WaitTillPodDataStoreSynced()
+	mock.Conditions.EXPECT().GetPodDataStoreSyncStatus().Return(true)
 	mock.Manager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, true)
 	mock.Manager.EXPECT().UpdateNode(mockNodeName).Return(nil)
 
@@ -111,7 +111,7 @@ func TestNodeReconciler_Reconcile_DeleteNode(t *testing.T) {
 
 	mock := NewNodeMock(ctrl)
 
-	mock.Conditions.EXPECT().WaitTillPodDataStoreSynced()
+	mock.Conditions.EXPECT().GetPodDataStoreSyncStatus().Return(true)
 	mock.Manager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, true)
 	mock.Manager.EXPECT().DeleteNode(mockNodeName).Return(nil)
 
@@ -126,7 +126,7 @@ func TestNodeReconciler_Reconcile_DeleteNonExistentNode(t *testing.T) {
 
 	mock := NewNodeMock(ctrl)
 
-	mock.Conditions.EXPECT().WaitTillPodDataStoreSynced()
+	mock.Conditions.EXPECT().GetPodDataStoreSyncStatus().Return(true)
 	mock.Manager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, false)
 
 	res, err := mock.Reconciler.Reconcile(context.TODO(), reconcileRequest)

--- a/controllers/core/pod_controller.go
+++ b/controllers/core/pod_controller.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/controllers/custom"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/condition"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/k8s"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/k8s/pod"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/node/manager"
@@ -42,8 +43,8 @@ type PodReconciler struct {
 	NodeManager manager.Manager
 	K8sAPI      k8s.K8sWrapper
 	// DataStore is the cache with memory optimized Pod Objects
-	DataStore       cache.Indexer
-	DataStoreSynced *bool
+	DataStore cache.Indexer
+	Condition condition.Conditions
 }
 
 var (
@@ -182,10 +183,9 @@ func (r *PodReconciler) SetupWithManager(ctx context.Context, manager ctrl.Manag
 		UsingConverter(&pod.PodConverter{
 			K8sResource:     "pods",
 			K8sResourceType: &v1.Pod{},
-		}).DataStoreSyncFlag(r.DataStoreSynced).
-		Options(custom.Options{
-			PageLimit:               pageLimit,
-			ResyncPeriod:            syncPeriod,
-			MaxConcurrentReconciles: MaxPodConcurrentReconciles,
-		}).Complete(r)
+		}).Options(custom.Options{
+		PageLimit:               pageLimit,
+		ResyncPeriod:            syncPeriod,
+		MaxConcurrentReconciles: MaxPodConcurrentReconciles,
+	}).UsingConditions(r.Condition).Complete(r)
 }

--- a/main.go
+++ b/main.go
@@ -276,8 +276,7 @@ func main() {
 	}
 
 	// hasPodDataStoreSynced is set to true when the custom controller has synced
-	var hasPodDataStoreSynced = new(bool)
-	controllerConditions := condition.NewControllerConditions(hasPodDataStoreSynced,
+	controllerConditions := condition.NewControllerConditions(
 		ctrl.Log.WithName("controller conditions"), k8sApi)
 
 	nodeManagerWorkers := asyncWorkers.NewDefaultWorkerPool("node async workers",
@@ -297,7 +296,7 @@ func main() {
 		NodeManager:     nodeManager,
 		K8sAPI:          k8sApi,
 		DataStore:       dataStore,
-		DataStoreSynced: hasPodDataStoreSynced,
+		Condition:       controllerConditions,
 	}).SetupWithManager(ctx, mgr, clientSet, listPageLimit, syncPeriod); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "pod")
 		os.Exit(1)

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/condition/mock_condition.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/condition/mock_condition.go
@@ -46,6 +46,20 @@ func (m *MockConditions) EXPECT() *MockConditionsMockRecorder {
 	return m.recorder
 }
 
+// GetPodDataStoreSyncStatus mocks base method.
+func (m *MockConditions) GetPodDataStoreSyncStatus() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPodDataStoreSyncStatus")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// GetPodDataStoreSyncStatus indicates an expected call of GetPodDataStoreSyncStatus.
+func (mr *MockConditionsMockRecorder) GetPodDataStoreSyncStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodDataStoreSyncStatus", reflect.TypeOf((*MockConditions)(nil).GetPodDataStoreSyncStatus))
+}
+
 // IsOldVPCControllerDeploymentPresent mocks base method.
 func (m *MockConditions) IsOldVPCControllerDeploymentPresent() bool {
 	m.ctrl.T.Helper()
@@ -74,14 +88,14 @@ func (mr *MockConditionsMockRecorder) IsWindowsIPAMEnabled() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWindowsIPAMEnabled", reflect.TypeOf((*MockConditions)(nil).IsWindowsIPAMEnabled))
 }
 
-// WaitTillPodDataStoreSynced mocks base method.
-func (m *MockConditions) WaitTillPodDataStoreSynced() {
+// SetPodDataStoreSyncStatus mocks base method.
+func (m *MockConditions) SetPodDataStoreSyncStatus(arg0 bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "WaitTillPodDataStoreSynced")
+	m.ctrl.Call(m, "SetPodDataStoreSyncStatus", arg0)
 }
 
-// WaitTillPodDataStoreSynced indicates an expected call of WaitTillPodDataStoreSynced.
-func (mr *MockConditionsMockRecorder) WaitTillPodDataStoreSynced() *gomock.Call {
+// SetPodDataStoreSyncStatus indicates an expected call of SetPodDataStoreSyncStatus.
+func (mr *MockConditionsMockRecorder) SetPodDataStoreSyncStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitTillPodDataStoreSynced", reflect.TypeOf((*MockConditions)(nil).WaitTillPodDataStoreSynced))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPodDataStoreSyncStatus", reflect.TypeOf((*MockConditions)(nil).SetPodDataStoreSyncStatus), arg0)
 }

--- a/pkg/condition/conditions_test.go
+++ b/pkg/condition/conditions_test.go
@@ -154,6 +154,14 @@ func TestCondition_IsWindowsIPAMEnabled(t *testing.T) {
 	}
 }
 
+// TestCondition_GetPodDataStoreSyncStatus tests two group of routines which are setting (write) the sync flag field
+// and are getting (read) the field.
+// In real case, pod controller routines keep checking the cache status and set the sync field to true if cache is ready.
+// At the same time, node controller routines keep asking if the pod cache is ready by Getting the status.
+// Until pod cache is ready, node controllers won't make any process but requeue coming requests exponenially
+// To simulate the case, the test cases create a routine as writer (pod routine) and routines as reader (node routines)
+// to request the lock on the field. By using these tests, we can preliminarily test the possibility of lock issue or
+// racing by safeguarding a processing time window.
 func TestCondition_GetPodDataStoreSyncStatus(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/pkg/condition/conditions_test.go
+++ b/pkg/condition/conditions_test.go
@@ -14,10 +14,13 @@
 package condition
 
 import (
+	"fmt"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s"
+	mock_k8s "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 
 	"github.com/golang/mock/gomock"
@@ -47,33 +50,6 @@ var (
 		},
 	}
 )
-
-func Test_WaitTillPodDataStoreSynced(t *testing.T) {
-	syncVariable := new(bool)
-	c := condition{
-		log:                zap.New(zap.UseDevMode(true)),
-		hasDataStoreSynced: syncVariable,
-	}
-
-	var hasSynced bool
-	go func() {
-		c.WaitTillPodDataStoreSynced()
-		hasSynced = true
-	}()
-
-	time.Sleep(CheckDataStoreSyncedInterval * 2)
-	// If hasSynced is True then the function didn't wait for the
-	// cache to be synced
-	assert.False(t, hasSynced)
-
-	// Set the variable so the previous go routine stops
-	// and next call to the function doesn't block the test
-	*syncVariable = true
-
-	// If the code was buggy, this execution would block and
-	// timeout the test
-	c.WaitTillPodDataStoreSynced()
-}
 
 func TestCondition_IsWindowsIPAMEnabled(t *testing.T) {
 	tests := []struct {
@@ -169,11 +145,97 @@ func TestCondition_IsWindowsIPAMEnabled(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockK8s := mock_k8s.NewMockK8sWrapper(ctrl)
-			conditions := NewControllerConditions(nil, zap.New(), mockK8s)
+			conditions := NewControllerConditions(zap.New(), mockK8s)
 
 			test.mock(mockK8s)
 
 			assert.Equal(t, conditions.IsWindowsIPAMEnabled(), test.expected)
+		})
+	}
+}
+
+func TestCondition_GetPodDataStoreSyncStatus(t *testing.T) {
+	tests := []struct {
+		name            string
+		testBlockedTime int
+		// buffer time is used to consider other execution time during the process
+		testBufferTime int
+		workers        int
+	}{
+		{
+			name:            "worker doesn't wait long enough",
+			testBlockedTime: 5,
+			testBufferTime:  -1,
+			workers:         1,
+		},
+		{
+			name:            "worker waits with a buffer time",
+			testBlockedTime: 5,
+			testBufferTime:  1,
+			workers:         1,
+		},
+		{
+			name:            "three workers check on the flag",
+			testBlockedTime: 5,
+			testBufferTime:  1,
+			workers:         3,
+		},
+		{
+			name:            "large number workers check on the flag",
+			testBlockedTime: 5,
+			testBufferTime:  1,
+			workers:         30, // we want to use an unusual large workers to test routines conflict
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockK8s := mock_k8s.NewMockK8sWrapper(ctrl)
+			conditions := NewControllerConditions(zap.New(), mockK8s)
+			start := time.Now()
+
+			// one routine is keeping the flag as false for 5s and then updates it to true
+			go func() {
+				waitFor := 0
+				for waitFor < test.testBlockedTime {
+					time.Sleep(time.Second * 1)
+					conditions.SetPodDataStoreSyncStatus(false)
+					waitFor++
+				}
+				conditions.SetPodDataStoreSyncStatus(true)
+			}()
+
+			var wg sync.WaitGroup
+			wg.Add(test.workers)
+
+			for i := 0; i < test.workers; i++ {
+				go func(id int) {
+					defer wg.Done()
+					worker := "worker-" + strconv.Itoa(id)
+					var synced bool
+					// this routine is checking if the flag is updated and how long the process took
+					// the processing time should be very small longer than required waiting time, otherwise fail the test
+					for {
+						synced = conditions.GetPodDataStoreSyncStatus()
+						if synced {
+							duration := int(time.Since(start).Seconds())
+							if test.testBufferTime >= 0 {
+								assert.GreaterOrEqual(t, test.testBlockedTime+test.testBufferTime, duration, fmt.Sprintf("worker %s Get the cache flag. Set and Get pod cache synced flag were not blocked", worker))
+							} else {
+								assert.GreaterOrEqual(t, duration, test.testBlockedTime+test.testBufferTime, fmt.Sprintf("worker %s didn't wait long enough, routines are not blocked", worker))
+							}
+							break
+						} else {
+							time.Sleep(time.Second * 1)
+						}
+					}
+				}(i)
+			}
+
+			wg.Wait()
 		})
 	}
 }

--- a/pkg/k8s/wrapper.go
+++ b/pkg/k8s/wrapper.go
@@ -24,7 +24,7 @@ import (
 	appv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
-  "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
*Issue #, if available:*
#117 
*Description of changes:*
In the PR, we are making these changes
1. In stead of use a pointer of boolean type, we are changing to use a pointer of struct with its flag as the cache sync indicator
2. in stead of making worker routine wait for cache sync, we are let them routine a retry for reconcile and retry exponentially 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
