### PR TITLE
Associate primary network interface SG with the trunk-eni when SG is not specified in ENIConfig

### DIFF
--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/mock_instance.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/mock_instance.go
@@ -47,18 +47,18 @@ func (m *MockEC2Instance) EXPECT() *MockEC2InstanceMockRecorder {
 	return m.recorder
 }
 
-// CurrentInstanceSecurityGroup mocks base method.
-func (m *MockEC2Instance) CurrentInstanceSecurityGroup() []string {
+// CurrentInstanceSecurityGroups mocks base method.
+func (m *MockEC2Instance) CurrentInstanceSecurityGroups() []string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CurrentInstanceSecurityGroup")
+	ret := m.ctrl.Call(m, "CurrentInstanceSecurityGroups")
 	ret0, _ := ret[0].([]string)
 	return ret0
 }
 
-// CurrentInstanceSecurityGroup indicates an expected call of CurrentInstanceSecurityGroup.
-func (mr *MockEC2InstanceMockRecorder) CurrentInstanceSecurityGroup() *gomock.Call {
+// CurrentInstanceSecurityGroups indicates an expected call of CurrentInstanceSecurityGroups.
+func (mr *MockEC2InstanceMockRecorder) CurrentInstanceSecurityGroups() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentInstanceSecurityGroup", reflect.TypeOf((*MockEC2Instance)(nil).CurrentInstanceSecurityGroup))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentInstanceSecurityGroups", reflect.TypeOf((*MockEC2Instance)(nil).CurrentInstanceSecurityGroups))
 }
 
 // FreeDeviceIndex mocks base method.

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/mock_instance.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/mock_instance.go
@@ -47,6 +47,20 @@ func (m *MockEC2Instance) EXPECT() *MockEC2InstanceMockRecorder {
 	return m.recorder
 }
 
+// CurrentInstanceSecurityGroup mocks base method.
+func (m *MockEC2Instance) CurrentInstanceSecurityGroup() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CurrentInstanceSecurityGroup")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// CurrentInstanceSecurityGroup indicates an expected call of CurrentInstanceSecurityGroup.
+func (mr *MockEC2InstanceMockRecorder) CurrentInstanceSecurityGroup() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentInstanceSecurityGroup", reflect.TypeOf((*MockEC2Instance)(nil).CurrentInstanceSecurityGroup))
+}
+
 // FreeDeviceIndex mocks base method.
 func (m *MockEC2Instance) FreeDeviceIndex(arg0 int64) {
 	m.ctrl.T.Helper()
@@ -86,20 +100,6 @@ func (m *MockEC2Instance) InstanceID() string {
 func (mr *MockEC2InstanceMockRecorder) InstanceID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceID", reflect.TypeOf((*MockEC2Instance)(nil).InstanceID))
-}
-
-// InstanceSecurityGroup mocks base method.
-func (m *MockEC2Instance) InstanceSecurityGroup() []string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstanceSecurityGroup")
-	ret0, _ := ret[0].([]string)
-	return ret0
-}
-
-// InstanceSecurityGroup indicates an expected call of InstanceSecurityGroup.
-func (mr *MockEC2InstanceMockRecorder) InstanceSecurityGroup() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceSecurityGroup", reflect.TypeOf((*MockEC2Instance)(nil).InstanceSecurityGroup))
 }
 
 // LoadDetails mocks base method.

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/node/manager/mock_manager.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/node/manager/mock_manager.go
@@ -22,7 +22,6 @@ import (
 
 	node "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/node"
 	gomock "github.com/golang/mock/gomock"
-	healthz "sigs.k8s.io/controller-runtime/pkg/healthz"
 )
 
 // MockManager is a mock of Manager interface.
@@ -74,20 +73,6 @@ func (m *MockManager) DeleteNode(arg0 string) error {
 func (mr *MockManagerMockRecorder) DeleteNode(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockManager)(nil).DeleteNode), arg0)
