### PR TITLE
Updated IP provider to support PD feature toggles

### DIFF
--- a/pkg/provider/ip/provider.go
+++ b/pkg/provider/ip/provider.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/api"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2"
-	ec2api "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2/api"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/vpc"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/condition"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
@@ -266,7 +265,7 @@ func (p *ipv4Provider) CreatePrivateIPv4AndUpdatePool(job *worker.WarmPoolJob) {
 		return
 	}
 	didSucceed := true
-	ips, err := instanceResource.eniManager.CreateIPV4Resource(job.ResourceCount, ec2api.ResourceTypeIPv4Address, p.apiWrapper.EC2API, p.log)
+	ips, err := instanceResource.eniManager.CreateIPV4Resource(job.ResourceCount, config.ResourceTypeIPv4Address, p.apiWrapper.EC2API, p.log)
 	if err != nil {
 		p.log.Error(err, "failed to create all/some of the IPv4 addresses", "created ips", ips)
 		didSucceed = false
@@ -301,7 +300,7 @@ func (p *ipv4Provider) DeletePrivateIPv4AndUpdatePool(job *worker.WarmPoolJob) {
 		return
 	}
 	didSucceed := true
-	failedIPs, err := instanceResource.eniManager.DeleteIPV4Resource(job.Resources, ec2api.ResourceTypeIPv4Address, p.apiWrapper.EC2API, p.log)
+	failedIPs, err := instanceResource.eniManager.DeleteIPV4Resource(job.Resources, config.ResourceTypeIPv4Address, p.apiWrapper.EC2API, p.log)
 	if err != nil {
 		p.log.Error(err, "failed to delete all/some of the IPv4 addresses", "failed ips", failedIPs)
 		didSucceed = false


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added support for toggling between two IP allocation modes. If toggling from secondary IP to PD, secondary IP provider will drain its pool. If toggling from PD to secondary IP mode, IP provider will set its pool to active state by passing in a valid default resource config. 
- Updated capacity calculation to take into account existing IPv4 prefixes.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
