### PR TITLE
clean up node label introduced from event solution

### DIFF
--- a/main.go
+++ b/main.go
@@ -207,11 +207,6 @@ func main() {
 				"metadata.namespace": config.KubeSystemNamespace,
 			}.AsSelector(),
 			},
-			// &eventsv1.Event{}: {Field: fields.Set{
-			// 	"reason":              config.VpcCNINodeEventReason,
-			// 	"reportingController": config.VpcCNIReportingAgent,
-			// }.AsSelector(),
-			// },
 		},
 	})
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -315,12 +315,6 @@ func (m *manager) performAsyncOperation(job interface{}) (ctrl.Result, error) {
 			return ctrl.Result{}, nil
 		}
 
-		// node was successfully initialized, we need to update trunk label value to True
-		// this is the only place that the controller set the label to true
-		if err := m.updateNodeTrunkLabel(asyncJob.nodeName, config.HasTrunkAttachedLabel, config.BooleanTrue); err != nil {
-			m.Log.Error(err, "updating node trunk label to true failed", "NodeName", asyncJob.nodeName)
-		}
-
 		// If there's no error, we need to update the node so the capacity is advertised
 		asyncJob.op = Update
 		return m.performAsyncOperation(asyncJob)

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -427,7 +427,7 @@ func Test_performAsyncOperation(t *testing.T) {
 	}
 
 	job.op = Init
-	mock.MockK8sAPI.EXPECT().GetNode(nodeName).Return(v1Node, nil)
+
 	mock.MockK8sAPI.EXPECT().AddLabelToManageNode(v1Node, config.HasTrunkAttachedLabel, config.BooleanTrue).Return(true, nil).AnyTimes()
 	mock.MockNode.EXPECT().InitResources(mock.MockResourceManager, mock.MockEC2API).Return(nil)
 	mock.MockNode.EXPECT().UpdateResources(mock.MockResourceManager, mock.MockEC2API).Return(nil)

--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -459,34 +459,8 @@ func (b *branchENIProvider) GetPool(_ string) (pool.Pool, bool) {
 // IsInstanceSupported returns true for linux node as pod eni is only supported for linux worker node
 func (b *branchENIProvider) IsInstanceSupported(instance ec2.EC2Instance) bool {
 	limits, found := vpc.Limits[instance.Type()]
-	supported := found && instance.Os() == config.OSLinux && limits.IsTrunkingCompatible
+	return found && instance.Os() == config.OSLinux && limits.IsTrunkingCompatible
 
-	// 1, since VPC CNI will not send events for nodes that are labelled as not-supported
-	// 2, since VPC CNI will not keep sending events if nodes have been labelled as true and trunk has been attached
-	// here calling GetNode API will not cause large call volume
-	if node, err := b.apiWrapper.K8sAPI.GetNode(instance.Name()); err != nil {
-		b.log.Error(err, "couldn't get the node when checking if the node is supported for trunk interface", "NodeName", instance.Name())
-	} else {
-		if node.Labels != nil {
-			if _, ok := node.Labels[config.HasTrunkAttachedLabel]; ok {
-				if !supported {
-					labelValue := config.NotSupportedEc2Type
-					updated, err := b.apiWrapper.K8sAPI.AddLabelToManageNode(node, config.HasTrunkAttachedLabel, labelValue)
-					if err != nil {
-						b.log.Error(err, "failed to update node label", "NodeName", instance.Name(), "LabelKey", config.HasTrunkAttachedLabel, "ExpectedLabelValue", labelValue)
-					} else if !updated {
-						b.log.V(1).Info("unable to update node with the existing label key/value pair", "NodeName", instance.Name(), "LabelKey", config.HasTrunkAttachedLabel, "ExpectedLabelValue", labelValue)
-					}
-				}
-			}
-		} else {
-			// at this point, the label map shouldn't be nil
-			// TODO: https://github.com/aws/amazon-vpc-resource-controller-k8s/issues/163
-			b.log.Error(err, "unexpected nil map for node labels", "NodeName", instance.Name())
-		}
-	}
-
-	return supported
 }
 
 func (b *branchENIProvider) Introspect() interface{} {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is for clean up `not-supported` label for not supported ec2 instance type since CNI will also reset as well and not support this label.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
