### PR TITLE
use GET API to retrieve event

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN GIT_VERSION=$(git describe --tags --always) && \
         CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
         -ldflags="-X ${VERSION_PKG}.GitVersion=${GIT_VERSION} -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" -a -o controller main.go
 
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2021-09-22-1632348472
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest.2
 
 WORKDIR /
 COPY --from=public.ecr.aws/eks-distro/kubernetes/go-runner:v0.9.0-eks-1-21-4 /usr/local/bin/go-runner /usr/local/bin/go-runner

--- a/controllers/core/event_controller.go
+++ b/controllers/core/event_controller.go
@@ -203,7 +203,6 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		cacheValue := []byte{0, 0}
 
 		// use cache to avoid unnecessary calls to API server/ClientCache and node controller cache
-		// due to using List, the redundant call number can be large
 		if hitValue, cacheErr := r.cache.Get(hostID); cacheErr == nil {
 			if (eventForSGP && hitValue[EnableSGP] == 1) || (eventForCN && hitValue[EnableCN] == 1) {
 				eventControllerEventNodeCacheOpsCount.WithLabelValues([]string{CacheHitMetricsValue, "", "", ""}...).Inc()

--- a/controllers/core/node_controller.go
+++ b/controllers/core/node_controller.go
@@ -70,10 +70,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	if err := r.Client.Get(ctx, req.NamespacedName, node); err != nil {
 		if errors.IsNotFound(err) {
 			cachedNode, found := r.Manager.GetNode(req.Name)
-			// TODO: we need investigate if we should initialize instance for unmanaged node as well
-			// only operate on managed node because unmanaged node has no instance initialized
-			// operating on them will lead to nil pointer dereference
-			if cachedNode != nil && cachedNode.IsManaged() {
+			if cachedNode != nil && cachedNode.HasInstance() {
 				// delete the not found node instance id from node event cache for housekeeping
 				r.deleteNodeFromNodeEventCache(cachedNode.GetNodeInstanceID())
 			}

--- a/controllers/core/node_controller.go
+++ b/controllers/core/node_controller.go
@@ -70,7 +70,10 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	if err := r.Client.Get(ctx, req.NamespacedName, node); err != nil {
 		if errors.IsNotFound(err) {
 			cachedNode, found := r.Manager.GetNode(req.Name)
-			if cachedNode != nil {
+			// TODO: we need investigate if we should initialize instance for unmanaged node as well
+			// only operate on managed node because unmanaged node has no instance initialized
+			// operating on them will lead to nil pointer dereference
+			if cachedNode != nil && cachedNode.IsManaged() {
 				// delete the not found node instance id from node event cache for housekeeping
 				r.deleteNodeFromNodeEventCache(cachedNode.GetNodeInstanceID())
 			}

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -205,6 +206,11 @@ func main() {
 			&appsv1.DaemonSet{}: {Field: fields.Set{
 				"metadata.name":      config.VpcCNIDaemonSetName,
 				"metadata.namespace": config.KubeSystemNamespace,
+			}.AsSelector(),
+			},
+			&eventsv1.Event{}: {Field: fields.Set{
+				"reason":              config.VpcCNINodeEventReason,
+				"reportingController": config.VpcCNIReportingAgent,
 			}.AsSelector(),
 			},
 		},

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/mock_k8swrapper.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/mock_k8swrapper.go
@@ -26,7 +26,7 @@ import (
 	v10 "k8s.io/api/core/v1"
 	v11 "k8s.io/api/events/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	client "sigs.k8s.io/controller-runtime/pkg/client"
+	types "k8s.io/apimachinery/pkg/types"
 )
 
 // MockK8sWrapper is a mock of K8sWrapper interface.
@@ -153,6 +153,21 @@ func (mr *MockK8sWrapperMockRecorder) GetENIConfig(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetENIConfig", reflect.TypeOf((*MockK8sWrapper)(nil).GetENIConfig), arg0)
 }
 
+// GetEvent mocks base method.
+func (m *MockK8sWrapper) GetEvent(arg0 types.NamespacedName) (*v11.Event, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEvent", arg0)
+	ret0, _ := ret[0].(*v11.Event)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEvent indicates an expected call of GetEvent.
+func (mr *MockK8sWrapperMockRecorder) GetEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEvent", reflect.TypeOf((*MockK8sWrapper)(nil).GetEvent), arg0)
+}
+
 // GetNode mocks base method.
 func (m *MockK8sWrapper) GetNode(arg0 string) (*v10.Node, error) {
 	m.ctrl.T.Helper()
@@ -166,21 +181,6 @@ func (m *MockK8sWrapper) GetNode(arg0 string) (*v10.Node, error) {
 func (mr *MockK8sWrapperMockRecorder) GetNode(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockK8sWrapper)(nil).GetNode), arg0)
-}
-
-// ListEvents mocks base method.
-func (m *MockK8sWrapper) ListEvents(arg0 []client.ListOption) (*v11.EventList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEvents", arg0)
-	ret0, _ := ret[0].(*v11.EventList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListEvents indicates an expected call of ListEvents.
-func (mr *MockK8sWrapperMockRecorder) ListEvents(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEvents", reflect.TypeOf((*MockK8sWrapper)(nil).ListEvents), arg0)
 }
 
 // ListNodes mocks base method.

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/node/mock_node.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/node/mock_node.go
@@ -76,6 +76,20 @@ func (mr *MockNodeMockRecorder) GetNodeInstanceID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeInstanceID", reflect.TypeOf((*MockNode)(nil).GetNodeInstanceID))
 }
 
+// HasInstance mocks base method.
+func (m *MockNode) HasInstance() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasInstance")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasInstance indicates an expected call of HasInstance.
+func (mr *MockNodeMockRecorder) HasInstance() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasInstance", reflect.TypeOf((*MockNode)(nil).HasInstance))
+}
+
 // InitResources mocks base method.
 func (m *MockNode) InitResources(arg0 resource.ResourceManager, arg1 api.EC2APIHelper) error {
 	m.ctrl.T.Helper()

--- a/pkg/k8s/wrapper.go
+++ b/pkg/k8s/wrapper.go
@@ -76,7 +76,7 @@ type K8sWrapper interface {
 	GetConfigMap(configMapName string, configMapNamespace string) (*v1.ConfigMap, error)
 	ListNodes() (*v1.NodeList, error)
 	AddLabelToManageNode(node *v1.Node, labelKey string, labelValue string) (bool, error)
-	ListEvents(ops []client.ListOption) (*eventsv1.EventList, error)
+	GetEvent(namespacedName types.NamespacedName) (*eventsv1.Event, error)
 }
 
 // k8sWrapper is the wrapper object with the client
@@ -213,10 +213,9 @@ func (k *k8sWrapper) AddLabelToManageNode(node *v1.Node, labelKey string, labelV
 	}
 }
 
-func (k *k8sWrapper) ListEvents(ops []client.ListOption) (*eventsv1.EventList, error) {
-	events := &eventsv1.EventList{}
-	if err := k.cacheClient.List(k.context, events, ops...); err != nil {
-		return nil, err
-	}
-	return events, nil
+func (k *k8sWrapper) GetEvent(namespacedName types.NamespacedName) (*eventsv1.Event, error) {
+	event := &eventsv1.Event{}
+	err := k.cacheClient.Get(k.context, namespacedName, event)
+
+	return event, err
 }

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -143,7 +143,8 @@ func (m *manager) AddNode(nodeName string) error {
 		log.Info("node added as a managed node")
 		op = Init
 	} else {
-		newNode = node.NewUnManagedNode()
+		newNode = node.NewUnManagedNode(m.Log, k8sNode.Name, GetNodeInstanceID(k8sNode),
+			GetNodeOS(k8sNode))
 		m.dataStore[k8sNode.Name] = newNode
 		log.V(1).Info("node added as an un-managed node")
 		return nil
@@ -197,7 +198,8 @@ func (m *manager) UpdateNode(nodeName string) error {
 		log.Info("node was being managed earlier, will be added as un-managed node now")
 		// Change the node in cache, but for de initializing all resource providers
 		// pass the async job the older cached value instead
-		m.dataStore[nodeName] = node.NewUnManagedNode()
+		m.dataStore[nodeName] = node.NewUnManagedNode(m.Log, k8sNode.Name,
+			GetNodeInstanceID(k8sNode), GetNodeOS(k8sNode))
 		op = Delete
 	case StillManaged:
 		// We only need to update the Subnet for Managed Node. This subnet is required for creating

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -69,7 +69,7 @@ var (
 	}
 	mockError = fmt.Errorf("mock error")
 
-	unManagedNode = node.NewUnManagedNode()
+	unManagedNode = node.NewUnManagedNode(zap.New(), nodeName, instanceID, config.OSLinux)
 	managedNode   = node.NewManagedNode(zap.New(), nodeName, instanceID, config.OSLinux)
 )
 
@@ -94,7 +94,7 @@ func (m *AsyncJobMatcher) String() string {
 
 func AreNodesEqual(expected node.Node, actual node.Node) bool {
 	return expected.IsManaged() == actual.IsManaged() &&
-		expected.IsReady() == actual.IsReady()
+		expected.IsReady() == actual.IsReady() && expected.GetNodeInstanceID() == actual.GetNodeInstanceID()
 }
 
 type Mock struct {
@@ -567,4 +567,11 @@ func Test_UpdateNode_Windows_UnManagedToManaged(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, mock.Manager.dataStore, nodeName)
 	assert.True(t, AreNodesEqual(mock.Manager.dataStore[nodeName], managedNode))
+}
+
+func Test_Node_HasInstance(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	assert.True(t, managedNode.HasInstance(), "managed node should have instance")
+	assert.True(t, unManagedNode.HasInstance(), "unmanaged node should have instance")
 }

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -32,9 +32,11 @@ import (
 )
 
 var (
-	nodeName  = "node-name"
-	mockError = fmt.Errorf("mock error")
-	mockNode  = v1.Node{
+	nodeName   = "node-name"
+	instanceID = "i-00000000001"
+	linux      = "linux"
+	mockError  = fmt.Errorf("mock error")
+	mockNode   = v1.Node{
 		ObjectMeta: metaV1.ObjectMeta{
 			Name: nodeName,
 		},
@@ -75,20 +77,22 @@ func NewMock(ctrl *gomock.Controller, mockProviderCount int) Mocks {
 
 // TestNewManagedNode tests the new node is not nil and node is managed but not ready
 func TestNewManagedNode(t *testing.T) {
-	node := NewManagedNode(zap.New(), nodeName, "", "")
+	node := NewManagedNode(zap.New(), nodeName, instanceID, linux)
 
 	assert.NotNil(t, node)
+	assert.True(t, node.GetNodeInstanceID() == instanceID)
 	assert.True(t, node.IsManaged())
 	assert.False(t, node.IsReady())
 }
 
 // TestNewUnManagedNode tests the new node is not nil and node is not managed
 func TestNewUnManagedNode(t *testing.T) {
-	node := NewUnManagedNode()
+	node := NewUnManagedNode(zap.New(), nodeName, instanceID, linux)
 
 	assert.NotNil(t, node)
 	assert.False(t, node.IsManaged())
 	assert.False(t, node.IsReady())
+	assert.True(t, node.GetNodeInstanceID() == instanceID)
 }
 
 // TestNode_InitResources tests the instance details is loaded and the node is initialized without error


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
LIST API causes large MEM and CPU usage. GET API use less MEM and much better CPU utilization.

Changes

1. changing from LIST to GET in event controller
2, update base image to latest
3, a bug when calling removing instance id from cache but the node is unmanaged

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
