### PR TITLE
add healthz deep subpathes for all controllers

### DIFF
--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/node/manager/mock_manager.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/node/manager/mock_manager.go
@@ -22,6 +22,7 @@ import (
 
 	node "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/node"
 	gomock "github.com/golang/mock/gomock"
+	healthz "sigs.k8s.io/controller-runtime/pkg/healthz"
 )
 
 // MockManager is a mock of Manager interface.
@@ -73,6 +74,20 @@ func (m *MockManager) DeleteNode(arg0 string) error {
 func (mr *MockManagerMockRecorder) DeleteNode(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockManager)(nil).DeleteNode), arg0)
+}
+
+// GetChecker mocks base method.
+func (m *MockManager) GetChecker() healthz.Checker {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetChecker")
+	ret0, _ := ret[0].(healthz.Checker)
+	return ret0
+}
+
+// GetChecker indicates an expected call of GetChecker.
+func (mr *MockManagerMockRecorder) GetChecker() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChecker", reflect.TypeOf((*MockManager)(nil).GetChecker))
 }
 
 // GetNode mocks base method.

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/provider/mock_provider.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/provider/mock_provider.go
@@ -23,6 +23,7 @@ import (
 	ec2 "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2"
 	pool "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/pool"
 	gomock "github.com/golang/mock/gomock"
+	healthz "sigs.k8s.io/controller-runtime/pkg/healthz"
 	reconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -61,6 +62,20 @@ func (m *MockResourceProvider) DeInitResource(arg0 ec2.EC2Instance) error {
 func (mr *MockResourceProviderMockRecorder) DeInitResource(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeInitResource", reflect.TypeOf((*MockResourceProvider)(nil).DeInitResource), arg0)
+}
+
+// GetHealthChecker mocks base method.
+func (m *MockResourceProvider) GetHealthChecker() healthz.Checker {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHealthChecker")
+	ret0, _ := ret[0].(healthz.Checker)
+	return ret0
+}
+
+// GetHealthChecker indicates an expected call of GetHealthChecker.
+func (mr *MockResourceProviderMockRecorder) GetHealthChecker() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHealthChecker", reflect.TypeOf((*MockResourceProvider)(nil).GetHealthChecker))
 }
 
 // GetPool mocks base method.

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/resource/mock_resources.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/resource/mock_resources.go
@@ -23,6 +23,7 @@ import (
 	handler "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/handler"
 	provider "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider"
 	gomock "github.com/golang/mock/gomock"
+	healthz "sigs.k8s.io/controller-runtime/pkg/healthz"
 )
 
 // MockResourceManager is a mock of ResourceManager interface.
@@ -46,6 +47,20 @@ func NewMockResourceManager(ctrl *gomock.Controller) *MockResourceManager {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockResourceManager) EXPECT() *MockResourceManagerMockRecorder {
 	return m.recorder
+}
+
+// GetCheckers mocks base method.
+func (m *MockResourceManager) GetCheckers() map[string]healthz.Checker {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCheckers")
+	ret0, _ := ret[0].(map[string]healthz.Checker)
+	return ret0
+}
+
+// GetCheckers indicates an expected call of GetCheckers.
+func (mr *MockResourceManagerMockRecorder) GetCheckers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCheckers", reflect.TypeOf((*MockResourceManager)(nil).GetCheckers))
 }
 
 // GetResourceHandler mocks base method.

