### PR TITLE
added a new condition to check for prefix delegation flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -275,16 +275,15 @@ func main() {
 		SGPAPI: sgpAPI,
 	}
 
+	// hasPodDataStoreSynced is set to true when the custom controller has synced
+	controllerConditions := condition.NewControllerConditions(
+		ctrl.Log.WithName("controller conditions"), k8sApi)
 	supportedResources := []string{config.ResourceNamePodENI, config.ResourceNameIPAddress}
-	resourceManager, err := resource.NewResourceManager(ctx, supportedResources, apiWrapper)
+	resourceManager, err := resource.NewResourceManager(ctx, supportedResources, apiWrapper, controllerConditions)
 	if err != nil {
 		ctrl.Log.Error(err, "failed to init resources", "resources", supportedResources)
 		os.Exit(1)
 	}
-
-	// hasPodDataStoreSynced is set to true when the custom controller has synced
-	controllerConditions := condition.NewControllerConditions(
-		ctrl.Log.WithName("controller conditions"), k8sApi)
 
 	nodeManagerWorkers := asyncWorkers.NewDefaultWorkerPool("node async workers",
 		10, 1, ctrl.Log.WithName("node async workers"), ctx)

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/condition/mock_condition.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/condition/mock_condition.go
@@ -88,6 +88,20 @@ func (mr *MockConditionsMockRecorder) IsWindowsIPAMEnabled() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWindowsIPAMEnabled", reflect.TypeOf((*MockConditions)(nil).IsWindowsIPAMEnabled))
 }
 
+// IsWindowsIPAMEnabled mocks base method.
+func (m *MockConditions) IsWindowsPrefixDelegationEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsWindowsPrefixDelegationEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsWindowsIPAMEnabled indicates an expected call of IsWindowsIPAMEnabled.
+func (mr *MockConditionsMockRecorder) IsWindowsPrefixDelegationEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWindowsPrefixDelegationEnabled", reflect.TypeOf((*MockConditions)(nil).IsWindowsPrefixDelegationEnabled))
+}
+
 // SetPodDataStoreSyncStatus mocks base method.
 func (m *MockConditions) SetPodDataStoreSyncStatus(arg0 bool) {
 	m.ctrl.T.Helper()

--- a/pkg/condition/conditions.go
+++ b/pkg/condition/conditions.go
@@ -39,6 +39,10 @@ type Conditions interface {
 	// IsWindowsIPAMEnabled to process events only when Windows IPAM is enabled
 	// by the user
 	IsWindowsIPAMEnabled() bool
+
+	// IsWindowsPrefixDelegationEnabled to process events only when Windows Prefix Delegation is enabled
+	IsWindowsPrefixDelegationEnabled() bool
+
 	// IsPodSGPEnabled to process events only when Security Group for Pods feature
 	// is enabled by the user
 	// IsPodSGPEnabled() bool We need to check if SGP is enabled via ConfigMap + Environment variables
@@ -61,6 +65,12 @@ var (
 			Help: "Binary value to indicate whether user has set enable-windows-ipam to true",
 		})
 
+	conditionWindowsPrefixDelegationEnabled = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "windows_prefix_delegation_enabled",
+			Help: "Binary value to indicate whether user has set enable-windows-prefix-delegation to true",
+		})
+
 	prometheusRegistered = false
 )
 
