### PR TITLE
updated warm pool to support resource group for secondary ip and pref…

### DIFF
--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/pool/mock_pool.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/pool/mock_pool.go
@@ -20,6 +20,7 @@ package mock_pool
 import (
 	reflect "reflect"
 
+	config "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	pool "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/pool"
 	worker "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/worker"
 	gomock "github.com/golang/mock/gomock"
@@ -160,6 +161,34 @@ func (m *MockPool) ReconcilePool() *worker.WarmPoolJob {
 func (mr *MockPoolMockRecorder) ReconcilePool() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcilePool", reflect.TypeOf((*MockPool)(nil).ReconcilePool))
+}
+
+// SetToActive mocks base method.
+func (m *MockPool) SetToActive(arg0 *config.WarmPoolConfig) *worker.WarmPoolJob {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetToActive", arg0)
+	ret0, _ := ret[0].(*worker.WarmPoolJob)
+	return ret0
+}
+
+// SetToActive indicates an expected call of SetToActive.
+func (mr *MockPoolMockRecorder) SetToActive(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetToActive", reflect.TypeOf((*MockPool)(nil).SetToActive), arg0)
+}
+
+// SetToDraining mocks base method.
+func (m *MockPool) SetToDraining() *worker.WarmPoolJob {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetToDraining")
+	ret0, _ := ret[0].(*worker.WarmPoolJob)
+	return ret0
+}
+
+// SetToDraining indicates an expected call of SetToDraining.
+func (mr *MockPoolMockRecorder) SetToDraining() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetToDraining", reflect.TypeOf((*MockPool)(nil).SetToDraining))
 }
 
 // UpdatePool mocks base method.

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/pool/mock_pool.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/pool/mock_pool.go
@@ -108,6 +108,20 @@ func (mr *MockPoolMockRecorder) Introspect() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Introspect", reflect.TypeOf((*MockPool)(nil).Introspect))
 }
 
