### PR TITLE
support action to detect deprecated apiGroups

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -44,3 +44,18 @@ jobs:
         run: make controller
       - name: Check binary runs
         run: ./bin/controller -h
+  deprecated-apigroups:
+    name: Detect deprecated apiGroups
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout latest commit
+        uses: actions/checkout@v3
+      - name: Download Pluto
+        run: |
+          version=$(curl -sL https://api.github.com/repos/FairwindsOps/pluto/releases/latest | jq -r ".tag_name")
+          number=${version:1}
+          wget https://github.com/FairwindsOps/pluto/releases/download/${version}/pluto_${number}_linux_amd64.tar.gz
+          sudo tar -C /usr/local -xzf pluto_${number}_linux_amd64.tar.gz
+      - name: Use pluto
+        run: |
+          /usr/local/pluto detect-files -d .


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use Pluto to scan for deprecated k8s apiGroups
https://github.com/FairwindsOps/pluto

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