-}
-
-// GetChecker mocks base method.
-func (m *MockManager) GetChecker() healthz.Checker {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChecker")
-	ret0, _ := ret[0].(healthz.Checker)
-	return ret0
-}
-
-// GetChecker indicates an expected call of GetChecker.
-func (mr *MockManagerMockRecorder) GetChecker() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChecker", reflect.TypeOf((*MockManager)(nil).GetChecker))
 }
 
 // GetNode mocks base method.

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/resource/mock_resources.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/resource/mock_resources.go
@@ -23,7 +23,6 @@ import (
 	handler "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/handler"
 	provider "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider"
 	gomock "github.com/golang/mock/gomock"
-	healthz "sigs.k8s.io/controller-runtime/pkg/healthz"
 )
 
 // MockResourceManager is a mock of ResourceManager interface.
@@ -47,20 +46,6 @@ func NewMockResourceManager(ctrl *gomock.Controller) *MockResourceManager {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockResourceManager) EXPECT() *MockResourceManagerMockRecorder {
 	return m.recorder
-}
-
-// GetCheckers mocks base method.
-func (m *MockResourceManager) GetCheckers() map[string]healthz.Checker {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCheckers")
-	ret0, _ := ret[0].(map[string]healthz.Checker)
-	return ret0
-}
-
-// GetCheckers indicates an expected call of GetCheckers.
-func (mr *MockResourceManagerMockRecorder) GetCheckers() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCheckers", reflect.TypeOf((*MockResourceManager)(nil).GetCheckers))
 }
 
 // GetResourceHandler mocks base method.

--- a/pkg/aws/ec2/instance_test.go
+++ b/pkg/aws/ec2/instance_test.go
@@ -119,7 +119,7 @@ func TestEc2Instance_LoadDetails(t *testing.T) {
 	assert.Equal(t, subnetCidrBlock, ec2Instance.SubnetCidrBlock())
 	assert.Equal(t, instanceType, ec2Instance.Type())
 	assert.Equal(t, []bool{true, false, true}, ec2Instance.deviceIndexes)
-	assert.Equal(t, []string{securityGroup1, securityGroup2}, ec2Instance.CurrentInstanceSecurityGroup())
+	assert.Equal(t, []string{securityGroup1, securityGroup2}, ec2Instance.CurrentInstanceSecurityGroups())
 	assert.Equal(t, primaryInterfaceID, ec2Instance.PrimaryNetworkInterfaceID())
 }
 
