### PR TITLE
refactor to use self managed retrywatcher

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -59,10 +59,7 @@ rules:
   resources:
   - events
   verbs:
-  - create
-  - list
-  - patch
-  - update
+  - get
   - watch
 - apiGroups:
   - vpcresources.k8s.aws

--- a/controllers/core/event_controller_test.go
+++ b/controllers/core/event_controller_test.go
@@ -16,54 +16,69 @@ package controllers
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+
+	// "errors"
 	"testing"
 	"time"
 
-	"github.com/allegro/bigcache/v3"
+	bigcache "github.com/allegro/bigcache/v3"
 	mock_k8s "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
+
+	// "github.com/stretchr/testify/assert"
 	eventsv1 "k8s.io/api/events/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	goWatch "k8s.io/client-go/tools/watch"
+
+	// "sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	corev1 "k8s.io/api/core/v1"
+
+	// eventsv1 "k8s.io/api/events/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	// "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var (
-	mockSGPEventName         = "node-sgp-event"
-	mockCNEventName          = "node-custom-networking-event"
-	mockEventNodeNameOne     = "ip-0-0-0-1.us-west-2.compute.internal"
-	mockEventNodeNameTwo     = "ip-0-0-0-2.us-west-2.compute.internal"
-	mockEventNodeNameThree   = "ip-0-0-0-3.us-west-2.compute.internal"
-	mockInstanceIdOne        = "i-00000000000000001"
-	mockInstanceIdTwo        = "i-00000000000000002"
-	mockInstanceIdThree      = "i-00000000000000003"
-	sgpEventReconcileRequest = reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Name:      mockSGPEventName,
-			Namespace: config.KubeSystemNamespace,
-		},
-	}
-	eniConfigEventReconcileRequest = reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Name:      mockCNEventName,
-			Namespace: config.KubeSystemNamespace,
-		},
+	mockSGPPodEventName    = "aws-node-sgp-event"
+	mockCNEventName        = "node-custom-networking-event"
+	mockEventNodeNameOne   = "ip-0-0-0-1.us-west-2.compute.internal"
+	mockEventNodeNameTwo   = "ip-0-0-0-2.us-west-2.compute.internal"
+	mockEventNodeNameThree = "ip-0-0-0-3.us-west-2.compute.internal"
+	mockInstanceIdOne      = "i-00000000000000001"
+	mockInstanceIdTwo      = "i-00000000000000002"
+	mockInstanceIdThree    = "i-00000000000000003"
+	EventRegardingKind     = "Node"
+	EventRelatedKind       = "Pod"
+
+	namespacedName = types.NamespacedName{
+		Name:      mockSGPPodEventName,
+		Namespace: config.KubeSystemNamespace,
 	}
 
 	oldSgpEvent = &eventsv1.Event{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              mockSGPEventName,
+			Name:              mockSGPPodEventName,
 			Namespace:         config.KubeSystemNamespace,
 			CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Minute * 3)},
 		},
 		Regarding: corev1.ObjectReference{
 			Kind: EventRegardingKind,
+			Name: mockSGPPodEventName,
+		},
+		Related: &corev1.ObjectReference{
+			Kind: EventRelatedKind,
 			Name: mockEventNodeNameOne,
 			UID:  types.UID(mockInstanceIdOne),
 		},
@@ -74,12 +89,16 @@ var (
 	}
 	newSgpEventOne = &eventsv1.Event{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              mockSGPEventName,
+			Name:              mockSGPPodEventName,
 			Namespace:         config.KubeSystemNamespace,
-			CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Minute * 1)},
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-30 * time.Second)},
 		},
 		Regarding: corev1.ObjectReference{
 			Kind: EventRegardingKind,
+			Name: mockSGPPodEventName,
+		},
+		Related: &corev1.ObjectReference{
+			Kind: EventRelatedKind,
 			Name: mockEventNodeNameTwo,
 			UID:  types.UID(mockInstanceIdTwo),
 		},
@@ -90,12 +109,16 @@ var (
 	}
 	newSgpEventTwo = &eventsv1.Event{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              mockSGPEventName,
+			Name:              mockSGPPodEventName,
 			Namespace:         config.KubeSystemNamespace,
-			CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Minute * 1)},
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-30 * time.Second)},
 		},
 		Regarding: corev1.ObjectReference{
 			Kind: EventRegardingKind,
+			Name: mockSGPPodEventName,
+		},
+		Related: &corev1.ObjectReference{
+			Kind: EventRelatedKind,
 			Name: mockEventNodeNameThree,
 			UID:  types.UID(mockInstanceIdThree),
 		},
@@ -112,6 +135,10 @@ var (
 		},
 		Regarding: corev1.ObjectReference{
 			Kind: EventRegardingKind,
+			Name: mockSGPPodEventName,
+		},
+		Related: &corev1.ObjectReference{
+			Kind: EventRelatedKind,
 			Name: mockEventNodeNameOne,
 			UID:  types.UID(mockInstanceIdOne),
 		},
@@ -124,10 +151,14 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              mockCNEventName,
 			Namespace:         config.KubeSystemNamespace,
-			CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Minute * 1)},
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-30 * time.Second)},
 		},
 		Regarding: corev1.ObjectReference{
 			Kind: EventRegardingKind,
+			Name: mockSGPPodEventName,
+		},
+		Related: &corev1.ObjectReference{
+			Kind: EventRelatedKind,
 			Name: mockEventNodeNameTwo,
 			UID:  types.UID(mockInstanceIdTwo),
 		},
@@ -140,10 +171,14 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              mockCNEventName,
 			Namespace:         config.KubeSystemNamespace,
-			CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Minute * 1)},
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-30 * time.Second)},
 		},
 		Regarding: corev1.ObjectReference{
 			Kind: EventRegardingKind,
+			Name: mockSGPPodEventName,
+		},
+		Related: &corev1.ObjectReference{
+			Kind: EventRelatedKind,
 			Name: mockEventNodeNameThree,
 			UID:  types.UID(mockInstanceIdThree),
 		},
@@ -157,9 +192,213 @@ var (
 	testCacheMiss      = "Entry not found"
 )
 
