### PR TITLE
enable node events when instance type is not supported

### DIFF
--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/node/mock_node.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/node/mock_node.go
@@ -20,7 +20,6 @@ package mock_node
 import (
 	reflect "reflect"
 
-	api "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2/api"
 	resource "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/resource"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -49,17 +48,17 @@ func (m *MockNode) EXPECT() *MockNodeMockRecorder {
 }
 
 // DeleteResources mocks base method.
-func (m *MockNode) DeleteResources(arg0 resource.ResourceManager, arg1 api.EC2APIHelper) error {
+func (m *MockNode) DeleteResources(arg0 resource.ResourceManager) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteResources", arg0, arg1)
+	ret := m.ctrl.Call(m, "DeleteResources", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteResources indicates an expected call of DeleteResources.
-func (mr *MockNodeMockRecorder) DeleteResources(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) DeleteResources(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResources", reflect.TypeOf((*MockNode)(nil).DeleteResources), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResources", reflect.TypeOf((*MockNode)(nil).DeleteResources), arg0)
 }
 
 // GetNodeInstanceID mocks base method.
@@ -91,17 +90,17 @@ func (mr *MockNodeMockRecorder) HasInstance() *gomock.Call {
 }
 
 // InitResources mocks base method.
-func (m *MockNode) InitResources(arg0 resource.ResourceManager, arg1 api.EC2APIHelper) error {
+func (m *MockNode) InitResources(arg0 resource.ResourceManager) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitResources", arg0, arg1)
+	ret := m.ctrl.Call(m, "InitResources", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InitResources indicates an expected call of InitResources.
-func (mr *MockNodeMockRecorder) InitResources(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) InitResources(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitResources", reflect.TypeOf((*MockNode)(nil).InitResources), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitResources", reflect.TypeOf((*MockNode)(nil).InitResources), arg0)
 }
 
 // IsManaged mocks base method.
@@ -145,15 +144,15 @@ func (mr *MockNodeMockRecorder) UpdateCustomNetworkingSpecs(arg0, arg1 interface
 }
 
 // UpdateResources mocks base method.
-func (m *MockNode) UpdateResources(arg0 resource.ResourceManager, arg1 api.EC2APIHelper) error {
+func (m *MockNode) UpdateResources(arg0 resource.ResourceManager) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateResources", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateResources", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateResources indicates an expected call of UpdateResources.
-func (mr *MockNodeMockRecorder) UpdateResources(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) UpdateResources(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateResources", reflect.TypeOf((*MockNode)(nil).UpdateResources), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateResources", reflect.TypeOf((*MockNode)(nil).UpdateResources), arg0)
 }

--- a/pkg/aws/ec2/instance.go
+++ b/pkg/aws/ec2/instance.go
@@ -115,7 +115,7 @@ func (i *ec2Instance) LoadDetails(ec2APIHelper api.EC2APIHelper) error {
 	i.instanceType = *instance.InstanceType
 	limits, ok := vpc.Limits[i.instanceType]
 	if !ok {
-		return fmt.Errorf("unsupported instance type, couldn't find ENI Limit for instance %s", i.instanceType)
+		return fmt.Errorf("unsupported instance type, couldn't find ENI Limit for instance %s, error: %w", i.instanceType, utils.ErrNotFound)
 	}
 
 	defaultCardIdx := limits.DefaultNetworkCardIndex

--- a/pkg/aws/ec2/instance_test.go
+++ b/pkg/aws/ec2/instance_test.go
@@ -17,7 +17,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/api"
+	mock_api "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/api"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/utils"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -258,6 +259,8 @@ func TestEc2Instance_LoadDetails_InstanceENILimitNotFound(t *testing.T) {
 
 	err := ec2Instance.LoadDetails(mockEC2ApiHelper)
 	assert.NotNil(t, err)
+	// ensure the expected error is returned to trigger a node event
+	assert.ErrorIs(t, err, utils.ErrNotFound)
 
 	// Clean up
 	nwInterfaces.InstanceType = &instanceType

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -71,7 +71,7 @@ var (
 	mockError = fmt.Errorf("mock error")
 
 	unManagedNode = node.NewUnManagedNode(zap.New(), nodeName, instanceID, config.OSLinux)
-	managedNode   = node.NewManagedNode(zap.New(), nodeName, instanceID, config.OSLinux)
+	managedNode   = node.NewManagedNode(zap.New(), nodeName, instanceID, config.OSLinux, nil, nil)
 
 	healthzHandler = healthz.NewHealthzHandler(5)
 )
@@ -432,19 +432,19 @@ func Test_performAsyncOperation(t *testing.T) {
 	job.op = Init
 
 	mock.MockK8sAPI.EXPECT().AddLabelToManageNode(v1Node, config.HasTrunkAttachedLabel, config.BooleanTrue).Return(true, nil).AnyTimes()
-	mock.MockNode.EXPECT().InitResources(mock.MockResourceManager, mock.MockEC2API).Return(nil)
-	mock.MockNode.EXPECT().UpdateResources(mock.MockResourceManager, mock.MockEC2API).Return(nil)
+	mock.MockNode.EXPECT().InitResources(mock.MockResourceManager).Return(nil)
+	mock.MockNode.EXPECT().UpdateResources(mock.MockResourceManager).Return(nil)
 	_, err := mock.Manager.performAsyncOperation(job)
 	assert.Contains(t, mock.Manager.dataStore, nodeName)
 	assert.NoError(t, err)
 
 	job.op = Update
-	mock.MockNode.EXPECT().UpdateResources(mock.MockResourceManager, mock.MockEC2API).Return(nil)
+	mock.MockNode.EXPECT().UpdateResources(mock.MockResourceManager).Return(nil)
 	_, err = mock.Manager.performAsyncOperation(job)
 	assert.NoError(t, err)
 
 	job.op = Delete
-	mock.MockNode.EXPECT().DeleteResources(mock.MockResourceManager, mock.MockEC2API).Return(nil)
+	mock.MockNode.EXPECT().DeleteResources(mock.MockResourceManager).Return(nil)
 	_, err = mock.Manager.performAsyncOperation(job)
 	assert.NoError(t, err)
 
@@ -465,7 +465,7 @@ func Test_performAsyncOperation_fail(t *testing.T) {
 		op:       Init,
 	}
 
-	mock.MockNode.EXPECT().InitResources(mock.MockResourceManager, mock.MockEC2API).Return(&node.ErrInitResources{})
+	mock.MockNode.EXPECT().InitResources(mock.MockResourceManager).Return(&node.ErrInitResources{})
 
 	_, err := mock.Manager.performAsyncOperation(job)
 	assert.NotContains(t, mock.Manager.dataStore, nodeName) // It should be cleared from cache

--- a/pkg/provider/ip/eni/eni.go
+++ b/pkg/provider/ip/eni/eni.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2/api"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/vpc"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/utils"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/go-logr/logr"
@@ -71,7 +72,7 @@ func (e *eniManager) InitResources(ec2APIHelper api.EC2APIHelper) ([]string, err
 
 	limits, found := vpc.Limits[e.instance.Type()]
 	if !found {
-		return nil, fmt.Errorf("unsupported instance type")
+		return nil, fmt.Errorf("unsupported instance type, error: %w", utils.ErrNotFound)
 	}
 
 	ipLimit := limits.IPv4PerInterface

--- a/pkg/utils/errors.go
+++ b/pkg/utils/errors.go
@@ -1,0 +1,7 @@
+package utils
+
+import "errors"
+
+var (
+	ErrNotFound = errors.New("resource was not found")
+)

--- a/pkg/utils/events.go
+++ b/pkg/utils/events.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/k8s"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var (
+	unsupportedInstanceTypeReason = "Unsupported"
+)
+
+func SendNodeEvent(client k8s.K8sWrapper, nodeName, reason, msg, eventType string, logger logr.Logger) {
+	if node, err := client.GetNode(nodeName); err == nil {
+		// set UID to node name for kubelet filter the event to node description
+		node.SetUID(types.UID(nodeName))
+		client.BroadcastEvent(node, unsupportedInstanceTypeReason, msg, eventType)
+	} else {
+		logger.Error(err, "had an error to get the node for sending unsupported event", "Node", nodeName)
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since this controller runs in EKS control plane, if the instance type is not supported, the error message is not available for users. To make users' debugging easier and better visibility, we should expose some of critical failures that can be mitigated from user side. Events are common use for this purpose. This change propose sending node event when 
- new instance types are not included to support for this controller (Linux SGP feature or Windows)
- instance types are in the supported types list but doesn't support trunk interface (SGP feature)

Other changes:
- refactoring how passing client to node/instance. Since node is k8s object and also carry AWS instance, I think it is making sense to add k8s/ec2 clients into node struct instead of need pass them to functions when calling node resources.
- updating unit tests

Tests:
The unsupported and mocked missing instance types were used to test the events

case 1: the instance type doesn't support SGP/trunk interface
```
Warning  Unsupported              3m20s (x6 over 3m41s)  vpc-resource-controller  The instance type t3.medium is not supported for trunk interface (Security Group for Pods)
```

case 2: the (mocked) instance is new and hasn't been added into the supporting list
```
Warning  Unsupported              3m27s (x5 over 3m40s)  vpc-resource-controller  The instance type m5.large is not supported yet by the vpc resource controller
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