+// IsManagedResource mocks base method.
+func (m *MockPool) IsManagedResource(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsManagedResource", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsManagedResource indicates an expected call of IsManagedResource.
+func (mr *MockPoolMockRecorder) IsManagedResource(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsManagedResource", reflect.TypeOf((*MockPool)(nil).IsManagedResource), arg0)
+}
+
 // ProcessCoolDownQueue mocks base method.
 func (m *MockPool) ProcessCoolDownQueue() bool {
 	m.ctrl.T.Helper()

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -27,6 +27,15 @@ const (
 	IPv4DefaultMaxDev  = 1
 	IPv4DefaultResSize = 0
 
+	// Default Configuration for IPv4 prefix resource type
+	IPv4PDDefaultWorker               = 2
+	IPv4PDDefaultWPSize               = 1
+	IPv4PDDefaultMaxDev               = 0
+	IPv4PDDefaultResSize              = 0
+	IPv4PDDefaultWarmIPTargetSize     = 1
+	IPv4PDDefaultMinIPTargetSize      = 3
+	IPv4PDDefaultWarmPrefixTargetSize = 0
+
 	// EC2 API QPS for user service client
 	// Tested: 15 + 20 limits
 	// Tested: 15 + 8 limits (not seeing significant degradation from 15+20)

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -71,6 +71,9 @@ const (
 	VpcCniConfigMapName              = "amazon-vpc-cni"
 	EnableWindowsIPAMKey             = "enable-windows-ipam"
 	EnableWindowsPrefixDelegationKey = "enable-windows-prefix-delegation"
+	WarmPrefixTarget                 = "warm-prefix-target"
+	WarmIPTarget                     = "warm-ip-target"
+	MinimumIPTarget                  = "minimum-ip-target"
 	// Since LeaderElectionNamespace and VpcCniConfigMapName may be different in the future
 	KubeSystemNamespace            = "kube-system"
 	VpcCNIDaemonSetName            = "aws-node"
@@ -116,10 +119,16 @@ type ResourceConfig struct {
 
 // WarmPoolConfig is the configuration of Warm Pool of a resource
 type WarmPoolConfig struct {
-	// Number of resources to keep in warm pool per node
+	// Number of resources to keep in warm pool per node; for prefix IP pool, this is used to check if pool is active
 	DesiredSize int
 	// Number of resources not to use in the warm pool
 	ReservedSize int
 	// The maximum number by which the warm pool can deviate from the desired size
 	MaxDeviation int
+	// The number of IPs to be available in prefix IP pool
+	WarmIPTarget int
+	// The floor of number of IPs to be stored in prefix IP pool
+	MinIPTarget int
+	// The number of prefixes to be available in prefix IP pool
+	WarmPrefixTarget int
 }

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -62,7 +62,7 @@ type pool struct {
 	// usedResources is the key value pair of the owner id to the resource id
 	usedResources map[string]Resource
 	// warmResources is the map of group id to a list of free resources available to be allocated to the pods
-	warmResources map[string][]Resource // use map  so that assign/free is fast, despite resync/reconsile always slow
+	warmResources map[string][]Resource
 	// coolDownQueue is the resources that sit in the queue for the cool down period
 	coolDownQueue []CoolDownResource
 	// pendingCreate represents the number of resources being created asynchronously

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -198,6 +198,9 @@ func (p *pool) ReSync(upstreamResourceGroupIDs []string) {
 					p.log.Info("removing resource from warm pool",
 						"group id", resource.GroupID, "resource id", resource.ResourceID)
 					p.warmResources[resource.GroupID] = append(p.warmResources[resource.GroupID][:i], p.warmResources[resource.GroupID][i+1:]...)
+					if len(p.warmResources[resource.GroupID]) == 0 {
+						delete(p.warmResources, resource.GroupID)
+					}
 				}
 			}
 
@@ -496,9 +499,18 @@ func (p *pool) Introspect() IntrospectResponse {
 		usedResources[k] = v
 	}
 
+	warmResources := make(map[string][]Resource)
+	for group, resources := range p.warmResources {
+		var resourcesCopy []Resource
+		for _, res := range resources {
+			resourcesCopy = append(resourcesCopy, res)
+		}
+		warmResources[group] = resourcesCopy
+	}
+
 	return IntrospectResponse{
 		UsedResources:    usedResources,
-		WarmResources:    p.warmResources,
+		WarmResources:    warmResources,
 		CoolingResources: p.coolDownQueue,
 	}
 }

--- a/pkg/pool/pool_test.go
+++ b/pkg/pool/pool_test.go
@@ -31,14 +31,6 @@ var (
 		ReservedSize: 1,
 		MaxDeviation: 1,
 	}
-	//pdPoolConfig = &config.WarmPoolConfig{
-	//	DesiredSize:      1,
-	//	ReservedSize:     1,
-	//	MaxDeviation:     1,
-	//	WarmIPTarget:     3,
-	//	MinIPTarget:      1,
-	//	WarmPrefixTarget: 1,
-	//}
 
 	nodeName = "node-name"
 

--- a/pkg/pool/pool_test.go
+++ b/pkg/pool/pool_test.go
@@ -38,22 +38,37 @@ var (
 	pod2 = "default/pod-2"
 	pod3 = "test/pod-3"
 
+	//grp1, grp2, grp3, grp4, grp5, grp6, grp7 = "grp-1", "grp-2", "grp-3", "grp-4", "grp-5", "grp-6", "grp-7"
 	res1, res2, res3, res4, res5, res6, res7 = "res-1", "res-2", "res-3", "res-4", "res-5", "res-6", "res-7"
 
-	warmPoolResources = []string{res3, res4}
-	usedResources     = map[string]string{pod1: res1, pod2: res2}
-)
-
-func getMockPool(poolConfig *config.WarmPoolConfig, usedResources map[string]string,
-	warmResources []string, capacity int) *pool {
-
-	usedResourcesCopy := map[string]string{}
-	for k, v := range usedResources {
-		usedResourcesCopy[k] = v
+	warmPoolResources = map[string][]Resource{
+		res3: {
+			{GroupID: res3, ResourceID: res3},
+		},
 	}
 
-	warmResourcesCopy := make([]string, len(warmResources))
-	copy(warmResourcesCopy, warmResources)
+	usedResources = map[string]Resource{
+		pod1: {GroupID: res1, ResourceID: res1},
+		pod2: {GroupID: res2, ResourceID: res2},
+	}
+)
+
+func getMockPool(poolConfig *config.WarmPoolConfig, usedResources map[string]Resource,
+	warmResources map[string][]Resource, capacity int, isPDPool bool) *pool {
+
+	usedResourcesCopy := map[string]Resource{}
+	for k, v := range usedResources {
+		usedResourcesCopy[k] = Resource{GroupID: v.GroupID, ResourceID: v.ResourceID}
+	}
+
+	warmResourcesCopy := make(map[string][]Resource, len(warmResources))
+	for k, resources := range warmResources {
+		var resourcesCopy []Resource
+		for _, res := range resources {
+			resourcesCopy = append(resourcesCopy, Resource{GroupID: res.GroupID, ResourceID: res.ResourceID})
+		}
+		warmResourcesCopy[k] = resourcesCopy
+	}
 
 	pool := &pool{
 		log:            zap.New(zap.UseDevMode(true)).WithValues("pool", "res-id/node-name"),
@@ -61,31 +76,32 @@ func getMockPool(poolConfig *config.WarmPoolConfig, usedResources map[string]str
 		usedResources:  usedResourcesCopy,
 		warmResources:  warmResourcesCopy,
 		capacity:       capacity,
+		isPDPool:       isPDPool,
 	}
 
 	return pool
 }
 
 func TestPool_NewResourcePool(t *testing.T) {
-	pool := NewResourcePool(zap.New(), poolConfig, usedResources, warmPoolResources, nodeName, 5)
+	pool := NewResourcePool(zap.New(), poolConfig, usedResources, warmPoolResources, nodeName, 5, false)
 	assert.NotNil(t, pool)
 }
 
-// TestPool_AssignResource tests resource is allocated ot pod if present in the warm pool
+// TestPool_AssignResource tests resource is allocated to pod if present in the warm pool
 func TestPool_AssignResource(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, warmPoolResources, 5)
+	warmPool := getMockPool(poolConfig, usedResources, warmPoolResources, 5, false)
 
 	resourceID, shouldReconcile, err := warmPool.AssignResource(pod3)
 
 	assert.NoError(t, err)
 	assert.True(t, shouldReconcile)
 	assert.Equal(t, res3, resourceID)
-	assert.Equal(t, res3, warmPool.usedResources[pod3])
+	assert.Equal(t, res3, warmPool.usedResources[pod3].ResourceID)
 }
 
 // TestPool_AssignResource_AlreadyAssigned tests error is returned if a pod already was allocated a resource
 func TestPool_AssignResource_AlreadyAssigned(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 2)
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 2, false)
 
 	_, shouldReconcile, err := warmPool.AssignResource(pod1)
 
@@ -95,7 +111,7 @@ func TestPool_AssignResource_AlreadyAssigned(t *testing.T) {
 
 // TestPool_AssignResource_AtCapacity tests error is returned if pool cannot allocate anymore resources
 func TestPool_AssignResource_AtCapacity(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 2)
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 2, false)
 
 	_, shouldReconcile, err := warmPool.AssignResource(pod3)
 
@@ -105,7 +121,7 @@ func TestPool_AssignResource_AtCapacity(t *testing.T) {
 
 // TestPool_AssignResources_WarmPoolEmpty tests error is returned if the warm pool is empty
 func TestPool_AssignResource_WarmPoolEmpty(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 5)
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 5, false)
 
 	_, shouldReconcile, err := warmPool.AssignResource(pod3)
 
@@ -115,8 +131,9 @@ func TestPool_AssignResource_WarmPoolEmpty(t *testing.T) {
 
 // TestPool_AssignResource_CoolDown tests error is returned if the resource are being cooled down
 func TestPool_AssignResource_CoolDown(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 3)
-	warmPool.coolDownQueue = append(warmPool.coolDownQueue, CoolDownResource{ResourceID: res3})
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 3, false)
+	warmPool.coolDownQueue = append(warmPool.coolDownQueue, CoolDownResource{
+		Resource: Resource{GroupID: res3, ResourceID: res3}})
 
 	_, shouldReconcile, err := warmPool.AssignResource(pod3)
 
@@ -126,7 +143,7 @@ func TestPool_AssignResource_CoolDown(t *testing.T) {
 
 // TestPool_FreeResource tests no error is returned on freeing a used resource
 func TestPool_FreeResource(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 3)
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 3, false)
 
 	shouldReconcile, err := warmPool.FreeResource(pod2, res2)
 	_, present := warmPool.usedResources[pod2]
@@ -134,13 +151,13 @@ func TestPool_FreeResource(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, shouldReconcile)
 	assert.False(t, present)
-	assert.Equal(t, res2, warmPool.coolDownQueue[0].ResourceID)
+	assert.Equal(t, res2, warmPool.coolDownQueue[0].Resource.ResourceID)
 }
 
 // TestPool_FreeResource_isNotAssigned test error is returned if trying to free a resource that doesn't belong to any
 // owner
 func TestPool_FreeResource_isNotAssigned(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 3)
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 3, false)
 
 	shouldReconcile, err := warmPool.FreeResource(pod3, res3)
 
@@ -150,7 +167,7 @@ func TestPool_FreeResource_isNotAssigned(t *testing.T) {
 
 // TestPool_FreeResource_IncorrectOwner tests error is returned if incorrect owner id is passed
 func TestPool_FreeResource_IncorrectOwner(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 3)
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 3, false)
 
 	shouldReconcile, err := warmPool.FreeResource(pod2, res1)
 
@@ -161,7 +178,7 @@ func TestPool_FreeResource_IncorrectOwner(t *testing.T) {
 // TestPool_UpdatePool_OperationCreate_Succeed tests resources are added to the warm pool if resource are created
 // successfully
 func TestPool_UpdatePool_OperationCreate_Succeed(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 3)
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 3, false)
 
 	createdResources := []string{res3, res4}
 	shouldReconcile := warmPool.UpdatePool(&worker.WarmPoolJob{
@@ -170,14 +187,17 @@ func TestPool_UpdatePool_OperationCreate_Succeed(t *testing.T) {
 		ResourceCount: 2,
 	}, true)
 
+	warmResources := make(map[string][]Resource)
+	warmResources[res3] = []Resource{{GroupID: res3, ResourceID: res3}}
+	warmResources[res4] = []Resource{{GroupID: res4, ResourceID: res4}}
 	// Resources should be added to warm pool
-	assert.Equal(t, createdResources, warmPool.warmResources)
+	assert.Equal(t, warmResources, warmPool.warmResources)
 	assert.False(t, shouldReconcile)
 }
 
 // TestPool_UpdatePool_OperationCreate_Failed tests that reconciler is triggered when create operation fails
 func TestPool_UpdatePool_OperationCreate_Failed(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 3)
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 3, false)
 
 	shouldReconcile := warmPool.UpdatePool(&worker.WarmPoolJob{
 		Operations:    worker.OperationCreate,
@@ -191,7 +211,7 @@ func TestPool_UpdatePool_OperationCreate_Failed(t *testing.T) {
 
 // TestPool_UpdatePool_OperationDelete tests that reconciler is not triggered again if delete operation succeeds
 func TestPool_UpdatePool_OperationDelete_Succeed(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 3)
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 3, false)
 
 	shouldReconcile := warmPool.UpdatePool(&worker.WarmPoolJob{
 		Operations:    worker.OperationDeleted,
@@ -206,8 +226,7 @@ func TestPool_UpdatePool_OperationDelete_Succeed(t *testing.T) {
 
 // TestPool_UpdatePool_OperationDelete_Failed tests resources are added back to the warm pool if delete fails
 func TestPool_UpdatePool_OperationDelete_Failed(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 3)
-
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 3, false)
 	failedResources := []string{res3, res4}
 	shouldReconcile := warmPool.UpdatePool(&worker.WarmPoolJob{
 		Operations:    worker.OperationDeleted,
@@ -215,48 +234,56 @@ func TestPool_UpdatePool_OperationDelete_Failed(t *testing.T) {
 		ResourceCount: 2,
 	}, false)
 
+	failed := make(map[string][]Resource)
+	failed[res3] = []Resource{{GroupID: res3, ResourceID: res3}}
+	failed[res4] = []Resource{{GroupID: res4, ResourceID: res4}}
+
 	// Assert resources are added back to the warm pool
-	assert.Equal(t, failedResources, warmPool.warmResources)
+	assert.Equal(t, failed, warmPool.warmResources)
 	assert.True(t, shouldReconcile)
 }
 
 // TestPool_ProcessCoolDownQueue tests that item are added back to the warm pool once they have cooled down
 func TestPool_ProcessCoolDownQueue(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 3)
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 3, false)
 	warmPool.coolDownQueue = []CoolDownResource{
-		{ResourceID: res3, DeletionTimestamp: time.Now().Add(-time.Second * 33)},
-		{ResourceID: res4, DeletionTimestamp: time.Now().Add(-time.Second * 32)},
-		{ResourceID: res5, DeletionTimestamp: time.Now().Add(-time.Second * 10)},
+		{Resource: Resource{GroupID: res3, ResourceID: res3}, DeletionTimestamp: time.Now().Add(-time.Second * 33)},
+		{Resource: Resource{GroupID: res4, ResourceID: res4}, DeletionTimestamp: time.Now().Add(-time.Second * 32)},
+		{Resource: Resource{GroupID: res5, ResourceID: res5}, DeletionTimestamp: time.Now().Add(-time.Second * 10)},
 	}
+
+	expectedWarm := make(map[string][]Resource)
+	expectedWarm[res3] = []Resource{{GroupID: res3, ResourceID: res3}}
+	expectedWarm[res4] = []Resource{{GroupID: res4, ResourceID: res4}}
 
 	needFurtherProcessing := warmPool.ProcessCoolDownQueue()
 
 	// As resource 5 is yet not deleted
 	assert.True(t, needFurtherProcessing)
 	// Assert resources are added back to the warm pool
-	assert.Equal(t, []string{res3, res4}, warmPool.warmResources)
+	assert.Equal(t, expectedWarm, warmPool.warmResources)
 	// Assert resource that is not cooled down is still in the queue
-	assert.Equal(t, res5, warmPool.coolDownQueue[0].ResourceID)
+	assert.Equal(t, res5, warmPool.coolDownQueue[0].Resource.ResourceID)
 }
 
 // TestPool_ProcessCoolDownQueue_NoFurtherProcessingRequired tests that if all the items of the cool down queue are
 // processed it should be empty
 func TestPool_ProcessCoolDownQueue_NoFurtherProcessingRequired(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 3)
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 3, false)
 
 	warmPool.coolDownQueue = []CoolDownResource{
-		{ResourceID: res3, DeletionTimestamp: time.Now().Add(-time.Second * 33)}}
+		{Resource: Resource{GroupID: res3, ResourceID: res3}, DeletionTimestamp: time.Now().Add(-time.Second * 33)}}
 
 	needFurtherProcessing := warmPool.ProcessCoolDownQueue()
 
-	// Cool down queue should now be empyy
+	// Cool down queue should now be empty
 	assert.Zero(t, len(warmPool.coolDownQueue))
 	assert.False(t, needFurtherProcessing)
 }
 
 // TestPool_getPendingResources tests total pending resource returns the pending create and pending delete items
 func TestPool_getPendingResources(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 7)
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 7, false)
 	warmPool.pendingCreate = 2
 	warmPool.pendingDelete = 3
 