+type TestSGPEvent struct {
+	event                 *eventsv1.Event
+	namespacedName        types.NamespacedName
+	isValidEventForSGP    bool
+	successfullyLabelNode bool
+	testNodeName          string
+	testNodeKey           string
+	msg                   string
+	hitCache              bool
+	missCache             bool
+	evictCache            bool
+	rv                    string
+}
+
+type TestCNEvent struct {
+	event                           *eventsv1.Event
+	namespacedName                  types.NamespacedName
+	isValidEventForCustomNetworking bool
+	successfullyLabelNode           bool
+	testNodeName                    string
+	testNodeKey                     string
+	msg                             string
+	hitCache                        bool
+	missCache                       bool
+	evictCache                      bool
+}
+
+type TestNode struct {
+	node     *corev1.Node
+	sgpEvent bool
+	cnEvent  bool
+	labelled bool
+	msg      string
+}
+
+var sgpEvents = []TestSGPEvent{
+	{
+		event:                 oldSgpEvent,
+		namespacedName:        namespacedName,
+		isValidEventForSGP:    true,
+		successfullyLabelNode: true,
+		testNodeName:          mockEventNodeNameOne,
+		testNodeKey:           string(oldSgpEvent.Related.UID),
+		msg:                   "SGP Cache Test: old event should still work",
+		hitCache:              false,
+		missCache:             true,
+		evictCache:            false,
+		rv:                    "1",
+	},
+	{
+		event:                 newSgpEventOne,
+		namespacedName:        namespacedName,
+		isValidEventForSGP:    true,
+		successfullyLabelNode: true,
+		testNodeName:          mockEventNodeNameTwo,
+		testNodeKey:           string(newSgpEventOne.Related.UID),
+		msg:                   "SGP Cache Test: Valid event one, label node",
+		hitCache:              false,
+		missCache:             true,
+		evictCache:            false,
+		rv:                    "2",
+	},
+	{
+		event:                 newSgpEventTwo,
+		namespacedName:        namespacedName,
+		isValidEventForSGP:    true,
+		successfullyLabelNode: false,
+		testNodeName:          mockEventNodeNameThree,
+		testNodeKey:           string(newSgpEventTwo.Related.UID),
+		msg:                   "SGP Cache Test: Valid event two, fail labelling node",
+		hitCache:              false,
+		missCache:             true,
+		evictCache:            false,
+		rv:                    "3",
+	},
+	{
+		event:                 newSgpEventTwo,
+		namespacedName:        namespacedName,
+		isValidEventForSGP:    true,
+		successfullyLabelNode: true,
+		testNodeName:          mockEventNodeNameThree,
+		testNodeKey:           string(newSgpEventTwo.Related.UID),
+		msg:                   "SGP Cache Test: Valid event two, label node",
+		hitCache:              false,
+		missCache:             true,
+		evictCache:            false,
+		rv:                    "4",
+	},
+	{
+		event:                 newSgpEventTwo,
+		namespacedName:        namespacedName,
+		isValidEventForSGP:    true,
+		successfullyLabelNode: true,
+		testNodeName:          mockEventNodeNameThree,
+		testNodeKey:           string(newSgpEventTwo.Related.UID),
+		msg:                   "SGP Cache Test: Valid event two, label node, cache hit",
+		hitCache:              true,
+		missCache:             false,
+		evictCache:            false,
+		rv:                    "5",
+	},
+	{
+		event:                 newSgpEventTwo,
+		namespacedName:        namespacedName,
+		isValidEventForSGP:    true,
+		successfullyLabelNode: true,
+		testNodeName:          mockEventNodeNameThree,
+		testNodeKey:           string(newSgpEventTwo.Related.UID),
+		msg:                   "SGP Cache Test: Valid event, label node, cache expired and should be miss",
+		hitCache:              false,
+		missCache:             true,
+		evictCache:            true,
+		rv:                    "6",
+	},
+	{
+		event:                 newSgpEventTwo,
+		namespacedName:        namespacedName,
+		isValidEventForSGP:    true,
+		successfullyLabelNode: true,
+		testNodeName:          mockEventNodeNameThree,
+		testNodeKey:           string(newSgpEventTwo.Related.UID),
+		msg:                   "SGP Cache Test: Valid event, label node, cache expired and should be miss",
+		hitCache:              false,
+		missCache:             true,
+		evictCache:            true,
+		rv:                    "7",
+	},
+}
+
+var cnEvents = []TestCNEvent{
+	{
+		event:                           oldEniConfigEvent,
+		namespacedName:                  namespacedName,
+		isValidEventForCustomNetworking: true,
+		successfullyLabelNode:           false,
+		testNodeName:                    mockEventNodeNameOne,
+		testNodeKey:                     string(oldEniConfigEvent.Related.UID),
+		msg:                             "Custom Networking Cache Test: old event is ok for processEvent method",
+		hitCache:                        false,
+		missCache:                       true,
+		evictCache:                      false,
+	},
+	{
+		event:                           newEniConfigEventOne,
+		namespacedName:                  namespacedName,
+		isValidEventForCustomNetworking: true,
+		successfullyLabelNode:           true,
+		testNodeName:                    mockEventNodeNameTwo,
+		testNodeKey:                     string(newEniConfigEventOne.Related.UID),
+		msg:                             "Custom Networking Cache Test: Valid event one, label node",
+		hitCache:                        false,
+		missCache:                       true,
+		evictCache:                      false,
+	},
+	{
+		event:                           newEniConfigEventTwo,
+		namespacedName:                  namespacedName,
+		isValidEventForCustomNetworking: true,
+		successfullyLabelNode:           false,
+		testNodeName:                    mockEventNodeNameThree,
+		testNodeKey:                     string(newEniConfigEventTwo.Related.UID),
+		msg:                             "Custom Networking Cache Test: Valid event two, fail labelling node",
+		hitCache:                        false,
+		missCache:                       true,
+		evictCache:                      false,
+	},
+	{
+		event:                           newEniConfigEventTwo,
+		namespacedName:                  namespacedName,
+		isValidEventForCustomNetworking: true,
+		successfullyLabelNode:           true,
+		testNodeName:                    mockEventNodeNameThree,
+		testNodeKey:                     string(newEniConfigEventTwo.Related.UID),
+		msg:                             "Custom Networking Cache Test: Valid event two, label node",
+		hitCache:                        false,
+		missCache:                       true,
+		evictCache:                      false,
+	},
+	{
+		event:                           newEniConfigEventTwo,
+		namespacedName:                  namespacedName,
+		isValidEventForCustomNetworking: true,
+		successfullyLabelNode:           true,
+		testNodeName:                    mockEventNodeNameThree,
+		testNodeKey:                     string(newEniConfigEventTwo.Related.UID),
+		msg:                             "Custom Networking Cache Test: Valid event two, label node, cache hit",
+		hitCache:                        true,
+		missCache:                       false,
+		evictCache:                      false,
+	},
+	{
+		event:                           newEniConfigEventTwo,
+		namespacedName:                  namespacedName,
+		isValidEventForCustomNetworking: true,
+		successfullyLabelNode:           true,
+		testNodeName:                    mockEventNodeNameThree,
+		testNodeKey:                     string(newEniConfigEventTwo.Related.UID),
+		msg:                             "Custom Networking Cache Test: Valid event, label node, cache expired and should be miss",
+		hitCache:                        false,
+		missCache:                       true,
+		evictCache:                      true,
+	},
+}
+
 type EventMock struct {
 	MockK8sAPI *mock_k8s.MockK8sWrapper
-	Reconciler EventReconciler
+	Controller WatchedEventController
 }
 
 func NewEventControllerMock(ctrl *gomock.Controller, mockObjects ...runtime.Object) EventMock {
@@ -169,137 +408,210 @@ func NewEventControllerMock(ctrl *gomock.Controller, mockObjects ...runtime.Obje
 	testCache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(testCacheExpiry))
 	return EventMock{
 		MockK8sAPI: mockK8sAPI,
-		Reconciler: EventReconciler{
-			Scheme: scheme,
-			Log:    zap.New(),
-			K8sAPI: mockK8sAPI,
-			cache:  testCache,
+		Controller: WatchedEventController{
+			logger:         zap.New(),
+			k8sAPI:         mockK8sAPI,
+			cache:          testCache,
+			ctx:            context.TODO(),
+			eventWatchTime: 1,
 		},
 	}
 }
 
-func TestEventReconciler_Reconcile_SGPEvent(t *testing.T) {
-	var events = []struct {
-		eventList             *eventsv1.EventList
-		isValidEventForSGP    bool
-		successfullyLabelNode bool
-		testNodeName          string
-		testNodeKey           string
-		msg                   string
-		hitCache              bool
-		missCache             bool
-		evictCache            bool
-	}{
-		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *oldSgpEvent),
-			},
-			isValidEventForSGP:    false,
-			successfullyLabelNode: false,
-			testNodeName:          mockEventNodeNameOne,
-			testNodeKey:           string(oldSgpEvent.Regarding.UID),
-			msg:                   "SGP Cache Test: Expired event is not valid event",
-			hitCache:              false,
-			missCache:             true,
-			evictCache:            false,
-		},
-		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newSgpEventOne),
-			},
-			isValidEventForSGP:    true,
-			successfullyLabelNode: true,
-			testNodeName:          mockEventNodeNameTwo,
-			testNodeKey:           string(newSgpEventOne.Regarding.UID),
-			msg:                   "SGP Cache Test: Valid event one, label node",
-			hitCache:              false,
-			missCache:             true,
-			evictCache:            false,
-		},
-		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newSgpEventTwo),
-			},
-			isValidEventForSGP:    true,
-			successfullyLabelNode: false,
-			testNodeName:          mockEventNodeNameThree,
-			testNodeKey:           string(newSgpEventTwo.Regarding.UID),
-			msg:                   "SGP Cache Test: Valid event two, fail labelling node",
-			hitCache:              false,
-			missCache:             true,
-			evictCache:            false,
-		},
-		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newSgpEventTwo),
-			},
-			isValidEventForSGP:    true,
-			successfullyLabelNode: true,
-			testNodeName:          mockEventNodeNameThree,
-			testNodeKey:           string(newSgpEventTwo.Regarding.UID),
-			msg:                   "SGP Cache Test: Valid event two, label node",
-			hitCache:              false,
-			missCache:             true,
-			evictCache:            false,
-		},
-		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newSgpEventTwo),
-			},
-			isValidEventForSGP:    true,
-			successfullyLabelNode: true,
-			testNodeName:          mockEventNodeNameThree,
-			testNodeKey:           string(newSgpEventTwo.Regarding.UID),
-			msg:                   "SGP Cache Test: Valid event two, label node, cache hit",
-			hitCache:              true,
-			missCache:             false,
-			evictCache:            false,
-		},
-		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newSgpEventTwo),
-			},
-			isValidEventForSGP:    true,
-			successfullyLabelNode: true,
-			testNodeName:          mockEventNodeNameThree,
-			testNodeKey:           string(newSgpEventTwo.Regarding.UID),
-			msg:                   "SGP Cache Test: Valid event, label node, cache expired and should be miss",
-			hitCache:              false,
-			missCache:             true,
-			evictCache:            true,
-		},
-		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newSgpEventTwo),
-			},
-			isValidEventForSGP:    true,
-			successfullyLabelNode: true,
-			testNodeName:          mockEventNodeNameThree,
-			testNodeKey:           string(newSgpEventTwo.Regarding.UID),
-			msg:                   "SGP Cache Test: Valid event, label node, cache expired and should be miss",
-			hitCache:              false,
-			missCache:             true,
-			evictCache:            true,
-		},
+// TestEventWatcher_ReceiveAll test if the watcher receives all events
+func TestEventWatcher_ReceiveAll(t *testing.T) {
+	var watchEvents []watch.Event
+	for _, e := range sgpEvents {
+		e.event.SetResourceVersion(e.rv)
+		watchEvents = append(watchEvents, makeTestEvent(e.event))
 	}
 
+	watcher, err := goWatch.NewRetryWatcher("1", &cache.ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return watch.NewProxyWatcher(arrayToChannel(watchEvents)), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create a RetryWatcher: %v", err)
+	}
+
+	// Give the watcher a chance to get to sending events (blocking)
+	time.Sleep(10 * time.Millisecond)
+
+	var wg sync.WaitGroup
+	eventsCount := len(sgpEvents)
+	wg.Add(eventsCount)
+	go func() {
+	LOOP:
+		for {
+			select {
+			case e, open := <-watcher.ResultChan():
+				if open {
+					fmt.Println("Result Chan is OPEN")
+					if e.Object != nil {
+						fmt.Printf("The event type is %v\n", e.Type)
+						wg.Done()
+					} else {
+						fmt.Println("Result Chan has no more event")
+						watcher.Stop()
+					}
+				} else {
+					fmt.Println("Result Chan is CLOSE")
+					break LOOP
+				}
+			case <-watcher.Done():
+				fmt.Println("Watcher is DONE")
+				break LOOP
+			}
+		}
+	}()
+
+	wg.Wait()
+	watcher.Stop()
+	fmt.Println("Main routine stopped watcher")
+	_, open := <-watcher.ResultChan()
+	assert.False(t, open, "watcher channel should be closed")
+}
+
+// TestEventWatcher_Waiting tests if watcher waits
+func TestEventWatcher_Waiting(t *testing.T) {
+	var watchEvents []watch.Event
+	for _, e := range sgpEvents {
+		e.event.SetResourceVersion(e.rv)
+		watchEvents = append(watchEvents, makeTestEvent(e.event))
+	}
+
+	watcher, err := goWatch.NewRetryWatcher("1", &cache.ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return watch.NewProxyWatcher(arrayToChannel(watchEvents)), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create a RetryWatcher: %v", err)
+	}
+
+	// Give the watcher a chance to get to sending events (blocking)
+	time.Sleep(10 * time.Millisecond)
+
+	go func() {
+	LOOP:
+		for {
+			select {
+			case e, open := <-watcher.ResultChan():
+				if open {
+					if e.Object != nil {
+						fmt.Printf("The event type is %v\n", e.Type)
+					} else {
+						fmt.Println("Result Chan has no more event")
+						watcher.Stop()
+					}
+				} else {
+					fmt.Println("Result Chan is CLOSE")
+					break LOOP
+				}
+			case <-watcher.Done():
+				fmt.Println("Watcher is DONE")
+				break LOOP
+			}
+		}
+	}()
+	fmt.Println("Waiting for 2 seconds")
+	for i := 0; i < 10; i += 1 {
+		select {
+		case <-watcher.Done():
+			t.Fatalf("watcher shouldn't be closed when waiting")
+		case _, open := <-watcher.ResultChan():
+			fmt.Println("Result Chan is OPEN in waiting window")
+			assert.True(t, open, "watcher channel should be open")
+		default:
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+	watcher.Stop()
+	fmt.Println("Main routine stopped watcher")
+	_, open := <-watcher.ResultChan()
+	assert.False(t, open, "watcher channel should be closed")
+}
+
+// TestEventWatcher_WatcherBehaviors tests how watcher works with events
+func TestEventWatcher_WatcherBehaviors(t *testing.T) {
+	var watchEvents []watch.Event
+	testEvents := []*eventsv1.Event{
+		oldSgpEvent,
+		newSgpEventOne,
+		newSgpEventTwo,
+	}
+	for rv, e := range testEvents {
+		e.SetResourceVersion(strconv.Itoa(rv + 1))
+		watchEvents = append(watchEvents, makeTestEvent(e))
+	}
+
+	watcher, err := goWatch.NewRetryWatcher("1", &cache.ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return watch.NewProxyWatcher(arrayToChannel(watchEvents)), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create a RetryWatcher: %v", err)
+	}
+
+	// Give the watcher a chance to get to sending events (blocking)
+	time.Sleep(10 * time.Millisecond)
+
+	// the old event has older creation timestamp and will be skipped
+	go checkEvent(t, watcher, len(testEvents)-1)
+	time.Sleep(3 * time.Second)
+	watcher.Stop()
+	_, open := <-watcher.Done()
+	assert.True(t, !open)
+}
+
+func checkEvent(t *testing.T, watcher *goWatch.RetryWatcher, callCounts int) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mock := NewEventControllerMock(ctrl)
-	ops := []client.ListOption{
-		client.MatchingFields{
-			EventFilterKey: config.VpcCNINodeEventReason,
+
+	mock.MockK8sAPI.EXPECT().GetRetryWatcher(gomock.Any(), gomock.Any()).Return(watcher, nil)
+	eventNode := &corev1.Node{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mockEventNodeNameOne,
 		},
 	}
+	// Don't remove Times(), we need explicitly test how many times they are called
+	mock.MockK8sAPI.EXPECT().GetNode(gomock.Any()).Return(eventNode, nil).Times(callCounts)
+	mock.MockK8sAPI.EXPECT().AddLabelToManageNode(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(callCounts)
 
-	for _, e := range events {
+	assert.Panics(t, func() { mock.Controller.watchEvents() }, "the controller should have panic after another routine stops watcher!")
+}
+
+// TestEventController_ProcessSGPEvent tests labelling for SGP with nodes
+func TestEventController_ProcessSGPEvent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mock := NewEventControllerMock(ctrl)
+	for _, e := range sgpEvents {
+
 		if e.evictCache {
 			time.Sleep(testCacheExpiry + testWaitCacheEvict)
 		}
-		mock.MockK8sAPI.EXPECT().ListEvents(ops).Return(e.eventList, nil)
+		callCount := 1
+		if e.hitCache {
+			callCount = 0
+		}
 
-		_, cacheErr := mock.Reconciler.cache.Get(e.testNodeKey)
+		eventNode := &corev1.Node{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   mockEventNodeNameOne,
+				Labels: make(map[string]string),
+			},
+		}
+
+		mock.MockK8sAPI.EXPECT().GetNode(e.testNodeName).Return(eventNode, nil).Times(callCount)
+
+		_, cacheErr := mock.Controller.cache.Get(e.testNodeKey)
 
 		// the same instance was added already but waited for expiry + 1 second, we should see cache miss error
 		if e.missCache && e.evictCache && !e.hitCache {
@@ -312,21 +624,13 @@ func TestEventReconciler_Reconcile_SGPEvent(t *testing.T) {
 		}
 
 		if e.isValidEventForSGP {
-			eventNode := &corev1.Node{
-				TypeMeta: metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   e.testNodeName,
-					Labels: map[string]string{config.NodeLabelOS: config.OSLinux},
-				},
-			}
-			mock.MockK8sAPI.EXPECT().GetNode(e.testNodeName).Return(eventNode, nil).AnyTimes()
 			if cacheErr == nil || e.successfullyLabelNode {
-				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.HasTrunkAttachedLabel, config.BooleanFalse).Return(true, nil).AnyTimes()
+				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.HasTrunkAttachedLabel, config.BooleanFalse).Return(true, nil).Times(callCount)
 			} else {
-				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.HasTrunkAttachedLabel, config.BooleanFalse).Return(false, errors.New("sgp-test"))
+				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.HasTrunkAttachedLabel, config.BooleanFalse).Return(false, errors.New("sgp-test")).Times(callCount)
 			}
 		}
