### PR TITLE
updated configmap controller to reconcile when PD flag is toggled

### DIFF
--- a/controllers/core/configmap_controller.go
+++ b/controllers/core/configmap_controller.go
@@ -32,12 +32,13 @@ import (
 // ConfigMapReconciler reconciles a ConfigMap object
 type ConfigMapReconciler struct {
 	client.Client
-	Log                   logr.Logger
-	Scheme                *runtime.Scheme
-	NodeManager           manager.Manager
-	K8sAPI                k8s.K8sWrapper
-	Condition             condition.Conditions
-	curWinIPAMEnabledCond bool
+	Log                               logr.Logger
+	Scheme                            *runtime.Scheme
+	NodeManager                       manager.Manager
+	K8sAPI                            k8s.K8sWrapper
+	Condition                         condition.Conditions
+	curWinIPAMEnabledCond             bool
+	curWinPrefixDelegationEnabledCond bool
 }
 
 //+kubebuilder:rbac:groups=core,resources=configmaps,namespace=kube-system,resourceNames=amazon-vpc-cni,verbs=get;list;watch
@@ -67,11 +68,27 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Check if the flag value has changed
 	newWinIPAMEnabledCond := r.Condition.IsWindowsIPAMEnabled()
 
+	var isIPAMFlagUpdated bool
 	if r.curWinIPAMEnabledCond != newWinIPAMEnabledCond {
 		r.curWinIPAMEnabledCond = newWinIPAMEnabledCond
 		logger.Info("updated configmap", config.EnableWindowsIPAMKey, r.curWinIPAMEnabledCond)
 
-		// Flag is updated, update all nodes
+		isIPAMFlagUpdated = true
+	}
+
+	// Check if the prefix delegation flag has changed
+	newWinPrefixDelegationEnabledCond := r.Condition.IsWindowsPrefixDelegationEnabled()
+
+	var isPrefixFlagUpdated bool
+	if r.curWinPrefixDelegationEnabledCond != newWinPrefixDelegationEnabledCond {
+		r.curWinPrefixDelegationEnabledCond = newWinPrefixDelegationEnabledCond
+		logger.Info("updated configmap", config.EnableWindowsPrefixDelegationKey, r.curWinPrefixDelegationEnabledCond)
+
+		isPrefixFlagUpdated = true
+	}
+
+	// Flag is updated, update all nodes
+	if isIPAMFlagUpdated || isPrefixFlagUpdated {
 		err := UpdateNodesOnConfigMapChanges(r.K8sAPI, r.NodeManager)
 		if err != nil {
 			// Error in updating nodes

--- a/controllers/core/configmap_controller_test.go
+++ b/controllers/core/configmap_controller_test.go
@@ -38,7 +38,12 @@ var (
 	mockConfigMap = &corev1.ConfigMap{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{Name: config.VpcCniConfigMapName, Namespace: config.KubeSystemNamespace},
-		Data:       map[string]string{config.EnableWindowsIPAMKey: "true"},
+		Data:       map[string]string{config.EnableWindowsIPAMKey: "true", config.EnableWindowsPrefixDelegationKey: "true"},
+	}
+	mockConfigMapPD = &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: config.VpcCniConfigMapName, Namespace: config.KubeSystemNamespace},
+		Data:       map[string]string{config.EnableWindowsIPAMKey: "false", config.EnableWindowsPrefixDelegationKey: "true"},
 	}
 	mockConfigMapReq = reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -59,12 +64,13 @@ var (
 )
 
 type ConfigMapMock struct {
-	MockNodeManager     *mock_manager.MockManager
-	ConfigMapReconciler *ConfigMapReconciler
-	MockNode            *mock_node.MockNode
-	MockK8sAPI          *mock_k8s.MockK8sWrapper
-	MockCondition       *mock_condition.MockConditions
-	curWinIPAMCond      bool
+	MockNodeManager            *mock_manager.MockManager
+	ConfigMapReconciler        *ConfigMapReconciler
+	MockNode                   *mock_node.MockNode
+	MockK8sAPI                 *mock_k8s.MockK8sWrapper
+	MockCondition              *mock_condition.MockConditions
+	curWinIPAMCond             bool
+	curWinPrefixDelegationCond bool
 }
 
 func NewConfigMapMock(ctrl *gomock.Controller, mockObjects ...runtime.Object) ConfigMapMock {
@@ -86,10 +92,11 @@ func NewConfigMapMock(ctrl *gomock.Controller, mockObjects ...runtime.Object) Co
 			K8sAPI:      mockK8sWrapper,
 			Condition:   mockCondition,
 		},
-		MockNode:       mockNode,
-		MockK8sAPI:     mockK8sWrapper,
-		MockCondition:  mockCondition,
-		curWinIPAMCond: false,
+		MockNode:                   mockNode,
+		MockK8sAPI:                 mockK8sWrapper,
+		MockCondition:              mockCondition,
+		curWinIPAMCond:             false,
+		curWinPrefixDelegationCond: false,
 	}
 }
 
