### PR TITLE
remove lock from caller to avoid reclaim locks

### DIFF
--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -396,9 +396,6 @@ func (b *branchENIProvider) CreateAndAnnotateResources(podNamespace string, podN
 }
 
 func (b *branchENIProvider) DeleteBranchUsedByPods(nodeName string, UID string) (ctrl.Result, error) {
-	b.lock.RLock()
-	defer b.lock.RUnlock()
-
 	trunkENI, isPresent := b.getTrunkFromCache(nodeName)
 	if !isPresent {
 		return ctrl.Result{}, fmt.Errorf("failed to find trunk ENI on the node %s", nodeName)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The controller shouldn't reclaim locks since the two methods from the caller already acquire locks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