-		res, err := mock.Reconciler.Reconcile(context.TODO(), sgpEventReconcileRequest)
+		err := mock.Controller.processEvent(*e.event)
 
 		if cacheErr == nil || e.successfullyLabelNode {
 			assert.NoError(t, err, e.msg)
@@ -338,120 +642,26 @@ func TestEventReconciler_Reconcile_SGPEvent(t *testing.T) {
 		} else {
 			assert.FailNow(t, "Unexpected test case, need to fail test as safeguard")
 		}
-
-		assert.Equal(t, res, reconcile.Result{}, e.msg)
 	}
 }
 
-func TestEventReconciler_Reconcile_ENIConfigLabelNodeEvent(t *testing.T) {
+// TestEventController_ProcessCNEvent tests labelling for custom networking
+func TestEventController_ProcessCNEvent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mock := NewEventControllerMock(ctrl)
 
-	ops := []client.ListOption{
-		client.MatchingFields{
-			EventFilterKey: config.VpcCNINodeEventReason,
-		},
-	}
-
-	var events = []struct {
-		eventList                       *eventsv1.EventList
-		isValidEventForCustomNetworking bool
-		successfullyLabelNode           bool
-		testNodeName                    string
-		testNodeKey                     string
-		msg                             string
-		hitCache                        bool
-		missCache                       bool
-		evictCache                      bool
-	}{
-		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *oldEniConfigEvent),
-			},
-			isValidEventForCustomNetworking: false,
-			successfullyLabelNode:           false,
-			testNodeName:                    mockEventNodeNameOne,
-			testNodeKey:                     string(oldEniConfigEvent.Regarding.UID),
-			msg:                             "Custom Networking Cache Test: Expired event is not valid event",
-			hitCache:                        false,
-			missCache:                       true,
-			evictCache:                      false,
-		},
-		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newEniConfigEventOne),
-			},
-			isValidEventForCustomNetworking: true,
-			successfullyLabelNode:           true,
-			testNodeName:                    mockEventNodeNameTwo,
-			testNodeKey:                     string(newEniConfigEventOne.Regarding.UID),
-			msg:                             "Custom Networking Cache Test: Valid event one, label node",
-			hitCache:                        false,
-			missCache:                       true,
-			evictCache:                      false,
-		},
-		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newEniConfigEventTwo),
-			},
-			isValidEventForCustomNetworking: true,
-			successfullyLabelNode:           false,
-			testNodeName:                    mockEventNodeNameThree,
-			testNodeKey:                     string(newEniConfigEventTwo.Regarding.UID),
-			msg:                             "Custom Networking Cache Test: Valid event two, fail labelling node",
-			hitCache:                        false,
-			missCache:                       true,
-			evictCache:                      false,
-		},
-		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newEniConfigEventTwo),
-			},
-			isValidEventForCustomNetworking: true,
-			successfullyLabelNode:           true,
-			testNodeName:                    mockEventNodeNameThree,
-			testNodeKey:                     string(newEniConfigEventTwo.Regarding.UID),
-			msg:                             "Custom Networking Cache Test: Valid event two, label node",
-			hitCache:                        false,
-			missCache:                       true,
-			evictCache:                      false,
-		},
-		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newEniConfigEventTwo),
-			},
-			isValidEventForCustomNetworking: true,
-			successfullyLabelNode:           true,
-			testNodeName:                    mockEventNodeNameThree,
-			testNodeKey:                     string(newEniConfigEventTwo.Regarding.UID),
-			msg:                             "Custom Networking Cache Test: Valid event two, label node, cache hit",
-			hitCache:                        true,
-			missCache:                       false,
-			evictCache:                      false,
-		},
-		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newEniConfigEventTwo),
-			},
-			isValidEventForCustomNetworking: true,
-			successfullyLabelNode:           true,
-			testNodeName:                    mockEventNodeNameThree,
-			testNodeKey:                     string(newEniConfigEventTwo.Regarding.UID),
-			msg:                             "Custom Networking Cache Test: Valid event, label node, cache expired and should be miss",
-			hitCache:                        false,
-			missCache:                       true,
-			evictCache:                      true,
-		},
-	}
-
-	for _, e := range events {
+	for _, e := range cnEvents {
 		if e.evictCache {
 			time.Sleep(testCacheExpiry + testWaitCacheEvict)
 		}
-		mock.MockK8sAPI.EXPECT().ListEvents(ops).Return(e.eventList, nil)
 
-		_, cacheErr := mock.Reconciler.cache.Get(e.testNodeKey)
+		callCount := 1
+		if e.hitCache {
+			callCount = 0
+		}
+
+		_, cacheErr := mock.Controller.cache.Get(e.testNodeKey)
 
 		// the same instance was added already but waited for expiry + 1 second, we should see cache miss error
 		if e.missCache && e.evictCache && !e.hitCache {
@@ -464,7 +674,6 @@ func TestEventReconciler_Reconcile_ENIConfigLabelNodeEvent(t *testing.T) {
 		}
 
 		if e.isValidEventForCustomNetworking {
-			// if the event is older, these func are not expected to be called.
 			eventNode := &corev1.Node{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
@@ -472,15 +681,15 @@ func TestEventReconciler_Reconcile_ENIConfigLabelNodeEvent(t *testing.T) {
 					Labels: map[string]string{config.NodeLabelOS: config.OSLinux, config.HasTrunkAttachedLabel: "false"},
 				},
 			}
-			mock.MockK8sAPI.EXPECT().GetNode(e.testNodeName).Return(eventNode, nil).AnyTimes()
+			mock.MockK8sAPI.EXPECT().GetNode(e.testNodeName).Return(eventNode, nil).Times(callCount)
 			if cacheErr == nil || e.successfullyLabelNode {
-				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.CustomNetworkingLabel, "testConfig").Return(true, nil).AnyTimes()
+				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.CustomNetworkingLabel, "testConfig").Return(true, nil).Times(callCount)
 			} else {
-				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.CustomNetworkingLabel, "testConfig").Return(false, errors.New("custom-networking-test"))
+				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.CustomNetworkingLabel, "testConfig").Return(false, errors.New("custom-networking-test")).Times(callCount)
 			}
 		}
 