@@ -99,9 +106,24 @@ func Test_Reconcile_ConfigMap_Updated(t *testing.T) {
 
 	mock := NewConfigMapMock(ctrl, mockConfigMap)
 	mock.MockCondition.EXPECT().IsWindowsIPAMEnabled().Return(true)
+	mock.MockCondition.EXPECT().IsWindowsPrefixDelegationEnabled().Return(true)
 	mock.MockK8sAPI.EXPECT().ListNodes().Return(nodeList, nil)
 	mock.MockNodeManager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, true)
 	mock.MockNodeManager.EXPECT().UpdateNode(mockNodeName).Return(nil)
+
+	res, err := mock.ConfigMapReconciler.Reconcile(context.TODO(), mockConfigMapReq)
+	assert.NoError(t, err)
+	assert.Equal(t, res, reconcile.Result{})
+
+}
+
+func Test_Reconcile_ConfigMap_PD_Disabled_If_IPAM_Disabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := NewConfigMapMock(ctrl, mockConfigMapPD)
+	mock.MockCondition.EXPECT().IsWindowsIPAMEnabled().Return(false)
+	mock.MockCondition.EXPECT().IsWindowsPrefixDelegationEnabled().Return(false)
 
 	res, err := mock.ConfigMapReconciler.Reconcile(context.TODO(), mockConfigMapReq)
 	assert.NoError(t, err)
@@ -118,7 +140,7 @@ func Test_Reconcile_ConfigMap_NoData(t *testing.T) {
 	mock := NewConfigMapMock(ctrl, mockConfigMap_WithNoData)
 
 	mock.MockCondition.EXPECT().IsWindowsIPAMEnabled().Return(false)
-
+	mock.MockCondition.EXPECT().IsWindowsPrefixDelegationEnabled().Return(false)
 	res, err := mock.ConfigMapReconciler.Reconcile(context.TODO(), mockConfigMapReq)
 	assert.NoError(t, err)
 	assert.Equal(t, res, reconcile.Result{})
@@ -130,6 +152,7 @@ func Test_Reconcile_ConfigMap_Deleted(t *testing.T) {
 
 	mock := NewConfigMapMock(ctrl)
 	mock.MockCondition.EXPECT().IsWindowsIPAMEnabled().Return(false)
+	mock.MockCondition.EXPECT().IsWindowsPrefixDelegationEnabled().Return(false)
 
 	res, err := mock.ConfigMapReconciler.Reconcile(context.TODO(), mockConfigMapReq)
 	assert.NoError(t, err)
@@ -142,6 +165,7 @@ func Test_Reconcile_UpdateNode_Error(t *testing.T) {
 
 	mock := NewConfigMapMock(ctrl, mockConfigMap)
 	mock.MockCondition.EXPECT().IsWindowsIPAMEnabled().Return(true)
+	mock.MockCondition.EXPECT().IsWindowsPrefixDelegationEnabled().Return(false)
 	mock.MockK8sAPI.EXPECT().ListNodes().Return(nodeList, nil)
 	mock.MockNodeManager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, true)
 	mock.MockNodeManager.EXPECT().UpdateNode(mockNodeName).Return(errMock)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added a check in config map controller to reconcile when PD flag is updated. Only update nodes when either Windows IPAM flag or PD flag is changed.
- Added a test to make sure if Windows IPAM is not enabled, then even if PD flag is set to `true` in config map, PD feature will not be enabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