@@ -198,7 +198,7 @@ func TestEc2Instance_LoadDetails_SubnetPreLoaded(t *testing.T) {
 
 	// Set the custom networking subnet ID and CIDR block
 	ec2Instance.newCustomNetworkingSubnetID = customNWSubnetID
-	ec2Instance.newCustomNetworkingSecurityGroup = customNWSecurityGroups
+	ec2Instance.newCustomNetworkingSecurityGroups = customNWSecurityGroups
 
 	customSubnet := &ec2.Subnet{CidrBlock: &customNWSubnetCidr}
 
@@ -209,7 +209,7 @@ func TestEc2Instance_LoadDetails_SubnetPreLoaded(t *testing.T) {
 	err := ec2Instance.LoadDetails(mockEC2ApiHelper)
 	assert.NoError(t, err)
 	assert.Equal(t, customNWSubnetID, ec2Instance.currentSubnetID)
-	assert.Equal(t, customNWSecurityGroups, ec2Instance.currentInstanceSecurityGroup)
+	assert.Equal(t, customNWSecurityGroups, ec2Instance.currentInstanceSecurityGroups)
 	assert.Equal(t, customNWSubnetCidr, ec2Instance.currentSubnetCIDRBlock)
 }
 
@@ -347,7 +347,7 @@ func TestEc2Instance_LoadDetails_InvalidCustomNetworkingConfiguration(t *testing
 	// Set the custom networking subnet ID and CIDR block
 	customNWSubnetID := "custom-networking"
 	ec2Instance.newCustomNetworkingSubnetID = customNWSubnetID
-	ec2Instance.newCustomNetworkingSecurityGroup = []string{}
+	ec2Instance.newCustomNetworkingSecurityGroups = []string{}
 
 	customNWSubnetCidr := "192.2.0.0/24"
 	customSubnet := &ec2.Subnet{CidrBlock: &customNWSubnetCidr}
@@ -360,6 +360,6 @@ func TestEc2Instance_LoadDetails_InvalidCustomNetworkingConfiguration(t *testing
 	assert.NoError(t, err)
 	assert.Equal(t, customNWSubnetID, ec2Instance.currentSubnetID)
 	// Expect the primary network interface security groups when ENIConfig SG is missing
-	assert.Equal(t, []string{securityGroup1, securityGroup2}, ec2Instance.currentInstanceSecurityGroup)
+	assert.Equal(t, []string{securityGroup1, securityGroup2}, ec2Instance.currentInstanceSecurityGroups)
 	assert.Equal(t, customNWSubnetCidr, ec2Instance.currentSubnetCIDRBlock)
 }

--- a/pkg/aws/ec2/instance_test.go
+++ b/pkg/aws/ec2/instance_test.go
@@ -119,7 +119,7 @@ func TestEc2Instance_LoadDetails(t *testing.T) {
 	assert.Equal(t, subnetCidrBlock, ec2Instance.SubnetCidrBlock())
 	assert.Equal(t, instanceType, ec2Instance.Type())
 	assert.Equal(t, []bool{true, false, true}, ec2Instance.deviceIndexes)
-	assert.Equal(t, []string{securityGroup1, securityGroup2}, ec2Instance.InstanceSecurityGroup())
+	assert.Equal(t, []string{securityGroup1, securityGroup2}, ec2Instance.CurrentInstanceSecurityGroup())
 	assert.Equal(t, primaryInterfaceID, ec2Instance.PrimaryNetworkInterfaceID())
 }
 
@@ -331,4 +331,35 @@ func TestEc2Instance_E2E(t *testing.T) {
 	assert.True(t, ec2Instance.deviceIndexes[1])
 	ec2Instance.FreeDeviceIndex(deviceIndex0)
 	assert.False(t, ec2Instance.deviceIndexes[deviceIndex0])
+}
+
+// Tests instance details when custom networking is incorrectly configured- missing security groups
+func TestEc2Instance_LoadDetails_InvalidCustomNetworkingConfiguration(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2Instance, mockEC2ApiHelper := getMockInstance(ctrl)
+
+	// Set the instance subnet ID and CIDR block
+	ec2Instance.instanceSubnetID = subnetID
+	ec2Instance.instanceSubnetCidrBlock = subnetCidrBlock
+
+	// Set the custom networking subnet ID and CIDR block
+	customNWSubnetID := "custom-networking"
+	ec2Instance.newCustomNetworkingSubnetID = customNWSubnetID
+	ec2Instance.newCustomNetworkingSecurityGroup = []string{}
+
+	customNWSubnetCidr := "192.2.0.0/24"
+	customSubnet := &ec2.Subnet{CidrBlock: &customNWSubnetCidr}
+
+	mockEC2ApiHelper.EXPECT().GetInstanceDetails(&instanceID).Return(nwInterfaces, nil)
+	mockEC2ApiHelper.EXPECT().GetSubnet(&subnetID).Return(subnet, nil)
+	mockEC2ApiHelper.EXPECT().GetSubnet(&customNWSubnetID).Return(customSubnet, nil)
+
+	err := ec2Instance.LoadDetails(mockEC2ApiHelper)
+	assert.NoError(t, err)
+	assert.Equal(t, customNWSubnetID, ec2Instance.currentSubnetID)
+	// Expect the primary network interface security groups when ENIConfig SG is missing
+	assert.Equal(t, []string{securityGroup1, securityGroup2}, ec2Instance.currentInstanceSecurityGroup)
+	assert.Equal(t, customNWSubnetCidr, ec2Instance.currentSubnetCIDRBlock)
 }

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -256,6 +256,7 @@ func Test_AddNode_CustomNetworking(t *testing.T) {
 }
 
 // Test adding node when custom networking is enabled but incorrect ENIConfig is defined; it should succeed
+// TODO: combine with other Test_AddNode_CustomNetworking tests
 func Test_AddNode_CustomNetworking_Incorrect_ENIConfig(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/provider/branch/trunk/trunk.go
+++ b/pkg/provider/branch/trunk/trunk.go
@@ -188,7 +188,7 @@ func (t *trunkENI) InitTrunk(instance ec2.EC2Instance, podList []v1.Pod) error {
 		}
 
 		trunk, err := t.ec2ApiHelper.CreateAndAttachNetworkInterface(&instanceID, aws.String(t.instance.SubnetID()),
-			t.instance.InstanceSecurityGroup(), nil, &freeIndex, &TrunkEniDescription, &InterfaceTypeTrunk, 0)
+			t.instance.CurrentInstanceSecurityGroup(), nil, &freeIndex, &TrunkEniDescription, &InterfaceTypeTrunk, 0)
 		if err != nil {
 			trunkENIOperationsErrCount.WithLabelValues("create_trunk_eni").Inc()
 			log.Error(err, "failed to create trunk interface")
@@ -311,7 +311,7 @@ func (t *trunkENI) CreateAndAssociateBranchENIs(pod *v1.Pod, securityGroups []st
 
 	// If the security group is empty use the instance security group
 	if securityGroups == nil || len(securityGroups) == 0 {
-		securityGroups = t.instance.InstanceSecurityGroup()
+		securityGroups = t.instance.CurrentInstanceSecurityGroup()
 	}
 
 	var newENIs []*ENIDetails

--- a/pkg/provider/branch/trunk/trunk.go
+++ b/pkg/provider/branch/trunk/trunk.go
@@ -188,7 +188,7 @@ func (t *trunkENI) InitTrunk(instance ec2.EC2Instance, podList []v1.Pod) error {
 		}
 
 		trunk, err := t.ec2ApiHelper.CreateAndAttachNetworkInterface(&instanceID, aws.String(t.instance.SubnetID()),
-			t.instance.CurrentInstanceSecurityGroup(), nil, &freeIndex, &TrunkEniDescription, &InterfaceTypeTrunk, 0)
+			t.instance.CurrentInstanceSecurityGroups(), nil, &freeIndex, &TrunkEniDescription, &InterfaceTypeTrunk, 0)
 		if err != nil {
 			trunkENIOperationsErrCount.WithLabelValues("create_trunk_eni").Inc()
 			log.Error(err, "failed to create trunk interface")
@@ -311,7 +311,7 @@ func (t *trunkENI) CreateAndAssociateBranchENIs(pod *v1.Pod, securityGroups []st
 
 	// If the security group is empty use the instance security group
 	if securityGroups == nil || len(securityGroups) == 0 {
-		securityGroups = t.instance.CurrentInstanceSecurityGroup()
+		securityGroups = t.instance.CurrentInstanceSecurityGroups()
 	}
 
 	var newENIs []*ENIDetails

--- a/pkg/provider/branch/trunk/trunk_test.go
+++ b/pkg/provider/branch/trunk/trunk_test.go
@@ -597,7 +597,7 @@ func TestTrunkENI_InitTrunk_TrunkNotExists(t *testing.T) {
 	freeIndex := int64(2)
 
 	mockInstance.EXPECT().InstanceID().Return(InstanceId)
-	mockInstance.EXPECT().InstanceSecurityGroup().Return(SecurityGroups)
+	mockInstance.EXPECT().CurrentInstanceSecurityGroup().Return(SecurityGroups)
 	mockEC2APIHelper.EXPECT().GetInstanceNetworkInterface(&InstanceId).Return([]*awsEc2.InstanceNetworkInterface{}, nil)
 	mockInstance.EXPECT().GetHighestUnusedDeviceIndex().Return(freeIndex, nil)
 	mockInstance.EXPECT().SubnetID().Return(SubnetId)
@@ -774,7 +774,7 @@ func TestTrunkENI_CreateAndAssociateBranchENIs_InstanceSecurityGroup(t *testing.
 	mockInstance.EXPECT().Type().Return(InstanceType)
 	mockInstance.EXPECT().SubnetID().Return(SubnetId).Times(2)
 	mockInstance.EXPECT().SubnetCidrBlock().Return(SubnetCidrBlock).Times(2)
-	mockInstance.EXPECT().InstanceSecurityGroup().Return(InstanceSecurityGroup)
+	mockInstance.EXPECT().CurrentInstanceSecurityGroup().Return(InstanceSecurityGroup)
 
 	mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, InstanceSecurityGroup,
 		vlan1Tag, 0, nil).Return(BranchInterface1, nil)

--- a/pkg/provider/branch/trunk/trunk_test.go
+++ b/pkg/provider/branch/trunk/trunk_test.go
@@ -597,7 +597,7 @@ func TestTrunkENI_InitTrunk_TrunkNotExists(t *testing.T) {
 	freeIndex := int64(2)
 
 	mockInstance.EXPECT().InstanceID().Return(InstanceId)
-	mockInstance.EXPECT().CurrentInstanceSecurityGroup().Return(SecurityGroups)
+	mockInstance.EXPECT().CurrentInstanceSecurityGroups().Return(SecurityGroups)
 	mockEC2APIHelper.EXPECT().GetInstanceNetworkInterface(&InstanceId).Return([]*awsEc2.InstanceNetworkInterface{}, nil)
 	mockInstance.EXPECT().GetHighestUnusedDeviceIndex().Return(freeIndex, nil)
 	mockInstance.EXPECT().SubnetID().Return(SubnetId)
@@ -774,7 +774,7 @@ func TestTrunkENI_CreateAndAssociateBranchENIs_InstanceSecurityGroup(t *testing.
 	mockInstance.EXPECT().Type().Return(InstanceType)
 	mockInstance.EXPECT().SubnetID().Return(SubnetId).Times(2)
 	mockInstance.EXPECT().SubnetCidrBlock().Return(SubnetCidrBlock).Times(2)
-	mockInstance.EXPECT().CurrentInstanceSecurityGroup().Return(InstanceSecurityGroup)
+	mockInstance.EXPECT().CurrentInstanceSecurityGroups().Return(InstanceSecurityGroup)
 
 	mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, InstanceSecurityGroup,
 		vlan1Tag, 0, nil).Return(BranchInterface1, nil)

--- a/pkg/provider/ip/eni/eni.go
+++ b/pkg/provider/ip/eni/eni.go
@@ -163,7 +163,7 @@ func (e *eniManager) CreateIPV4Address(required int, ec2APIHelper api.EC2APIHelp
 			want = ipLimit
 		}
 		nwInterface, err := ec2APIHelper.CreateAndAttachNetworkInterface(aws.String(e.instance.InstanceID()),
-			aws.String(e.instance.SubnetID()), e.instance.InstanceSecurityGroup(), nil, aws.Int64(deviceIndex),
+			aws.String(e.instance.SubnetID()), e.instance.CurrentInstanceSecurityGroup(), nil, aws.Int64(deviceIndex),
 			&ENIDescription, nil, want)
 		if err != nil {
 			// TODO: Check if any clean up is required here for linux nodes only?

--- a/pkg/provider/ip/eni/eni.go
+++ b/pkg/provider/ip/eni/eni.go
@@ -163,7 +163,7 @@ func (e *eniManager) CreateIPV4Address(required int, ec2APIHelper api.EC2APIHelp
 			want = ipLimit
 		}
 		nwInterface, err := ec2APIHelper.CreateAndAttachNetworkInterface(aws.String(e.instance.InstanceID()),
-			aws.String(e.instance.SubnetID()), e.instance.CurrentInstanceSecurityGroup(), nil, aws.Int64(deviceIndex),
+			aws.String(e.instance.SubnetID()), e.instance.CurrentInstanceSecurityGroups(), nil, aws.Int64(deviceIndex),
 			&ENIDescription, nil, want)
 		if err != nil {
 			// TODO: Check if any clean up is required here for linux nodes only?

--- a/pkg/provider/ip/eni/eni_test.go
+++ b/pkg/provider/ip/eni/eni_test.go
@@ -247,7 +247,7 @@ func TestEniManager_CreateIPV4Address_FromNewENI(t *testing.T) {
 	mockInstance.EXPECT().InstanceID().Return(instanceID).Times(2)
 	mockInstance.EXPECT().SubnetID().Return(subnetID).Times(2)
 	mockInstance.EXPECT().SubnetMask().Return(subnetMask).Times(4)
-	mockInstance.EXPECT().InstanceSecurityGroup().Return(instanceSG).Times(2)
+	mockInstance.EXPECT().CurrentInstanceSecurityGroup().Return(instanceSG).Times(2)
 
 	gomock.InOrder(
 		mockEc2APIHelper.EXPECT().CreateAndAttachNetworkInterface(&instanceID, &subnetID, instanceSG, nil, aws.Int64(3),
@@ -283,7 +283,7 @@ func TestEniManager_CreateIPV4Address_InBetweenENIFail(t *testing.T) {
 	mockInstance.EXPECT().GetHighestUnusedDeviceIndex().Return(int64(3), nil).Times(2)
 	mockInstance.EXPECT().InstanceID().Return(instanceID).Times(2)
 	mockInstance.EXPECT().SubnetID().Return(subnetID).Times(2)
-	mockInstance.EXPECT().InstanceSecurityGroup().Return(instanceSG).Times(2)
+	mockInstance.EXPECT().CurrentInstanceSecurityGroup().Return(instanceSG).Times(2)
 
 	gomock.InOrder(
 		mockEc2APIHelper.EXPECT().CreateAndAttachNetworkInterface(&instanceID, &subnetID, instanceSG, nil, aws.Int64(3),

--- a/pkg/provider/ip/eni/eni_test.go
+++ b/pkg/provider/ip/eni/eni_test.go
@@ -247,7 +247,7 @@ func TestEniManager_CreateIPV4Address_FromNewENI(t *testing.T) {
 	mockInstance.EXPECT().InstanceID().Return(instanceID).Times(2)
 	mockInstance.EXPECT().SubnetID().Return(subnetID).Times(2)
 	mockInstance.EXPECT().SubnetMask().Return(subnetMask).Times(4)
-	mockInstance.EXPECT().CurrentInstanceSecurityGroup().Return(instanceSG).Times(2)
+	mockInstance.EXPECT().CurrentInstanceSecurityGroups().Return(instanceSG).Times(2)
 
 	gomock.InOrder(
 		mockEc2APIHelper.EXPECT().CreateAndAttachNetworkInterface(&instanceID, &subnetID, instanceSG, nil, aws.Int64(3),
@@ -283,7 +283,7 @@ func TestEniManager_CreateIPV4Address_InBetweenENIFail(t *testing.T) {
 	mockInstance.EXPECT().GetHighestUnusedDeviceIndex().Return(int64(3), nil).Times(2)
 	mockInstance.EXPECT().InstanceID().Return(instanceID).Times(2)
 	mockInstance.EXPECT().SubnetID().Return(subnetID).Times(2)
-	mockInstance.EXPECT().CurrentInstanceSecurityGroup().Return(instanceSG).Times(2)
+	mockInstance.EXPECT().CurrentInstanceSecurityGroups().Return(instanceSG).Times(2)
 
 	gomock.InOrder(
 		mockEc2APIHelper.EXPECT().CreateAndAttachNetworkInterface(&instanceID, &subnetID, instanceSG, nil, aws.Int64(3),

--- a/scripts/gen_mocks.sh
+++ b/scripts/gen_mocks.sh
@@ -24,4 +24,4 @@ mockgen -destination=../mocks/amazon-vcp-resource-controller-k8s/pkg/pool/mock_p
 # package resource maocks
 mockgen -destination=../mocks/amazon-vcp-resource-controller-k8s/pkg/resource/mock_resources.go github.com/aws/amazon-vpc-resource-controller-k8s/pkg/resource ResourceManager
 # package condition maocks
-mockgen -destination=../mocks/amazon-vcp-resource-controller-k8s/pkg/condition/mock_condtion.go github.com/aws/amazon-vpc-resource-controller-k8s/pkg/condition Conditions
+mockgen -destination=../mocks/amazon-vcp-resource-controller-k8s/pkg/condition/mock_condition.go github.com/aws/amazon-vpc-resource-controller-k8s/pkg/condition Conditions


### PR DESCRIPTION
*Issue #, if available:*
Fixes #189 

*Description of changes:*
Currently, when security group is not specified in ENIConfig, the trunk ENI is associated with the default security group of the VPC. The expected behavior when using vpc-cni >= v1.8.0 is to use the primary network interface security groups with secondary network interfaces. 

Changes in this PR is to associate the trunk ENI with the primary network interface security groups when ENIConfig is missing security groups. 

*Testing:*

1. Created two eniconfigs as follows-
```
[10/05/23 1:34:11] ➜  ~ kubectl get eniconfigs.crd.k8s.amazonaws.com -o yaml
apiVersion: v1
items:
- apiVersion: crd.k8s.amazonaws.com/v1alpha1
  kind: ENIConfig
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"crd.k8s.amazonaws.com/v1alpha1","kind":"ENIConfig","metadata":{"annotations":{},"name":"us-west-2a"},"spec":{"securityGroups":["sg-1111111111"],"subnet":"subnet-1111111111"}}
    creationTimestamp: "2023-04-24T23:07:30Z"
    generation: 4
    name: us-west-2a
    resourceVersion: "11479510"
    uid: a261d5a8-8aea-4df4-a1b5-05e2525ea395
  spec:
    securityGroups:
    - sg-1111111111
    subnet: subnet-1111111111
- apiVersion: crd.k8s.amazonaws.com/v1alpha1
  kind: ENIConfig
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"crd.k8s.amazonaws.com/v1alpha1","kind":"ENIConfig","metadata":{"annotations":{},"name":"us-west-2b"},"spec":{"subnet":"subnet-2222222222"}}
    creationTimestamp: "2023-04-27T16:05:58Z"
    generation: 3
    name: us-west-2b
    resourceVersion: "6314138"
    uid: f80f995b-a1fc-4d56-a93d-b4dab5b60546
  spec:
    subnet: subnet-2222222222
kind: List
metadata:
  resourceVersion: ""
```
In v1.1.5, the trunk ENI of the instance in `us-west-2b` is associated with the default security group of the VPC. Verified that with the changes in this PR the trunk ENI is associated with the primary network interface security groups. 
Also verified with correct ENIConfigs that the trunk ENI is associated with the SG specified in the ENIConfig

2. Ran all SGP tests in non-custom networking cluster to verify no regression issues- (skipping LOCAL tests)
```
Running Suite: Per Pod Security Group Suite - /home/ravsushm/go/src/github.com/aws/amazon-vpc-resource-controller-k8s/test/integration/perpodsg
===============================================================================================================================================
Random Seed: 1683852685

Will run 18 of 22 specs
-- redacted--

[AfterSuite] 
/home/ravsushm/go/src/github.com/aws/amazon-vpc-resource-controller-k8s/test/integration/perpodsg/perpodsg_suite_test.go:58
  STEP: waiting for all the ENIs to be deleted after being cooled down @ 05/12/23 01:12:50.433
[AfterSuite] PASSED [90.552 seconds]
------------------------------

Ran 18 of 22 Specs in 1372.557 seconds
SUCCESS! -- 18 Passed | 0 Failed | 0 Pending | 4 Skipped
PASS

```

*Release Notes:* 
This PR introduces a breaking change. Starting in v1.1.6+, when security groups are not specified in ENIConfig with custom networking enabled, the trunk ENI will be associated with the security group of the primary network interface rather than the default security group of the VPC. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