-		res, err := mock.Reconciler.Reconcile(context.TODO(), eniConfigEventReconcileRequest)
+		err := mock.Controller.processEvent(*e.event)
 
 		if cacheErr == nil || e.successfullyLabelNode {
 			assert.NoError(t, err)
@@ -492,20 +701,15 @@ func TestEventReconciler_Reconcile_ENIConfigLabelNodeEvent(t *testing.T) {
 		} else {
 			assert.FailNow(t, "Unexpected test case, need to fail test as safeguard")
 		}
-		assert.Equal(t, res, reconcile.Result{})
 	}
 }
 
+// TestEventReconciler_Reconcile_DualEvents tests both SGP and CN need to be labeled with nodes
 func TestEventReconciler_Reconcile_DualEvents(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mock := NewEventControllerMock(ctrl)
-	ops := []client.ListOption{
-		client.MatchingFields{
-			EventFilterKey: config.VpcCNINodeEventReason,
-		},
-	}
 
 	eventList := &eventsv1.EventList{}
 	eventList.Items = append([]eventsv1.Event{}, *newSgpEventOne)
@@ -516,71 +720,69 @@ func TestEventReconciler_Reconcile_DualEvents(t *testing.T) {
 	eventNode := &corev1.Node{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   mockEventNodeNameTwo,
-			Labels: map[string]string{config.NodeLabelOS: config.OSLinux, config.HasTrunkAttachedLabel: "false"},
+			Name: mockEventNodeNameTwo,
 		},
 	}
-	// calls should be made only twice since after one SGP event and one Custom networking event other events for the same instance should be ignored
-	// due to cache hit
-	expectedCallTimes := 2
-	mock.MockK8sAPI.EXPECT().ListEvents(ops).Return(eventList, nil)
-	mock.MockK8sAPI.EXPECT().GetNode(mockEventNodeNameTwo).Return(eventNode, nil).Times(expectedCallTimes)
-	mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, gomock.Any(), gomock.Any()).Return(true, nil).Times(expectedCallTimes)
-	res, err := mock.Reconciler.Reconcile(context.TODO(), sgpEventReconcileRequest)
 