--- a/pkg/healthz/healthz.go
+++ b/pkg/healthz/healthz.go
@@ -1,0 +1,83 @@
+package healthz
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+type HealthzHandler struct {
+	CheckersMap map[string]healthz.Checker
+}
+
+var (
+	HealthzTimeout time.Duration = 2
+)
+
+func NewHealthzHandler(timeout int) *HealthzHandler {
+	HealthzTimeout = time.Duration(timeout)
+	return &HealthzHandler{
+		CheckersMap: make(map[string]healthz.Checker),
+	}
+}
+
+func (hh *HealthzHandler) AddControllerHealthChecker(name string, controllerCheck healthz.Checker) {
+	// only add health check if the map doesn't already contain
+	if _, ok := hh.CheckersMap[name]; !ok {
+		hh.CheckersMap[name] = controllerCheck
+	}
+}
+
+func (hh *HealthzHandler) AddControllersHealthCheckers(controllerCheckers map[string]healthz.Checker) {
+	for key, value := range controllerCheckers {
+		hh.AddControllerHealthChecker(key, value)
+	}
+}
+
+func (hh *HealthzHandler) AddControllersHealthStatusChecksToManager(mgr manager.Manager) error {
+	if len(hh.CheckersMap) > 0 {
+		return hh.checkControllersHealthStatus(mgr, hh.CheckersMap)
+	} else {
+		return errors.New("couldn't find any controller's check to add for healthz endpoint")
+	}
+}
+
+func (hh *HealthzHandler) checkControllersHealthStatus(mgr manager.Manager, checkers map[string]healthz.Checker) error {
+	var err error
+	for name, check := range checkers {
+		err = mgr.AddHealthzCheck(name, check)
+		fmt.Printf("Added Health check for %s with error %v\n", name, err)
+		if err != nil {
+			break
+		}
+	}
+	return err
+}
+
+func SimplePing(controllerName string, log logr.Logger) healthz.Checker {
+	log.Info(fmt.Sprintf("%s's healthz subpath was added", controllerName))
+	return func(req *http.Request) error {
+		log.V(1).Info(fmt.Sprintf("***** %s healthz endpoint was pinged *****", controllerName))
+		return nil
+	}
+}
+
+func PingWithTimeout(healthCheck func(c chan<- error), logger logr.Logger) error {
+	status := make(chan error, 1)
+	var err error
+	go healthCheck(status)
+
+	select {
+	case err = <-status:
+		logger.V(1).Info("finished healthz check on controller before probing times out", "TimeoutInSecond", HealthzTimeout*time.Second)
+	case <-time.After(HealthzTimeout * time.Second):
+		err = errors.New("healthz check failed due to timeout")
+		logger.Error(err, "healthz check has a preset timeout to fail no responding probing", "TimeoutInSecond", HealthzTimeout*time.Second)
+	}
+	return err
+}

--- a/pkg/healthz/healthz_test.go
+++ b/pkg/healthz/healthz_test.go
@@ -1,0 +1,62 @@
+package healthz
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var testTimeout = 3
+
+// TestHealthzHandler tests creating a new healthz handler with timeout value passed to it
+func TestHealthzHandler(t *testing.T) {
+	handler := NewHealthzHandler(testTimeout)
+	assert.True(t, handler != nil)
+	assert.True(t, HealthzTimeout == time.Duration(testTimeout))
+}
+
+// TestAddControllerHealthChecker tests adding individual healthz checker
+func TestAddControllerHealthChecker(t *testing.T) {
+	handler := NewHealthzHandler(testTimeout)
+	checker := healthz.Ping
+	name := "test-ping"
+	handler.AddControllerHealthChecker(name, checker)
+	assert.True(t, len(handler.CheckersMap) == 1, "Should be only one healthz checker")
+	_, ok := handler.CheckersMap[name]
+	assert.True(t, ok)
+}
+
+// TestAddControllersHealthCheckers tests adding the map of healthz checkers
+func TestAddControllersHealthCheckers(t *testing.T) {
+	handler := NewHealthzHandler(testTimeout)
+	checkers := map[string]healthz.Checker{
+		"test-checker-1": healthz.Ping,
+		"test-checker-2": SimplePing("test", zap.New()),
+	}
+	handler.AddControllersHealthCheckers(checkers)
+	assert.True(t, len(handler.CheckersMap) == 2, "Two checkers should be added")
+}
+
+// TestPingWithTimeout_Success tests ping responding before timeout
+func TestPingWithTimeout_Success(t *testing.T) {
+	err := PingWithTimeout(func(c chan<- error) {
+		time.Sleep(1 * time.Second)
+		c <- nil
+	}, zap.New())
+	time.Sleep(5 * time.Second)
+	assert.NoError(t, err)
+}
+
+// TestPingWithTimeout_Failure tests ping responding after timeout
+func TestPingWithTimeout_Failure(t *testing.T) {
+	err := PingWithTimeout(func(c chan<- error) {
+		time.Sleep(4 * time.Second)
+		c <- nil
+	}, zap.New())
+	time.Sleep(5 * time.Second)
+	assert.Error(t, err)
+	assert.EqualErrorf(t, err, "healthz check failed due to timeout", "Healthz check should fail due to timeout")
+}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -15,16 +15,20 @@ package manager
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/api"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/condition"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+	rcHealthz "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/healthz"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/node"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/resource"
 	asyncWorker "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/worker"