@@ -68,6 +78,7 @@ func prometheusRegister() {
 	if !prometheusRegistered {
 		metrics.Registry.MustRegister(
 			conditionWindowsIPAMEnabled,
+			conditionWindowsPrefixDelegationEnabled,
 		)
 	}
 
@@ -77,6 +88,7 @@ func prometheusRegister() {
 func NewControllerConditions(log logr.Logger, k8sApi k8s.K8sWrapper) Conditions {
 	prometheusRegister()
 	conditionWindowsIPAMEnabled.Set(0)
+	conditionWindowsPrefixDelegationEnabled.Set(0)
 
 	return &condition{
 		log:    log,
@@ -103,6 +115,35 @@ func (c *condition) IsWindowsIPAMEnabled() bool {
 	}
 
 	conditionWindowsIPAMEnabled.Set(0)
+	return false
+}
+
+func (c *condition) IsWindowsPrefixDelegationEnabled() bool {
+	if c.IsOldVPCControllerDeploymentPresent() {
+		return false
+	}
+
+	// Return false if configmap not present/any errors
+	vpcCniConfigMap, err := c.K8sAPI.GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace)
+
+	if err == nil && vpcCniConfigMap.Data != nil {
+		if ipamVal, ok := vpcCniConfigMap.Data[config.EnableWindowsIPAMKey]; ok {
+			// Check if Windows IPAM is enabled
+			enableWinIpamVal, err := strconv.ParseBool(ipamVal)
+			if err == nil && enableWinIpamVal {
+				if pdVal, ok := vpcCniConfigMap.Data[config.EnableWindowsPrefixDelegationKey]; ok {
+					enableWinPDVal, err := strconv.ParseBool(pdVal)
+					// Check if Windows PD is enabled
+					if err == nil && enableWinPDVal {
+						conditionWindowsPrefixDelegationEnabled.Set(1)
+						return true
+					}
+				}
+			}
+		}
+	}
+
+	conditionWindowsPrefixDelegationEnabled.Set(0)
 	return false
 }
 

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -66,10 +66,11 @@ const (
 )
 
 const (
-	LeaderElectionKey       = "cp-vpc-resource-controller"
-	LeaderElectionNamespace = "kube-system"
-	VpcCniConfigMapName     = "amazon-vpc-cni"
-	EnableWindowsIPAMKey    = "enable-windows-ipam"
+	LeaderElectionKey                = "cp-vpc-resource-controller"
+	LeaderElectionNamespace          = "kube-system"
+	VpcCniConfigMapName              = "amazon-vpc-cni"
+	EnableWindowsIPAMKey             = "enable-windows-ipam"
+	EnableWindowsPrefixDelegationKey = "enable-windows-prefix-delegation"
 	// Since LeaderElectionNamespace and VpcCniConfigMapName may be different in the future
 	KubeSystemNamespace            = "kube-system"
 	VpcCNIDaemonSetName            = "aws-node"

--- a/pkg/resource/manager.go
+++ b/pkg/resource/manager.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/api"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/condition"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/handler"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider"
@@ -42,7 +43,7 @@ type ResourceManager interface {
 	GetResourceHandler(resourceName string) (handler.Handler, bool)
 }
 
-func NewResourceManager(ctx context.Context, resourceNames []string, wrapper api.Wrapper) (ResourceManager, error) {
+func NewResourceManager(ctx context.Context, resourceNames []string, wrapper api.Wrapper, conditions condition.Conditions) (ResourceManager, error) {
 	// Load that static configuration of the resource
 	resourceConfig := config.LoadResourceConfig()
 
@@ -70,7 +71,7 @@ func NewResourceManager(ctx context.Context, resourceNames []string, wrapper api
 
 		if resourceName == config.ResourceNameIPAddress {
 			resourceProvider = ip.NewIPv4Provider(ctrl.Log.WithName("ipv4 provider"),
-				wrapper, workers, resourceConfig)
+				wrapper, workers, resourceConfig, conditions)
 			resourceHandler = handler.NewWarmResourceHandler(ctrl.Log.WithName(resourceName), wrapper,
 				resourceName, resourceProvider, ctx)
 		} else if resourceName == config.ResourceNamePodENI {

--- a/pkg/resource/manager_test.go
+++ b/pkg/resource/manager_test.go
@@ -18,10 +18,13 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/handler"
+	mock_k8s "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/api"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/condition"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 type Mock struct {
@@ -42,8 +45,9 @@ func Test_NewResourceManager(t *testing.T) {
 
 	mock := NewMock(ctrl)
 	resources := []string{config.ResourceNamePodENI, config.ResourceNameIPAddress}
-
-	manger, err := NewResourceManager(context.TODO(), resources, mock.Wrapper)
+	mockK8s := mock_k8s.NewMockK8sWrapper(ctrl)
+	conditions := condition.NewControllerConditions(zap.New(), mockK8s)
+	manger, err := NewResourceManager(context.TODO(), resources, mock.Wrapper, conditions)
 	assert.NoError(t, err)
 
 	_, ok := manger.GetResourceHandler(config.ResourceNamePodENI)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added a new condition to check for prefix delegation flag in config map `amazon-vpc-cni`, so that resource manager can pass it to resource provider, which will use the condition to initialize resource pools accordingly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