-	assert.NoError(t, err, "Reconcile has no error for dual events tests")
-	assert.True(t, res.Requeue == false, "Reconcile has no requeue for dual events tests")
-	assert.True(t, mock.Reconciler.cache.Len() == 1)
-	cachedEntry, err := mock.Reconciler.cache.Get(mockInstanceIdTwo)
+	events := []*eventsv1.Event{newSgpEventOne, newEniConfigEventOne}
+
+	times := 2
+	var err error
+	for i := 0; i < times; i++ {
+		for _, value := range events {
+			// calls should be made only twice since after one SGP event and one Custom networking event other events for the same instance should be ignored
+			// due to cache hit
+			expectedCallTimes := times - i - 1
+			mock.MockK8sAPI.EXPECT().GetNode(mockEventNodeNameTwo).Return(eventNode, nil).Times(expectedCallTimes)
+			mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, gomock.Any(), gomock.Any()).Return(true, nil).Times(expectedCallTimes)
+			err = mock.Controller.processEvent(*value)
+			assert.NoError(t, err, "Event processor has no error for test event", value)
+		}
+	}
+	assert.NoError(t, err, "Event processor has no error for dual events tests")
+	assert.True(t, mock.Controller.cache.Len() == 1)
+	cachedEntry, err := mock.Controller.cache.Get(mockInstanceIdTwo)
 	assert.NoError(t, err, "Should get entry from test cache successfully")
 	assert.True(t, cachedEntry[EnableSGP] == 1, "SGP is cached")
 	assert.True(t, cachedEntry[EnableCN] == 1, "Custom networking is cached")
 }
 
