### PR TITLE
Support GOLANG_IMAGE and BASE_IMAGE variables in Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
+ARG BASE_IMAGE
+ARG BUILD_IMAGE
 # Build the controller binary
-FROM public.ecr.aws/bitnami/golang:1.20.1 as builder
+FROM $BUILD_IMAGE as builder
 
 WORKDIR /workspace
 ENV GOPROXY direct
@@ -28,7 +30,7 @@ RUN GIT_VERSION=$(git describe --tags --always) && \
         CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
         -ldflags="-X ${VERSION_PKG}.GitVersion=${GIT_VERSION} -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" -a -o controller main.go
 
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest.2
+FROM $BASE_IMAGE
 
 WORKDIR /
 COPY --from=public.ecr.aws/eks-distro/kubernetes/go-runner:v0.9.0-eks-1-21-4 /usr/local/bin/go-runner /usr/local/bin/go-runner

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ export GOPROXY = direct
 
 VERSION ?= $(GIT_VERSION)
 IMAGE ?= $(REPO):$(VERSION)
+BASE_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest.2
+BUILD_IMAGE ?= public.ecr.aws/bitnami/golang:1.20.1
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
@@ -68,7 +70,7 @@ generate: controller-gen
 
 # Build the docker image
 docker-build: check-env test
-	docker build . -t ${IMAGE}
+	docker build --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg BUILD_IMAGE=$(BUILD_IMAGE) . -t ${IMAGE}
 
 # Push the docker image
 docker-push: check-env


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This PR allows users to customize GOLANG_IMAGE and BASE_IMAGE for docker builds through Makefile

Ran `BASE_IMAGE=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2023-02-22-1677092456.2 BUILD_IMAGE=public.ecr.aws/eks-distro-build-tooling/golang:1.20-gcc-al2 AWS_ACCOUNT=<REDACTED> AWS_REGION=us-west-2 make docker-build` locally and confirmed the build was succeesfully and the GOLANG_IMAGE and BASE_IMAGE overrides are in place.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
