### PR TITLE
Add more filters to bring down memory usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN GIT_VERSION=$(git describe --tags --always) && \
         CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
         -ldflags="-X ${VERSION_PKG}.GitVersion=${GIT_VERSION} -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" -a -o controller main.go
 
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2021-09-22-1632348472
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest.2
 
 WORKDIR /
 COPY --from=public.ecr.aws/eks-distro/kubernetes/go-runner:v0.9.0-eks-1-21-4 /usr/local/bin/go-runner /usr/local/bin/go-runner

--- a/controllers/core/event_controller_test.go
+++ b/controllers/core/event_controller_test.go
@@ -289,7 +289,7 @@ func TestEventReconciler_Reconcile_SGPEvent(t *testing.T) {
 	mock := NewEventControllerMock(ctrl)
 	ops := []client.ListOption{
 		client.MatchingFields{
-			EventFilterKey: config.VpcCNIReportingAgent,
+			EventFilterKey: config.VpcCNINodeEventReason,
 		},
 	}
 
@@ -350,7 +350,7 @@ func TestEventReconciler_Reconcile_ENIConfigLabelNodeEvent(t *testing.T) {
 
 	ops := []client.ListOption{
 		client.MatchingFields{
-			EventFilterKey: config.VpcCNIReportingAgent,
+			EventFilterKey: config.VpcCNINodeEventReason,
 		},
 	}
 
@@ -503,7 +503,7 @@ func TestEventReconciler_Reconcile_DualEvents(t *testing.T) {
 	mock := NewEventControllerMock(ctrl)
 	ops := []client.ListOption{
 		client.MatchingFields{
-			EventFilterKey: config.VpcCNIReportingAgent,
+			EventFilterKey: config.VpcCNINodeEventReason,
 		},
 	}
 
@@ -544,7 +544,7 @@ func TestEventReconciler_Reconcile_DualEventsCacheStatus(t *testing.T) {
 
 	ops := []client.ListOption{
 		client.MatchingFields{
-			EventFilterKey: config.VpcCNIReportingAgent,
+			EventFilterKey: config.VpcCNINodeEventReason,
 		},
 	}
 

--- a/controllers/core/node_controller.go
+++ b/controllers/core/node_controller.go
@@ -70,7 +70,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	if err := r.Client.Get(ctx, req.NamespacedName, node); err != nil {
 		if errors.IsNotFound(err) {
 			cachedNode, found := r.Manager.GetNode(req.Name)
-			if cachedNode != nil {
+			if cachedNode != nil && cachedNode.HasInstance() {
 				// delete the not found node instance id from node event cache for housekeeping
 				r.deleteNodeFromNodeEventCache(cachedNode.GetNodeInstanceID())
 			}

--- a/controllers/core/node_controller_test.go
+++ b/controllers/core/node_controller_test.go
@@ -117,6 +117,7 @@ func TestNodeReconciler_Reconcile_DeleteNode(t *testing.T) {
 	mock.Manager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, true)
 	mock.MockNode.EXPECT().GetNodeInstanceID().Return("i-00000000000000001")
 	mock.Manager.EXPECT().DeleteNode(mockNodeName).Return(nil)
+	mock.MockNode.EXPECT().HasInstance().Return(true).Times(1)
 
 	res, err := mock.Reconciler.Reconcile(context.TODO(), reconcileRequest)
 	assert.NoError(t, err)
@@ -132,6 +133,40 @@ func TestNodeReconciler_Reconcile_DeleteNonExistentNode(t *testing.T) {
 	mock.Conditions.EXPECT().GetPodDataStoreSyncStatus().Return(true)
 	mock.Manager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, false)
 	mock.MockNode.EXPECT().GetNodeInstanceID().Return("i-00000000000000001")
+	mock.MockNode.EXPECT().HasInstance().Return(true).Times(1)
+
+	res, err := mock.Reconciler.Reconcile(context.TODO(), reconcileRequest)
+	assert.NoError(t, err)
+	assert.Equal(t, res, reconcile.Result{})
+}
+
+func TestNodeReconciler_Reconcile_DeleteNonExistentUnmanagedNode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := NewNodeMock(ctrl)
+
+	mock.Conditions.EXPECT().GetPodDataStoreSyncStatus().Return(true)
+	mock.Manager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, false)
+	mock.MockNode.EXPECT().GetNodeInstanceID().Return("i-00000000000000001").Times(1)
+	mock.MockNode.EXPECT().HasInstance().Return(true).Times(1)
+
+	res, err := mock.Reconciler.Reconcile(context.TODO(), reconcileRequest)
+	assert.NoError(t, err)
+	assert.Equal(t, res, reconcile.Result{})
+}
+
+func TestNodeReconciler_Reconcile_DeleteNonExistentUnmanagedWithoutInstanceNode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := NewNodeMock(ctrl)
+
+	mock.Conditions.EXPECT().GetPodDataStoreSyncStatus().Return(true)
+	mock.Manager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, false)
+	// if instance failed to be initialized for node, the GetInstanceID shouldn't be called to avoid dereference on nil pointer
+	mock.MockNode.EXPECT().GetNodeInstanceID().Return("i-00000000000000001").Times(0)
+	mock.MockNode.EXPECT().HasInstance().Return(false).Times(1)
 
 	res, err := mock.Reconciler.Reconcile(context.TODO(), reconcileRequest)
 	assert.NoError(t, err)

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -191,7 +192,7 @@ func main() {
 	renewDeadline := time.Second * time.Duration(leaderLeaseRenewDeadline)
 	retryPeriod := time.Second * time.Duration(leaderLeaseRetryPeriod)
 
-	// filter cache to subscribe to events from specific configmaps
+	// filter cache to subscribe to events from specific resources
 	newCache := cache.BuilderWithOptions(cache.Options{
 		SelectorsByObject: cache.SelectorsByObject{
 			&corev1.ConfigMap{}: {Field: fields.Set{
@@ -205,6 +206,11 @@ func main() {
 			&appsv1.DaemonSet{}: {Field: fields.Set{
 				"metadata.name":      config.VpcCNIDaemonSetName,
 				"metadata.namespace": config.KubeSystemNamespace,
+			}.AsSelector(),
+			},
+			&eventsv1.Event{}: {Field: fields.Set{
+				"reason":              config.VpcCNINodeEventReason,
+				"reportingController": config.VpcCNIReportingAgent,
 			}.AsSelector(),
 			},
 		},

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/node/mock_node.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/node/mock_node.go
@@ -76,6 +76,20 @@ func (mr *MockNodeMockRecorder) GetNodeInstanceID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeInstanceID", reflect.TypeOf((*MockNode)(nil).GetNodeInstanceID))
 }
 
+// HasInstance mocks base method.
+func (m *MockNode) HasInstance() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasInstance")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasInstance indicates an expected call of HasInstance.
+func (mr *MockNodeMockRecorder) HasInstance() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasInstance", reflect.TypeOf((*MockNode)(nil).HasInstance))
+}
+
 // InitResources mocks base method.
 func (m *MockNode) InitResources(arg0 resource.ResourceManager, arg1 api.EC2APIHelper) error {
 	m.ctrl.T.Helper()

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -143,7 +143,8 @@ func (m *manager) AddNode(nodeName string) error {
 		log.Info("node added as a managed node")
 		op = Init
 	} else {
-		newNode = node.NewUnManagedNode()
+		newNode = node.NewUnManagedNode(m.Log, k8sNode.Name, GetNodeInstanceID(k8sNode),
+			GetNodeOS(k8sNode))
 		m.dataStore[k8sNode.Name] = newNode
 		log.V(1).Info("node added as an un-managed node")
 		return nil
@@ -197,7 +198,8 @@ func (m *manager) UpdateNode(nodeName string) error {
 		log.Info("node was being managed earlier, will be added as un-managed node now")
 		// Change the node in cache, but for de initializing all resource providers
 		// pass the async job the older cached value instead
-		m.dataStore[nodeName] = node.NewUnManagedNode()
+		m.dataStore[nodeName] = node.NewUnManagedNode(m.Log, k8sNode.Name,
+			GetNodeInstanceID(k8sNode), GetNodeOS(k8sNode))
 		op = Delete
 	case StillManaged:
 		// We only need to update the Subnet for Managed Node. This subnet is required for creating

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -69,7 +69,7 @@ var (
 	}
 	mockError = fmt.Errorf("mock error")
 
-	unManagedNode = node.NewUnManagedNode()
+	unManagedNode = node.NewUnManagedNode(zap.New(), nodeName, instanceID, config.OSLinux)
 	managedNode   = node.NewManagedNode(zap.New(), nodeName, instanceID, config.OSLinux)
 )
 
@@ -94,7 +94,7 @@ func (m *AsyncJobMatcher) String() string {
 
 func AreNodesEqual(expected node.Node, actual node.Node) bool {
 	return expected.IsManaged() == actual.IsManaged() &&
-		expected.IsReady() == actual.IsReady()
+		expected.IsReady() == actual.IsReady() && expected.GetNodeInstanceID() == actual.GetNodeInstanceID()
 }
 
 type Mock struct {
@@ -567,4 +567,11 @@ func Test_UpdateNode_Windows_UnManagedToManaged(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, mock.Manager.dataStore, nodeName)
 	assert.True(t, AreNodesEqual(mock.Manager.dataStore[nodeName], managedNode))
+}
+
+func Test_Node_HasInstance(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	assert.True(t, managedNode.HasInstance(), "managed node should have instance")
+	assert.True(t, unManagedNode.HasInstance(), "unmanaged node should have instance")
 }

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -32,9 +32,11 @@ import (
 )
 
 var (
-	nodeName  = "node-name"
-	mockError = fmt.Errorf("mock error")
-	mockNode  = v1.Node{
+	nodeName   = "node-name"
+	instanceID = "i-00000000001"
+	linux      = "linux"
+	mockError  = fmt.Errorf("mock error")
+	mockNode   = v1.Node{
 		ObjectMeta: metaV1.ObjectMeta{
 			Name: nodeName,
 		},
@@ -75,20 +77,22 @@ func NewMock(ctrl *gomock.Controller, mockProviderCount int) Mocks {
 
 // TestNewManagedNode tests the new node is not nil and node is managed but not ready
 func TestNewManagedNode(t *testing.T) {
-	node := NewManagedNode(zap.New(), nodeName, "", "")
+	node := NewManagedNode(zap.New(), nodeName, instanceID, linux)
 
 	assert.NotNil(t, node)
+	assert.True(t, node.GetNodeInstanceID() == instanceID)
 	assert.True(t, node.IsManaged())
 	assert.False(t, node.IsReady())
 }
 
 // TestNewUnManagedNode tests the new node is not nil and node is not managed
 func TestNewUnManagedNode(t *testing.T) {
-	node := NewUnManagedNode()
+	node := NewUnManagedNode(zap.New(), nodeName, instanceID, linux)
 
 	assert.NotNil(t, node)
 	assert.False(t, node.IsManaged())
 	assert.False(t, node.IsReady())
+	assert.True(t, node.GetNodeInstanceID() == instanceID)
 }
 
 // TestNode_InitResources tests the instance details is loaded and the node is initialized without error


### PR DESCRIPTION
initialize unmanaged node as well

update base image to latest

*Issue #, if available:*

*Description of changes:*
In the PR, I am proposing three changes

1. using more specific filters/conditions in manager resource cache for events, event controller setup with manager. This can help avoid cache/watch too many events which can cause high memory/cpu utilization in some case.
2. initializing unmanaged nodes as well to avoid dereference nil pointer when calling those nodes' fields
3. updating base image to gain latest patches

Tests have been done for 

1. Integration tests for webhook, SGP feature, and Windows
2. Scaling tests have been done with 3k to 10k pods in a cluster having 400 - 1k nodes
3. Stress tests have been done with flooding events into the cluster every second
4. API call volume have been verified

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