+// TestEventReconciler_Reconcile_DualEventsCacheStatus tests code labels node cache behavior for both SGP and CN enabled
 func TestEventReconciler_Reconcile_DualEventsCacheStatus(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mock := NewEventControllerMock(ctrl)
 
-	ops := []client.ListOption{
-		client.MatchingFields{
-			EventFilterKey: config.VpcCNINodeEventReason,
-		},
-	}
-
 	var events = []struct {
-		eventList *eventsv1.EventList
-		sgp       bool
-		cn        bool
-		msg       string
+		event *eventsv1.Event
+		nn    types.NamespacedName
+		sgp   bool
+		cn    bool
+		msg   string
 	}{
 		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newSgpEventOne),
-			},
-			sgp: true,
-			msg: "SGP event one",
+			event: newSgpEventOne,
+			nn:    namespacedName,
+			sgp:   true,
+			msg:   "SGP event one",
 		},
 		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newEniConfigEventOne),
-			},
-			cn:  true,
-			msg: "Custom networking event one",
+			event: newEniConfigEventOne,
+			nn:    namespacedName,
+			cn:    true,
+			msg:   "Custom networking event one",
 		},
 		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newSgpEventOne),
-			},
-			sgp: true,
-			msg: "SGP event one",
+			event: newSgpEventOne,
+			nn:    namespacedName,
+			sgp:   true,
+			msg:   "SGP event one",
 		},
 		{
-			eventList: &eventsv1.EventList{
-				Items: append([]eventsv1.Event{}, *newEniConfigEventOne),
-			},
-			cn:  true,
-			msg: "Custom networking event one",
+			event: newEniConfigEventOne,
+			nn:    namespacedName,
+			cn:    true,
+			msg:   "Custom networking event one",
 		},
 	}
 
@@ -589,11 +791,9 @@ func TestEventReconciler_Reconcile_DualEventsCacheStatus(t *testing.T) {
 		eventNode := &corev1.Node{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   mockEventNodeNameTwo,
-				Labels: map[string]string{config.NodeLabelOS: config.OSLinux, config.HasTrunkAttachedLabel: "false"},
+				Name: mockEventNodeNameTwo,
 			},
 		}
-		mock.MockK8sAPI.EXPECT().ListEvents(ops).Return(e.eventList, nil)
 		switch idx {
 		case 0:
 			expectedCallTimes = 1
@@ -603,9 +803,9 @@ func TestEventReconciler_Reconcile_DualEventsCacheStatus(t *testing.T) {
 			} else {
 				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.CustomNetworkingLabel, "testConfig").Return(true, nil).Times(expectedCallTimes)
 			}
-			_, err := mock.Reconciler.cache.Get(mockInstanceIdTwo)
+			_, err := mock.Controller.cache.Get(mockInstanceIdTwo)
 			assert.Error(t, err)
-			assert.True(t, mock.Reconciler.cache.Len() == 0)
+			assert.True(t, mock.Controller.cache.Len() == 0)
 		case 1:
 			expectedCallTimes = 1
 			mock.MockK8sAPI.EXPECT().GetNode(mockEventNodeNameTwo).Return(eventNode, nil).Times(expectedCallTimes)
@@ -614,9 +814,9 @@ func TestEventReconciler_Reconcile_DualEventsCacheStatus(t *testing.T) {
 			} else {
 				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.CustomNetworkingLabel, "testConfig").Return(true, nil).Times(expectedCallTimes)
 			}
-			entry, err := mock.Reconciler.cache.Get(mockInstanceIdTwo)
+			entry, err := mock.Controller.cache.Get(mockInstanceIdTwo)
 			assert.NoError(t, err)
-			assert.True(t, mock.Reconciler.cache.Len() == 1)
+			assert.True(t, mock.Controller.cache.Len() == 1)
 			assert.True(t, entry[EnableSGP] == 1 && entry[EnableCN] == 0, "Cache miss with entry")
 		default:
 			// at this moment, the cache should have updated for the key (instance id) with both features flagged as {1, 1}
@@ -628,12 +828,138 @@ func TestEventReconciler_Reconcile_DualEventsCacheStatus(t *testing.T) {
 			} else {
 				mock.MockK8sAPI.EXPECT().AddLabelToManageNode(eventNode, config.CustomNetworkingLabel, "testConfig").Return(true, nil).Times(expectedCallTimes)
 			}
-			entry, err := mock.Reconciler.cache.Get(mockInstanceIdTwo)
+			entry, err := mock.Controller.cache.Get(mockInstanceIdTwo)
 			assert.NoError(t, err)
-			assert.True(t, mock.Reconciler.cache.Len() == 1)
+			assert.True(t, mock.Controller.cache.Len() == 1)
 			assert.True(t, entry[EnableSGP] == 1 && entry[EnableCN] == 1, "Cache hit")
 		}
