### PR TITLE
only set label to true when node is successfully initialized

### DIFF
--- a/controllers/core/event_controller.go
+++ b/controllers/core/event_controller.go
@@ -232,7 +232,7 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			} else {
 				eventControllerEventNodeCacheOpsCount.WithLabelValues([]string{"", CacheMissMetricsValue, ""}...).Inc()
 				eventControllerEventNodeCacheSize.Set(float64(r.cache.Len()))
-				if r.isEventToManageNode(event) && eventForSGP {
+				if eventForSGP {
 					// make the label value to false that indicates the node is ok to be proceeded by providers
 					// provider will decide if the node can be attached with trunk interface
 					labelled, err := r.K8sAPI.AddLabelToManageNode(node, config.HasTrunkAttachedLabel, config.BooleanFalse)
@@ -290,10 +290,6 @@ func (r *EventReconciler) isValidEventForSGP(event eventsv1.Event) bool {
 func (r *EventReconciler) isValidEventForCustomNetworking(event eventsv1.Event) bool {
 	return event.ReportingController == config.VpcCNIReportingAgent &&
 		event.Reason == config.VpcCNINodeEventReason && event.Action == config.VpcCNINodeEventActionForEniConfig
-}
-
-func (r *EventReconciler) isEventToManageNode(event eventsv1.Event) bool {
-	return event.Note == config.TrunkNotAttached || event.Note == config.TrunkAttached
 }
 
 func (r *EventReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -306,7 +306,7 @@ func (m *manager) performAsyncOperation(job interface{}) (ctrl.Result, error) {
 		if err != nil {
 			log.Error(err, "removing the node from cache as it failed to initialize")
 			m.removeNodeSafe(asyncJob.nodeName)
-			// if nitializing node failed, we want to make this visible although the manager will retry
+			// if initializing node failed, we want to make this visible although the manager will retry
 			// the trunk label will stay as false until retry succeed
 
 			// Node will be retried for init on next event

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -309,6 +309,13 @@ func (m *manager) performAsyncOperation(job interface{}) (ctrl.Result, error) {
 			// Node will be retried for init on next event
 			return ctrl.Result{}, nil
 		}
+
+		// node was successfully initialized, we need to update trunk label value to True
+		// this is the only place that the controller set the label to true
+		if err := m.updateNodeTrunkLabel(asyncJob.nodeName, config.HasTrunkAttachedLabel, config.BooleanTrue); err != nil {
+			m.Log.Error(err, "updating node trunk label to true failed", "NodeName", asyncJob.nodeName)
+		}
+
 		// If there's no error, we need to update the node so the capacity is advertised
 		asyncJob.op = Update
 		return m.performAsyncOperation(asyncJob)
@@ -396,4 +403,17 @@ func (m *manager) removeNodeSafe(nodeName string) {
 	defer m.lock.Unlock()
 
 	delete(m.dataStore, nodeName)
+}
+
+func (m *manager) updateNodeTrunkLabel(nodeName, labelKey, labelValue string) error {
+	if node, err := m.wrapper.K8sAPI.GetNode(nodeName); err != nil {
+		return err
+	} else {
+		// initializing node failed, we want to make this visible although the manager will retry
+		updated, err := m.wrapper.K8sAPI.AddLabelToManageNode(node, labelKey, labelValue)
+		if !updated {
+			m.Log.Info("failed updating the node label for trunk when operating on node", "NodeName", nodeName, "LabelKey", labelKey, "LabelValue", labelValue)
+		}
+		return err
+	}
 }

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -306,6 +306,9 @@ func (m *manager) performAsyncOperation(job interface{}) (ctrl.Result, error) {
 		if err != nil {
 			log.Error(err, "removing the node from cache as it failed to initialize")
 			m.removeNodeSafe(asyncJob.nodeName)
+			// if nitializing node failed, we want to make this visible although the manager will retry
+			// the trunk label will stay as false until retry succeed
+
 			// Node will be retried for init on next event
 			return ctrl.Result{}, nil
 		}
@@ -409,7 +412,6 @@ func (m *manager) updateNodeTrunkLabel(nodeName, labelKey, labelValue string) er
 	if node, err := m.wrapper.K8sAPI.GetNode(nodeName); err != nil {
 		return err
 	} else {
-		// initializing node failed, we want to make this visible although the manager will retry
 		updated, err := m.wrapper.K8sAPI.AddLabelToManageNode(node, labelKey, labelValue)
 		if !updated {
 			m.Log.Info("failed updating the node label for trunk when operating on node", "NodeName", nodeName, "LabelKey", labelKey, "LabelValue", labelValue)

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -427,6 +427,8 @@ func Test_performAsyncOperation(t *testing.T) {
 	}
 
 	job.op = Init
+	mock.MockK8sAPI.EXPECT().GetNode(nodeName).Return(v1Node, nil)
+	mock.MockK8sAPI.EXPECT().AddLabelToManageNode(v1Node, config.HasTrunkAttachedLabel, config.BooleanTrue).Return(true, nil).AnyTimes()
 	mock.MockNode.EXPECT().InitResources(mock.MockResourceManager, mock.MockEC2API).Return(nil)
 	mock.MockNode.EXPECT().UpdateResources(mock.MockResourceManager, mock.MockEC2API).Return(nil)
 	_, err := mock.Manager.performAsyncOperation(job)

--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -472,15 +472,14 @@ func (b *branchENIProvider) IsInstanceSupported(instance ec2.EC2Instance) bool {
 	} else {
 		if node.Labels != nil {
 			if _, ok := node.Labels[config.HasTrunkAttachedLabel]; ok {
-				labelValue := config.BooleanTrue
 				if !supported {
-					labelValue = config.NotSupportedEc2Type
-				}
-				updated, err := b.apiWrapper.K8sAPI.AddLabelToManageNode(node, config.HasTrunkAttachedLabel, labelValue)
-				if err != nil {
-					b.log.Error(err, "failed to update node label", "NodeName", instance.Name(), "LabelKey", config.HasTrunkAttachedLabel, "ExpectedLabelValue", labelValue)
-				} else if !updated {
-					b.log.V(1).Info("unable to update node with the existing label key/value pair", "NodeName", instance.Name(), "LabelKey", config.HasTrunkAttachedLabel, "ExpectedLabelValue", labelValue)
+					labelValue := config.NotSupportedEc2Type
+					updated, err := b.apiWrapper.K8sAPI.AddLabelToManageNode(node, config.HasTrunkAttachedLabel, labelValue)
+					if err != nil {
+						b.log.Error(err, "failed to update node label", "NodeName", instance.Name(), "LabelKey", config.HasTrunkAttachedLabel, "ExpectedLabelValue", labelValue)
+					} else if !updated {
+						b.log.V(1).Info("unable to update node with the existing label key/value pair", "NodeName", instance.Name(), "LabelKey", config.HasTrunkAttachedLabel, "ExpectedLabelValue", labelValue)
+					}
 				}
 			}
 		} else {

--- a/pkg/provider/branch/provider_test.go
+++ b/pkg/provider/branch/provider_test.go
@@ -318,6 +318,34 @@ func TestBranchENIProvider_NotSupported_LabelNode(t *testing.T) {
 	assert.False(t, supported)
 }
 
+func TestBranchENIProvider_Supported_LabelNode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	provider, mockK8sWrapper := getProviderAndMockK8sWrapper(ctrl)
+	mockInstance := mock_ec2.NewMockEC2Instance(ctrl)
+
+	supportedInstanceType := "c5.large"
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   NodeName,
+			Labels: map[string]string{config.HasTrunkAttachedLabel: config.BooleanFalse},
+		},
+	}
+
+	mockInstance.EXPECT().Name().Return(NodeName)
+	mockInstance.EXPECT().Os().Return("linux")
+	mockInstance.EXPECT().Type().Return(supportedInstanceType)
+	mockK8sWrapper.EXPECT().GetNode(NodeName).Return(node, nil)
+	// not calling the label method if the instance is supported
+	mockK8sWrapper.EXPECT().AddLabelToManageNode(node, gomock.Any(), gomock.Any()).Return(true, nil).Times(0)
+
+	supported := provider.IsInstanceSupported(mockInstance)
+	assert.True(t, supported)
+	// not updating the label if the instance is supported
+	assert.True(t, node.Labels[config.HasTrunkAttachedLabel] == config.BooleanFalse)
+}
+
 // TestBranchENIProvider_CreateAndAnnotateResources tests that create is invoked equal to the number of resources to
 // be created
 func TestBranchENIProvider_CreateAndAnnotateResources(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The controller shouldn't set the trunk label to true before nodes are initialized. 

Changes:
- in `IsInstanceSupported`, only set non-supported if the node is not supported
- in manager, set the label to true only when the node is successfully initialized
- in event controller, remove the redundant trunk event check


Tests
After injecting an error in node init, the labels stay on `false`
```
(23-01-30 1:54:09) <0> [~]  
% k get no -oyaml | grep -e trunk -e eniConfig
      vpc.amazonaws.com/eniConfig: us-west-2a
      vpc.amazonaws.com/eniConfig: us-west-2a
      vpc.amazonaws.com/has-trunk-attached: "false"
      vpc.amazonaws.com/eniConfig: us-west-2a
      vpc.amazonaws.com/has-trunk-attached: "false"
      vpc.amazonaws.com/eniConfig: us-west-2b
      vpc.amazonaws.com/has-trunk-attached: "false"
```
after more than 15 minutes
```
(23-01-30 2:11:32) <0> [~]  
% k get no -oyaml | grep -e trunk -e eniConfig
      vpc.amazonaws.com/eniConfig: us-west-2a
      vpc.amazonaws.com/eniConfig: us-west-2a
      vpc.amazonaws.com/has-trunk-attached: "false"
      vpc.amazonaws.com/eniConfig: us-west-2a
      vpc.amazonaws.com/has-trunk-attached: "false"
      vpc.amazonaws.com/eniConfig: us-west-2b
      vpc.amazonaws.com/has-trunk-attached: "false"
```
After switching to the build from this PR
```
(23-01-30 2:17:30) <0> [~]  
% k get no -oyaml | grep -e trunk -e eniConfig
      vpc.amazonaws.com/eniConfig: us-west-2a
      vpc.amazonaws.com/eniConfig: us-west-2a
      vpc.amazonaws.com/has-trunk-attached: "true"
      vpc.amazonaws.com/eniConfig: us-west-2a
      vpc.amazonaws.com/has-trunk-attached: "true"
      vpc.amazonaws.com/eniConfig: us-west-2b
      vpc.amazonaws.com/has-trunk-attached: "true"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
