### PR TITLE
check default card interfaces for index

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
+	golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -323,6 +323,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 h1:pVgRXcIictcr+lBQIFeiwuwtDIs4eL21OuM9nyAADmo=
+golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/utils/math.go
+++ b/pkg/utils/math.go
@@ -1,0 +1,52 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"golang.org/x/exp/constraints"
+)
+
+func Minimum[T constraints.Ordered](a, b T) T {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func Maximum[T constraints.Ordered](a, b T) T {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func MinOf[T constraints.Ordered](vars ...T) T {
+	result := vars[0]
+	for _, v := range vars {
+		if result > v {
+			result = v
+		}
+	}
+	return result
+}
+
+func MaxOf[T constraints.Ordered](vars ...T) T {
+	result := vars[0]
+	for _, v := range vars {
+		if result < v {
+			result = v
+		}
+	}
+	return result
+}

--- a/pkg/utils/math_test.go
+++ b/pkg/utils/math_test.go
@@ -1,0 +1,49 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTwoElements(t *testing.T) {
+	a := 10
+	b := 11
+	assert.True(t, Minimum(a, b) == a)
+	assert.True(t, Maximum(a, b) == b)
+
+	x := "ab"
+	y := "ba"
+	assert.True(t, Minimum(x, y) == x)
+	assert.True(t, Maximum(x, y) == y)
+}
+
+func TestMultipleElements(t *testing.T) {
+	a := 10
+	b := 11
+	c := 5
+	vars := []int{a, b, c}
+	assert.True(t, MinOf(vars...) == c)
+	assert.True(t, MaxOf(vars...) == b)
+
+	x := "ab"
+	y := "aba"
+	z := "aa"
+	varStr := []string{x, y, z}
+
+	assert.True(t, MinOf(varStr...) == z)
+	assert.True(t, MaxOf(varStr...) == y)
+}


### PR DESCRIPTION
*Issue #, if available:*
#185 
*Description of changes:*
Instead of using instance max interfaces for index, we should use default network card's interfaces count, especially for multi-card instance types. Currently this controller and VPC CNI only support single network card.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