+		mock.Controller.processEvent(*e.event)
+	}
+}
 
-		mock.Reconciler.Reconcile(context.TODO(), sgpEventReconcileRequest)
+// TestEventController_LabelledNod tests if code skip labelled node to avoid race condition
+func TestEventController_LabelledNode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mock := NewEventControllerMock(ctrl)
+
+	events := []TestNode{
+		{
+			node: &corev1.Node{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   mockEventNodeNameTwo,
+					Labels: map[string]string{config.NodeLabelOS: config.OSLinux, config.HasTrunkAttachedLabel: "false"},
+				},
+			},
+			sgpEvent: true,
+			labelled: true,
+			msg:      "node has been labelled with false for SGP",
+		},
+		{
+			node: &corev1.Node{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   mockEventNodeNameTwo,
+					Labels: map[string]string{config.NodeLabelOS: config.OSLinux, config.HasTrunkAttachedLabel: "true"},
+				},
+			},
+			sgpEvent: true,
+			labelled: true,
+			msg:      "node has been labelled with true for SGP",
+		},
+		{
+			node: &corev1.Node{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   mockEventNodeNameTwo,
+					Labels: map[string]string{config.NodeLabelOS: config.OSLinux, config.HasTrunkAttachedLabel: "not-supported"},
+				},
+			},
+			sgpEvent: true,
+			labelled: true,
+			msg:      "node has been labelled with not-supported for SGP",
+		},
+		{
+			node: &corev1.Node{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   mockEventNodeNameTwo,
+					Labels: map[string]string{config.NodeLabelOS: config.OSLinux, config.HasTrunkAttachedLabel: "testConfig"},
+				},
+			},
+			cnEvent:  true,
+			labelled: true,
+			msg:      "node has been labelled with config for custom networking",
+		},
+		{
+			node: &corev1.Node{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   mockEventNodeNameTwo,
+					Labels: map[string]string{config.NodeLabelOS: config.OSLinux},
+				},
+			},
+			sgpEvent: true,
+			labelled: false,
+			msg:      "node has no valid label",
+		},
+		{
+			node: &corev1.Node{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   mockEventNodeNameTwo,
+					Labels: make(map[string]string),
+				},
+			},
+			sgpEvent: true,
+			labelled: false,
+			msg:      "node has empty label map",
+		},
+		{
+			node: &corev1.Node{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: mockEventNodeNameTwo,
+				},
+			},
+			sgpEvent: true,
+			labelled: false,
+			msg:      "node has nil label map",
+		},
+	}
+
+	for _, e := range events {
+		callCount := 1
+		if e.labelled {
+			callCount = 0
+		}
+		mock.MockK8sAPI.EXPECT().GetNode(mockEventNodeNameTwo).Return(e.node, nil).Times(1)
+		mock.MockK8sAPI.EXPECT().AddLabelToManageNode(e.node, gomock.Any(), gomock.Any()).Return(true, nil).Times(callCount)
+		err := mock.Controller.processEvent(*updateTestNodeUID(*newSgpEventOne))
+		assert.NoError(t, err, "")
+	}
+}
+
+func updateTestNodeUID(event eventsv1.Event) *eventsv1.Event {
+	copy := event.DeepCopy()
+	copy.Related.UID = types.UID(uuid.New().String())
+	return copy
+}
+
+func arrayToChannel(array []watch.Event) chan watch.Event {
+	ch := make(chan watch.Event, len(array))
+
+	for _, event := range array {
+		ch <- event
+	}
+
+	return ch
+}
+
+func makeTestEvent(e *eventsv1.Event) watch.Event {
+	return watch.Event{
+		Type:   watch.Added,
+		Object: e,
 	}
 }

--- a/controllers/core/metrics_config.go
+++ b/controllers/core/metrics_config.go
@@ -1,0 +1,140 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package controllers
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	EventFilterKey               = "reason"
+	LoggerName                   = "event"
+	TotalValidEventsCount        = "total_valid_event"
+	EventFailureCountMetrics     = "failing_watch"
+	EventGetCallCountMetrics     = "call_get_node"
+	SGPEventsFailureCountMetrics = "trunk_label_failed"
+	SGPEventsCountMetrics        = "trunk_labelled"
+	CNEventsFailureCountMetrics  = "eniconfig_label_failed"
+	CNEventsCountMetrics         = "eniconfig_labelled"
+	WatchEventsLatencyMetrics    = "watch_events"
+	LabelOperation               = "operation"
+	LabelTime                    = "time"
+	LabelCacheHit                = "cache_hit"
+	LabelCacheMiss               = "cache_miss"
+	LabelCacheAdd                = "cache_add"
+	LabelCacheSetErr             = "cache_set_error"
+	CacheHitMetricsValue         = "NODE_CACHED"
+	CacheMissMetricsValue        = "NODE_NOT_CACHED"
+	CacheAddMetricsValue         = "NODE_ADDED"
+	CacheErrMetricsValue         = "NODE_CACHE_ERROR"
+	WatcherPanicCount            = "event_watcher_panic_to_restart"
+	TotalEventWatchedCount       = "event_watched_total"
+)
+
+var (
+	eventControllerTotalValidEventsCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "total_events_watched_by_event_controller",
+			Help: "The number of events that were watched by the controller",
+		},
+		[]string{LabelOperation},
+	)
+
+	eventControllerCallGETToAPIServerCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "total_count_of_call_api_server_for_get_node",
+			Help: "The number of get calls to api server for node",
+		},
+		[]string{LabelOperation},
+	)
+
+	eventControllerSGPEventsCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "security_group_pod_events_watched_by_event_controller",
+			Help: "The number of SGP events that were watched by the controller",
+		},
+		[]string{LabelOperation},
+	)
+
+	eventControllerSGPEventsFailureCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "failed_security_group_pod_events_watched_by_event_controller",
+			Help: "The number of SGP events that were watched by the controller but failed on label node",
+		},
+		[]string{LabelOperation},
+	)
+
+	eventControllerCNEventsCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "custom_networking_events_watched_by_event_controller",
+			Help: "The number of custom networking events that were watched by the controller",
+		},
+		[]string{LabelOperation},
+	)
+
+	eventControllerCNEventsFailureCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "failed_custom_networking_events_watched_by_event_controller",
+			Help: "The number of custom networking events that were watched by the controller but failed on label node",
+		},
+		[]string{LabelOperation},
+	)
+
+	eventControllerEventWatcherFailureCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "failed_watch_events_by_event_watcher",
+			Help: "The number of failures on getting events by the controller",
+		},
+		[]string{LabelOperation},
+	)
+
+	eventWatchOperationLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "event_watch_operation_latency",
+			Help: "Event controller watch events latency in second",
+		},
+		[]string{LabelTime},
+	)
+
+	eventControllerNodeCacheSize = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "event_watch_node_cache_size",
+			Help: "Event controller node cache size",
+		},
+	)
+
+	eventControllerNodeCacheOpsCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "event_watch_node_cache_operations",
+			Help: "The number of ops on retrieving node from cache",
+		},
+		[]string{LabelCacheHit, LabelCacheMiss, LabelCacheAdd, LabelCacheSetErr},
+	)
+
+	eventWatcherPanicCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "event_watcher_panic_to_restart_count",
+			Help: "The number of event watcher has to panic to restart",
+		},
+		[]string{LabelOperation},
+	)
+
+	eventWatchedTotalCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "event_watched_total_count",
+			Help: "The number of events watcher has watched",
+		},
+		[]string{LabelOperation},
+	)
+)

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/mock_k8swrapper.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/mock_k8swrapper.go
@@ -24,9 +24,9 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/apps/v1"
 	v10 "k8s.io/api/core/v1"