@@ -265,11 +292,15 @@ func TestPool_getPendingResources(t *testing.T) {
 
 // TestPool_ReconcilePool_MaxCapacity tests reconciliation doesn't happen if the pod is at max capacity
 func TestPool_ReconcilePool_MaxCapacity(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{pod1}, 6)
+	warmResources := make(map[string][]Resource)
+	warmResources[res1] = []Resource{{GroupID: res1, ResourceID: res1}}
+
+	warmPool := getMockPool(poolConfig, usedResources, warmResources, 6, false)
 	warmPool.pendingCreate = 1
 	warmPool.pendingDelete = 1
 
-	warmPool.coolDownQueue = append(warmPool.coolDownQueue, CoolDownResource{ResourceID: res4})
+	warmPool.coolDownQueue = append(warmPool.coolDownQueue, CoolDownResource{
+		Resource: Resource{GroupID: res4, ResourceID: res4}})
 
 	// used = 2, warm = 1, total pending = 2, cool down queue = 1, total = 6 & capacity = 6 => At max capacity
 	job := warmPool.ReconcilePool()
@@ -281,7 +312,7 @@ func TestPool_ReconcilePool_MaxCapacity(t *testing.T) {
 // TestPool_ReconcilePool_NotRequired tests if the deviation form warm pool is equal to or less than the max deviation
 // then reconciliation is not triggered
 func TestPool_ReconcilePool_NotRequired(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 7)
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 7, false)
 	warmPool.pendingCreate = 1
 
 	job := warmPool.ReconcilePool()
@@ -293,7 +324,7 @@ func TestPool_ReconcilePool_NotRequired(t *testing.T) {
 
 // TestPool_ReconcilePool tests job with operation type create is returned when the warm pool deviates form max deviation
 func TestPool_ReconcilePool_Create(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 7)
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 7, false)
 
 	job := warmPool.ReconcilePool()
 
@@ -306,7 +337,7 @@ func TestPool_ReconcilePool_Create(t *testing.T) {
 // TestPool_ReconcilePool_Create_LimitByMaxCapacity tests when the warm pool deviates from max deviation and the deviation
 // is greater than the capacity of the pool, then only resources upto the max capacity are created
 func TestPool_ReconcilePool_Create_LimitByMaxCapacity(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 7)
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 7, false)
 	warmPool.pendingDelete = 4
 
 	job := warmPool.ReconcilePool()
@@ -320,7 +351,11 @@ func TestPool_ReconcilePool_Create_LimitByMaxCapacity(t *testing.T) {
 // TestPool_ReconcilePool_Delete_NotRequired tests that if the warm pool is over the desired warm pool size but has not
 // exceeded the max deviation then we don't return a delete job
 func TestPool_ReconcilePool_Delete_NotRequired(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{res3, res4, res5}, 7)
+	warmResources := make(map[string][]Resource)
+	warmResources[res3] = []Resource{{GroupID: res3, ResourceID: res3}}
+	warmResources[res4] = []Resource{{GroupID: res4, ResourceID: res4}}
+	warmResources[res5] = []Resource{{GroupID: res5, ResourceID: res5}}
+	warmPool := getMockPool(poolConfig, usedResources, warmResources, 7, false)
 
 	job := warmPool.ReconcilePool()
 
@@ -332,18 +367,24 @@ func TestPool_ReconcilePool_Delete_NotRequired(t *testing.T) {
 // TestPool_ReconcilePool_Delete tests that if the warm pool is over the desired warm pool size and has exceed the max
 // deviation then we issue a return a delete job
 func TestPool_ReconcilePool_Delete(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{res3, res4, res5, res6}, 7)
+	warmResources := make(map[string][]Resource)
+	warmResources[res3] = []Resource{{GroupID: res3, ResourceID: res3}}
+	warmResources[res4] = []Resource{{GroupID: res4, ResourceID: res4}}
+	warmResources[res5] = []Resource{{GroupID: res5, ResourceID: res5}}
+	warmResources[res6] = []Resource{{GroupID: res6, ResourceID: res6}}
+	warmPool := getMockPool(poolConfig, usedResources, warmResources, 7, false)
 
 	job := warmPool.ReconcilePool()
-
-	// deviation = 2(desired WP) - 3(actual WP) = -1, (-deviation)1 > (max deviation)1 => false, so no need delete
-	assert.Equal(t, &worker.WarmPoolJob{Operations: worker.OperationDeleted,
-		Resources: []string{res6, res5}, ResourceCount: 2}, job)
+	// deviation = 2(desired WP) - 4(actual WP) = -2, (-deviation)2 > (max deviation)1 => true, need to delete
+	// since the warm resources is a map, there is no particular order to delete ip address from secondary ip pool,
+	// we can't assert which two ips would get deleted here
+	assert.Equal(t, 2, job.ResourceCount)
+	assert.Equal(t, worker.OperationDeleted, job.Operations)
 	assert.Equal(t, 2, warmPool.pendingDelete)
 }
 
 func TestPool_Reconcile_ReSync(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, []string{}, 4)
+	warmPool := getMockPool(poolConfig, usedResources, map[string][]Resource{}, 4, false)
 
 	warmPool.reSyncRequired = true
 	warmPool.nodeName = nodeName
@@ -359,18 +400,28 @@ func TestPool_Reconcile_ReSync(t *testing.T) {
 }
 
 func TestPool_ReSync(t *testing.T) {
-	warm := []string{res3, res4}
-	coolDown := []CoolDownResource{{ResourceID: res5}, {ResourceID: res6}}
+	warm := make(map[string][]Resource)
+	warm[res3] = []Resource{{GroupID: res3, ResourceID: res3}}
+	warm[res4] = []Resource{{GroupID: res4, ResourceID: res4}}
+
+	warm2 := make(map[string][]Resource)
+	warm2[res3] = []Resource{{GroupID: res3, ResourceID: res3}}
+	warm2[res7] = []Resource{{GroupID: res7, ResourceID: res7}}
+
+	coolDown := []CoolDownResource{
+		{Resource: Resource{GroupID: res5, ResourceID: res5}},
+		{Resource: Resource{GroupID: res6, ResourceID: res6}},
+	}
 
 	tests := []struct {
 		name string
 
 		shouldResync bool
 
-		warmPool      []string
+		warmPool      map[string][]Resource
 		coolDownQueue []CoolDownResource
 
-		expectedWarmPool      []string
+		expectedWarmPool      map[string][]Resource
 		expectedCoolDownQueue []CoolDownResource
 
 		upstreamResources []string
@@ -397,8 +448,8 @@ func TestPool_ReSync(t *testing.T) {
 			shouldResync:          true,
 			warmPool:              warm,
 			coolDownQueue:         coolDown,
-			expectedWarmPool:      []string{res3, res7},
-			expectedCoolDownQueue: []CoolDownResource{{ResourceID: res6}},
+			expectedWarmPool:      warm2,
+			expectedCoolDownQueue: []CoolDownResource{{Resource: Resource{GroupID: res6, ResourceID: res6}}},
 			//Resource 4, 6 and got deleted from upstream and resource 7 added
 			upstreamResources: []string{res1, res2, res3, res6, res7},
 		},
@@ -406,22 +457,22 @@ func TestPool_ReSync(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			warmPool := getMockPool(poolConfig, usedResources, test.warmPool, 7)
+			warmPool := getMockPool(poolConfig, usedResources, test.warmPool, 7, false)
 			warmPool.coolDownQueue = test.coolDownQueue
 			warmPool.reSyncRequired = test.shouldResync
 
 			warmPool.ReSync(test.upstreamResources)
 
 			assert.False(t, warmPool.reSyncRequired)
-			assert.Equal(t, warmPool.usedResources, usedResources)
-			assert.ElementsMatch(t, warmPool.warmResources, test.expectedWarmPool)
+			assert.True(t, reflect.DeepEqual(warmPool.usedResources, usedResources))
+			assert.True(t, reflect.DeepEqual(warmPool.warmResources, test.expectedWarmPool))
 			assert.ElementsMatch(t, warmPool.coolDownQueue, test.expectedCoolDownQueue)
 		})
 	}
 }
 
 func TestPool_GetAssignedResource(t *testing.T) {
-	warmPool := getMockPool(poolConfig, usedResources, nil, 7)
+	warmPool := getMockPool(poolConfig, usedResources, nil, 7, false)
 
 	resID, found := warmPool.GetAssignedResource(pod1)
 	assert.True(t, found)
@@ -434,14 +485,12 @@ func TestPool_GetAssignedResource(t *testing.T) {
 
 func TestPool_Introspect(t *testing.T) {
 	coolingResources := []CoolDownResource{{
-		ResourceID: res6,
+		Resource: Resource{GroupID: res6, ResourceID: res6},
 	}}
-	warmPool := getMockPool(poolConfig, usedResources, warmPoolResources, 7)
+	warmPool := getMockPool(poolConfig, usedResources, warmPoolResources, 7, false)
 	warmPool.coolDownQueue = coolingResources
-
 	resp := warmPool.Introspect()
-
 	assert.True(t, reflect.DeepEqual(warmPool.usedResources, resp.UsedResources))
-	assert.ElementsMatch(t, warmPool.warmResources, resp.WarmResources)
+	assert.True(t, reflect.DeepEqual(warmPool.warmResources, resp.WarmResources))
 	assert.ElementsMatch(t, warmPool.coolDownQueue, resp.CoolingResources)
 }

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -15,6 +15,9 @@ package utils
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"strings"
 
 	vpcresourcesv1beta1 "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
 
@@ -159,4 +162,43 @@ func (s *SecurityGroupForPods) filterPodSecurityGroups(
 
 	sgList = RemoveDuplicatedSg(sgList)
 	return sgList
+}
+
+// DeconstructIPsFromPrefix deconstructs a IPv4 prefix into a list of /32 IPv4 addresses
+func DeconstructIPsFromPrefix(prefix string) ([]string, error) {
+	var deconstructedIPs []string
+
+	// find the index of / in prefix
+	index := strings.Index(prefix, "/")
+	if index < 0 {
+		return nil, fmt.Errorf("invalid IPv4 prefix %v", prefix)
+	}
+
+	// construct network address
+	addr := strings.Split(prefix[:index], ".")
+	if addr == nil || len(addr) != 4 {
+		return nil, fmt.Errorf("invalid IPv4 prefix %v", prefix)
+	}
+	networkAddr := addr[0] + "." + addr[1] + "." + addr[2] + "."
+
+	// get mask and calculate number of IPv4 addresses in the range
+	mask, err := strconv.Atoi(prefix[index+1:])
+	if err != nil {
+		return nil, err
+	}
+	if mask < 0 || mask > 32 {
+		return nil, fmt.Errorf("invalid IPv4 prefix %v", prefix)
+	}
+	numOfAddresses := IntPower(2, 32-mask)
+
+	// concatenate network addr and host addr to get /32 IPv4 address
+	for i := 0; i < numOfAddresses; i++ {
+		hostAddr, err := strconv.Atoi(addr[3])
+		if err != nil {
+			return nil, err
+		}
+		ipAddr := networkAddr + strconv.Itoa(hostAddr+i) + "/32"
+		deconstructedIPs = append(deconstructedIPs, ipAddr)
+	}
+	return deconstructedIPs, nil
 }

--- a/pkg/utils/math.go
+++ b/pkg/utils/math.go
@@ -51,6 +51,19 @@ func MaxOf[T constraints.Ordered](vars ...T) T {
 	return result
 }
 
+// CeilDivision returns the ceiling result of numerator x divided by denominator y. y should be non-zero
 func CeilDivision(x, y int) int {
 	return (x + y - 1) / y
+}
+
+// IntPower calculates n to the mth power. m should be a non-negative power to have an int return value
+func IntPower(n, m int) int {
+	if m == 0 {
+		return 1
+	}
+	result := n
+	for i := 1; i < m; i++ {
+		result *= n
+	}
+	return result
 }

--- a/pkg/utils/math.go
+++ b/pkg/utils/math.go
@@ -50,3 +50,7 @@ func MaxOf[T constraints.Ordered](vars ...T) T {
 	}
 	return result
 }
+
+func CeilDivision(x, y int) int {
+	return (x + y - 1) / y
+}

--- a/pkg/utils/math_test.go
+++ b/pkg/utils/math_test.go
@@ -47,3 +47,19 @@ func TestMultipleElements(t *testing.T) {
 	assert.True(t, MinOf(varStr...) == z)
 	assert.True(t, MaxOf(varStr...) == y)
 }
+
+func TestCeilDivision(t *testing.T) {
+	assert.True(t, CeilDivision(0, 16) == 0)
+	assert.True(t, CeilDivision(32, 1) == 32)
+	assert.True(t, CeilDivision(32, 16) == 2)
+	assert.True(t, CeilDivision(32, 30) == 2)
+	assert.True(t, CeilDivision(50, 16) == 4)
+}
+
+func TestIntPower(t *testing.T) {
+	assert.True(t, IntPower(2, 0) == 1)
+	assert.True(t, IntPower(2, 4) == 16)
+	assert.True(t, IntPower(-2, 2) == 4)
+	assert.True(t, IntPower(-2, 3) == -8)
+	assert.True(t, IntPower(-2, 0) == 1)
+}

--- a/pkg/utils/set.go
+++ b/pkg/utils/set.go
@@ -14,8 +14,8 @@
 package utils
 
 // Difference returns a-b, elements present in a and not in b
-func Difference(a, b []string) (diff []string) {
-	m := make(map[string]struct{})
+func Difference[T comparable](a, b []T) (diff []T) {
+	m := make(map[T]struct{})
 
 	for _, item := range b {
 		m[item] = struct{}{}

--- a/pkg/utils/set_test.go
+++ b/pkg/utils/set_test.go
@@ -19,6 +19,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type TestResource struct {
+	GroupID    string
+	ResourceID string
+}
+
 func TestDifference(t *testing.T) {
 	a := []string{"X", "Y", "Z"}
 	b := []string{"X", "Z", "Q"}
@@ -26,6 +31,25 @@ func TestDifference(t *testing.T) {
 	assert.ElementsMatch(t, Difference(a, b), []string{"Y"})
 	assert.ElementsMatch(t, Difference(b, a), []string{"Q"})
 	assert.ElementsMatch(t, Difference(a, a), []string{})
+}
+
+func TestDifferenceResource(t *testing.T) {
+	res1 := TestResource{GroupID: "res1", ResourceID: "res1"}
+	res2 := TestResource{GroupID: "res2", ResourceID: "res2"}
+	res3 := TestResource{GroupID: "res3", ResourceID: "res3"}
+	a := []TestResource{res1, res2}
+	b := []TestResource{res1, res3}
+	c := []TestResource{res3}
+	var d []TestResource
+
+	assert.ElementsMatch(t, Difference(a, b), []TestResource{res2})
+	assert.ElementsMatch(t, Difference(b, a), []TestResource{res3})
+	assert.ElementsMatch(t, Difference(a, a), []TestResource{})
+	assert.ElementsMatch(t, Difference(a, c), []TestResource{res1, res2})
+	assert.ElementsMatch(t, Difference(c, a), []TestResource{res3})
+	assert.ElementsMatch(t, Difference(d, a), d)
+	assert.ElementsMatch(t, Difference(a, d), a)
+	assert.ElementsMatch(t, Difference(d, d), d)
 }
 
 func TestGetKeySet(t *testing.T) {


### PR DESCRIPTION
…ix-ip

*Issue #, if available:*

*Description of changes:*
- Added a struct for `Resource` which either represents a secondary IP address where group ID is the same as resource ID, or represents a prefix-deconstructed IP address where group ID is a `/28` prefix, and resource ID is a `/32` IPv4 address.
- Updated `usedResources` to be a map from owner id to `Resource` struct
- Updated  `warmResources` to be a map from resource group ID to a list of `Resource` that belong to that group. For secondary IP resource group, each key is a secondary IPv4 address, and the value contains 1 `Resource`. For prefix IP resource group, each key is a prefix, and the value is the list of IPv4 addresses deconstructed from that prefix.
- Added API `IsManagedResource` so that pod controller can call this and check if a pod's IP is managed by a IP pool or a PD pool.
- Added APIs `SetToDraining` and `SetToActive` to handle toggle situations between secondary IP mode and prefix delegation mode.
- When assigning IPs from secondary IP pool, it picks a random IP from the warm pool, whereas for prefix IP pool, it chooses the IP from the resource group (the prefix) with fewest elements to avoid prefix starvation.
- `getPDDeviation` calculates number of prefixes to maintain in the warm pool to satisfy `WarmIPTarget`, `MinimumIPTarget` and `WarmPrefixTarget` requirements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