+	"github.com/google/uuid"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
@@ -84,7 +88,7 @@ type AsyncOperationJob struct {
 
 // NewNodeManager returns a new node manager
 func NewNodeManager(logger logr.Logger, resourceManager resource.ResourceManager,
-	wrapper api.Wrapper, worker asyncWorker.Worker, conditions condition.Conditions) (Manager, error) {
+	wrapper api.Wrapper, worker asyncWorker.Worker, conditions condition.Conditions, healthzHandler *rcHealthz.HealthzHandler) (Manager, error) {
 
 	manager := &manager{
 		resourceManager: resourceManager,
@@ -94,6 +98,11 @@ func NewNodeManager(logger logr.Logger, resourceManager resource.ResourceManager
 		worker:          worker,
 		conditions:      conditions,
 	}
+
+	// add health check on subpath for node manager
+	healthzHandler.AddControllersHealthCheckers(
+		map[string]healthz.Checker{"health-node-manager": manager.check()},
+	)
 
 	return manager, worker.StartWorkerPool(manager.performAsyncOperation)
 }
@@ -404,14 +413,19 @@ func (m *manager) removeNodeSafe(nodeName string) {
 	delete(m.dataStore, nodeName)
 }
 
-func (m *manager) updateNodeTrunkLabel(nodeName, labelKey, labelValue string) error {
-	if node, err := m.wrapper.K8sAPI.GetNode(nodeName); err != nil {
-		return err
-	} else {
-		updated, err := m.wrapper.K8sAPI.AddLabelToManageNode(node, labelKey, labelValue)
-		if !updated {
-			m.Log.Info("failed updating the node label for trunk when operating on node", "NodeName", nodeName, "LabelKey", labelKey, "LabelValue", labelValue)
-		}
+func (m *manager) check() healthz.Checker {
+	// instead of using SimplePing, testing the node cache from manager makes the test more accurate
+	return func(req *http.Request) error {
+		err := rcHealthz.PingWithTimeout(func(c chan<- error) {
+			randomName := uuid.New().String()
+			_, found := m.GetNode(randomName)
+			m.Log.V(1).Info("health check tested ping GetNode to check on datastore cache in node manager successfully", "TesedNodeName", randomName, "NodeFound", found)
+			var ping interface{}
+			m.worker.SubmitJob(ping)
+			m.Log.V(1).Info("health check tested ping SubmitJob with a nil job to check on worker queue in node manager successfully")
+			c <- nil
+		}, m.Log)
+
 		return err
 	}
 }

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -26,6 +26,7 @@ import (
 	mock_worker "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/worker"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/api"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/healthz"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/node"
 
 	"github.com/golang/mock/gomock"
@@ -71,6 +72,8 @@ var (
 
 	unManagedNode = node.NewUnManagedNode(zap.New(), nodeName, instanceID, config.OSLinux)
 	managedNode   = node.NewManagedNode(zap.New(), nodeName, instanceID, config.OSLinux)
+
+	healthzHandler = healthz.NewHealthzHandler(5)
 )
 
 type AsyncJobMatcher struct {
@@ -144,7 +147,7 @@ func Test_GetNewManager(t *testing.T) {
 	mock := NewMock(ctrl, map[string]node.Node{})
 
 	mock.MockWorker.EXPECT().StartWorkerPool(gomock.Any()).Return(nil)
-	manager, err := NewNodeManager(zap.New(), nil, api.Wrapper{}, mock.MockWorker, mock.MockConditions)
+	manager, err := NewNodeManager(zap.New(), nil, api.Wrapper{}, mock.MockWorker, mock.MockConditions, healthzHandler)
 
 	assert.NotNil(t, manager)
 	assert.NoError(t, err)
@@ -158,7 +161,7 @@ func Test_GetNewManager_Error(t *testing.T) {
 	mock := NewMock(ctrl, map[string]node.Node{})
 
 	mock.MockWorker.EXPECT().StartWorkerPool(gomock.Any()).Return(mockError)
-	manager, err := NewNodeManager(zap.New(), nil, api.Wrapper{}, mock.MockWorker, mock.MockConditions)
+	manager, err := NewNodeManager(zap.New(), nil, api.Wrapper{}, mock.MockWorker, mock.MockConditions, healthzHandler)
 
 	assert.NotNil(t, manager)
 	assert.Error(t, err, mockError)

--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 	"sync"
 	"time"
@@ -25,16 +26,19 @@ import (
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/vpc"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+	rcHealthz "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/healthz"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/pool"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/branch/trunk"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/worker"
+	"github.com/google/uuid"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -94,6 +98,7 @@ type branchENIProvider struct {
 	// apiWrapper
 	apiWrapper api.Wrapper
 	ctx        context.Context
+	checker    healthz.Checker
 }
 
 // NewBranchENIProvider returns the Branch ENI Provider for all nodes across the cluster
@@ -102,13 +107,15 @@ func NewBranchENIProvider(logger logr.Logger, wrapper api.Wrapper,
 	prometheusRegister()
 	trunk.PrometheusRegister()
 
-	return &branchENIProvider{
+	provider := &branchENIProvider{
 		apiWrapper:    wrapper,
 		log:           logger,
 		workerPool:    worker,
 		trunkENICache: make(map[string]trunk.TrunkENI),
 		ctx:           ctx,
 	}
+	provider.checker = provider.check()
+	return provider
 }
 
 // prometheusRegister registers prometheus metrics
@@ -485,4 +492,27 @@ func (b *branchENIProvider) IntrospectNode(nodeName string) interface{} {
 		return struct{}{}
 	}
 	return trunkENI.Introspect()
+}
+
+func (b *branchENIProvider) check() healthz.Checker {
+	b.log.Info("Branch provider's healthz subpath was added")
+	return func(req *http.Request) error {
+		err := rcHealthz.PingWithTimeout(func(c chan<- error) {
+			var ping interface{}
+			// check on job queue
+			b.SubmitAsyncJob(ping)
+			// check on trunk cache map
+			testNodeName := "test-node" + uuid.New().String()
+			trunk, found := b.getTrunkFromCache(testNodeName)
+			b.log.V(1).Info("healthz check vulnerable site on locks around trunk map", "TestTrunk", trunk, "FoundInCache", found)
+			b.log.V(1).Info("***** health check on branch ENI provider tested SubmitAsyncJob *****")
+			c <- nil
+		}, b.log)
+
+		return err
+	}
+}
+
+func (b *branchENIProvider) GetHealthChecker() healthz.Checker {
+	return b.checker
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/pool"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 )
 
 // ResourceProvider is the provider interface that each resource managed by the controller has to implement
@@ -39,4 +40,6 @@ type ResourceProvider interface {
 	Introspect() interface{}
 	// IntrospectNode allows introspection of a node for the given resource
 	IntrospectNode(node string) interface{}
+	// GetHealthChecker provider a health check subpath for pinging provider
+	GetHealthChecker() healthz.Checker
 }

--- a/pkg/resource/introspect.go
+++ b/pkg/resource/introspect.go
@@ -18,8 +18,10 @@ import (
 	"encoding/json"
 	"net/http"
 
+	rcHealthz "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/healthz"
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 )
 
 const (
@@ -93,6 +95,11 @@ func (i *IntrospectHandler) NodeResourceHandler(w http.ResponseWriter, r *http.R
 	w.Write(jsonData)
 }
 
-func (i *IntrospectHandler) SetupWithManager(mgr ctrl.Manager) error {
+func (i *IntrospectHandler) SetupWithManager(mgr ctrl.Manager, healthzHanlder *rcHealthz.HealthzHandler) error {
+	// add health check on subpath for introspect controller
+	healthzHanlder.AddControllersHealthCheckers(
+		map[string]healthz.Checker{"health-introspect-controller": rcHealthz.SimplePing("Introspect controller", i.Log)},
+	)
+
 	return mgr.Add(i)
 }

--- a/pkg/resource/manager_test.go
+++ b/pkg/resource/manager_test.go
@@ -17,17 +17,21 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/handler"
+	mock_handler "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/handler"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/api"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/healthz"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 type Mock struct {
 	Handler *mock_handler.MockHandler
 	Wrapper api.Wrapper
 }
+
+var healthzHandler = healthz.NewHealthzHandler(5)
 
 func NewMock(controller *gomock.Controller) Mock {
 	return Mock{
@@ -43,7 +47,7 @@ func Test_NewResourceManager(t *testing.T) {
 	mock := NewMock(ctrl)
 	resources := []string{config.ResourceNamePodENI, config.ResourceNameIPAddress}
 
-	manger, err := NewResourceManager(context.TODO(), resources, mock.Wrapper)
+	manger, err := NewResourceManager(context.TODO(), resources, mock.Wrapper, zap.New(zap.UseDevMode(true)), healthzHandler)
 	assert.NoError(t, err)
 
 	_, ok := manger.GetResourceHandler(config.ResourceNamePodENI)

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -126,6 +126,12 @@ func (w *worker) SetWorkerFunc(workerFunc func(interface{}) (ctrl.Result, error)
 
 // SubmitJob adds the job to the rate limited queue
 func (w *worker) SubmitJob(job interface{}) {
+	// in theory, only health check endpoint should send a nil job to test periodically
+	if job == nil {
+		queueLen := w.queue.Len()
+		w.Log.V(1).Info("For informational / health check purpose only to check worker queue availability", "WorkerQueueLen", queueLen)
+		return
+	}
 	w.queue.Add(job)
 	jobsSubmittedCount.WithLabelValues(w.resourceName).Inc()
 }

--- a/webhooks/core/pod_webhook_test.go
+++ b/webhooks/core/pod_webhook_test.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/condition"
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/utils"
+	mock_condition "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/condition"
+	mock_utils "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/utils"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 
 	"github.com/golang/mock/gomock"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We want to add deep health check probes into individual controllers. 

The current healthz `ping` is simple and basically just checking if the VPC RC manager goroutine (main routine) is not failing. Reported customers’ cases told us the main check may not be sufficient in some cases. What we want
- if one goroutine blocks resources, the healthz need to restart the entire controller
- the healthz probes should cover all sub controllers
- the heatlhz probe should have its own timeout instead of rely on kubelet timeout
- the health status monitored by kubelet should be aggregated (one failure should fails all)
- simple ping or complicate probing real data should depend on how critical and vulnerable the targeted controller may be.


Tests have been done
```
[+]health-annotation-validating-webhook ok
[+]health-branch-provider ok
[+]health-cm-controller ok
[+]health-custom-pod-controller ok
[+]health-deploy-controller ok
[+]health-interface-cleaner ok
[+]health-introspect-controller ok
[+]health-ipv4-provider ok
[+]health-node-controller ok
[+]health-node-manager ok
[+]health-node-validating-webhook ok
[+]health-pod-controller ok
[+]health-pod-mutating-webhook ok
[+]health-resource-manager ok
[+]health-root-manager-ping ok
healthz check passed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