-	v11 "k8s.io/api/events/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	client "sigs.k8s.io/controller-runtime/pkg/client"
+	cache "k8s.io/client-go/tools/cache"
+	watch "k8s.io/client-go/tools/watch"
 )
 
 // MockK8sWrapper is a mock of K8sWrapper interface.
@@ -168,19 +168,19 @@ func (mr *MockK8sWrapperMockRecorder) GetNode(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockK8sWrapper)(nil).GetNode), arg0)
 }
 
-// ListEvents mocks base method.
-func (m *MockK8sWrapper) ListEvents(arg0 []client.ListOption) (*v11.EventList, error) {
+// GetRetryWatcher mocks base method.
+func (m *MockK8sWrapper) GetRetryWatcher(arg0 string, arg1 cache.WatchFunc) (*watch.RetryWatcher, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEvents", arg0)
-	ret0, _ := ret[0].(*v11.EventList)
+	ret := m.ctrl.Call(m, "GetRetryWatcher", arg0, arg1)
+	ret0, _ := ret[0].(*watch.RetryWatcher)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListEvents indicates an expected call of ListEvents.
-func (mr *MockK8sWrapperMockRecorder) ListEvents(arg0 interface{}) *gomock.Call {
+// GetRetryWatcher indicates an expected call of GetRetryWatcher.
+func (mr *MockK8sWrapperMockRecorder) GetRetryWatcher(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEvents", reflect.TypeOf((*MockK8sWrapper)(nil).ListEvents), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRetryWatcher", reflect.TypeOf((*MockK8sWrapper)(nil).GetRetryWatcher), arg0, arg1)
 }
 
 // ListNodes mocks base method.

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -72,6 +72,7 @@ const (
 	EnableWindowsIPAMKey    = "enable-windows-ipam"
 	// Since LeaderElectionNamespace and VpcCniConfigMapName may be different in the future
 	KubeSystemNamespace            = "kube-system"
+	DefaultNamespace               = "default"
 	VpcCNIDaemonSetName            = "aws-node"
 	OldVPCControllerDeploymentName = "vpc-resource-controller"
 )

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -315,12 +315,6 @@ func (m *manager) performAsyncOperation(job interface{}) (ctrl.Result, error) {
 			return ctrl.Result{}, nil
 		}
 
-		// node was successfully initialized, we need to update trunk label value to True
-		// this is the only place that the controller set the label to true
-		if err := m.updateNodeTrunkLabel(asyncJob.nodeName, config.HasTrunkAttachedLabel, config.BooleanTrue); err != nil {
-			m.Log.Error(err, "updating node trunk label to true failed", "NodeName", asyncJob.nodeName)
-		}
-
 		// If there's no error, we need to update the node so the capacity is advertised
 		asyncJob.op = Update
 		return m.performAsyncOperation(asyncJob)
@@ -408,16 +402,4 @@ func (m *manager) removeNodeSafe(nodeName string) {
 	defer m.lock.Unlock()
 
 	delete(m.dataStore, nodeName)
-}
-
-func (m *manager) updateNodeTrunkLabel(nodeName, labelKey, labelValue string) error {
-	if node, err := m.wrapper.K8sAPI.GetNode(nodeName); err != nil {
-		return err
-	} else {
-		updated, err := m.wrapper.K8sAPI.AddLabelToManageNode(node, labelKey, labelValue)
-		if !updated {
-			m.Log.Info("failed updating the node label for trunk when operating on node", "NodeName", nodeName, "LabelKey", labelKey, "LabelValue", labelValue)
-		}
-		return err
-	}
 }

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -427,8 +427,6 @@ func Test_performAsyncOperation(t *testing.T) {
 	}
 
 	job.op = Init
-	mock.MockK8sAPI.EXPECT().GetNode(nodeName).Return(v1Node, nil)
-	mock.MockK8sAPI.EXPECT().AddLabelToManageNode(v1Node, config.HasTrunkAttachedLabel, config.BooleanTrue).Return(true, nil).AnyTimes()
 	mock.MockNode.EXPECT().InitResources(mock.MockResourceManager, mock.MockEC2API).Return(nil)
 	mock.MockNode.EXPECT().UpdateResources(mock.MockResourceManager, mock.MockEC2API).Return(nil)
 	_, err := mock.Manager.performAsyncOperation(job)

--- a/pkg/provider/branch/provider_test.go
+++ b/pkg/provider/branch/provider_test.go
@@ -333,10 +333,10 @@ func TestBranchENIProvider_Supported_LabelNode(t *testing.T) {
 		},
 	}
 
-	mockInstance.EXPECT().Name().Return(NodeName)
+	mockInstance.EXPECT().Name().Return(NodeName).Times(0)
 	mockInstance.EXPECT().Os().Return("linux")
 	mockInstance.EXPECT().Type().Return(supportedInstanceType)
-	mockK8sWrapper.EXPECT().GetNode(NodeName).Return(node, nil)
+	mockK8sWrapper.EXPECT().GetNode(NodeName).Return(node, nil).Times(0)
 	// not calling the label method if the instance is supported
 	mockK8sWrapper.EXPECT().AddLabelToManageNode(node, gomock.Any(), gomock.Any()).Return(true, nil).Times(0)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Due to high level event APIs off-load pressures onto API sever and ETCD server, we need refactor the event controller to use low level watcher from client-go. RetryWatcher is an utility that can help restart the watcher when it stops for various reasons. Using this watcher, we can significantly reduce the resource usage and loads on servers side.

Tests have been done
- Functional integration tests
- 48 hours performance tests
- 48 hours dual labeling tests for both SGP and custom networking labels

Resource usage monitored
- 48 hours MEM/CPU usage monitoring
- 48 hours goroutines leak monitoring

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
