### PR TITLE
fix a bug when cache for two features

### DIFF
--- a/pkg/provider/branch/trunk/trunk.go
+++ b/pkg/provider/branch/trunk/trunk.go
@@ -157,7 +157,7 @@ func PrometheusRegister() {
 // to EC2 API
 func (t *trunkENI) InitTrunk(instance ec2.EC2Instance, podList []v1.Pod) error {
 	instanceID := t.instance.InstanceID()
-	log := t.log.WithValues("request", "initialize", "instance ID", instance)
+	log := t.log.WithValues("request", "initialize", "instance ID", instanceID)
 
 	nwInterfaces, err := t.ec2ApiHelper.GetInstanceNetworkInterface(&instanceID)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This bug was found during tests enabling custom networking. The cache entry's value is incorrectly initialized and updated. Instead of updating the feature value purely based on coming event, we need to update the value based on coming event and the already cached value for another feature flag. 

For example
If SGP value has been cached, in cache --> "instance-id": {1, 0}
when the custom networking event comes, the update should be 
- new entry value {0, 0}
- update the new entry based on CN feature {0, 1}
- update the new entry based on existing cache entry {1, 0} to {1, 1}
- save the entry {1, 1} into cache


This PR also adds a prometheus metrics for cache add, and fix a typo in previous code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
