### PR TITLE
added prefix provider and support for PD configuration params

### DIFF
--- a/controllers/core/configmap_controller.go
+++ b/controllers/core/configmap_controller.go
@@ -94,7 +94,7 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Check if configurations for Windows prefix delegation have changed
 	var isPDConfigUpdated bool
-	warmIPTarget, minIPTarget, warmPrefixTarget := config.ParseWinPDTargets(configmap)
+	warmIPTarget, minIPTarget, warmPrefixTarget := config.ParseWinPDTargets(r.Log, configmap)
 	if r.curWinPDWarmIPTarget != warmIPTarget || r.curWinPDMinIPTarget != minIPTarget || r.curWinPDWarmPrefixTarget != warmPrefixTarget {
 		r.curWinPDWarmIPTarget = warmIPTarget
 		r.curWinPDMinIPTarget = minIPTarget

--- a/controllers/core/configmap_controller.go
+++ b/controllers/core/configmap_controller.go
@@ -21,12 +21,14 @@ import (
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/k8s"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/node/manager"
+
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 // ConfigMapReconciler reconciles a ConfigMap object
@@ -39,6 +41,9 @@ type ConfigMapReconciler struct {
 	Condition                         condition.Conditions
 	curWinIPAMEnabledCond             bool
 	curWinPrefixDelegationEnabledCond bool
+	curWinPDWarmIPTarget              int
+	curWinPDMinIPTarget               int
+	curWinPDWarmPrefixTarget          int
 }
 
 //+kubebuilder:rbac:groups=core,resources=configmaps,namespace=kube-system,resourceNames=amazon-vpc-cni,verbs=get;list;watch
@@ -65,7 +70,7 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	// Check if the flag value has changed
+	// Check if the Windows IPAM flag has changed
 	newWinIPAMEnabledCond := r.Condition.IsWindowsIPAMEnabled()
 
 	var isIPAMFlagUpdated bool
@@ -87,8 +92,21 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		isPrefixFlagUpdated = true
 	}
 
+	// Check if configurations for Windows prefix delegation have changed
+	var isPDConfigUpdated bool
+	warmIPTarget, minIPTarget, warmPrefixTarget := config.ParseWinPDTargets(configmap)
+	if r.curWinPDWarmIPTarget != warmIPTarget || r.curWinPDMinIPTarget != minIPTarget || r.curWinPDWarmPrefixTarget != warmPrefixTarget {
+		r.curWinPDWarmIPTarget = warmIPTarget
+		r.curWinPDMinIPTarget = minIPTarget
+		r.curWinPDWarmPrefixTarget = warmPrefixTarget
+		logger.Info("updated PD configs from configmap", config.WarmIPTarget, r.curWinPDWarmIPTarget,
+			config.MinimumIPTarget, r.curWinPDMinIPTarget, config.WarmPrefixTarget, r.curWinPDWarmPrefixTarget)
+
+		isPDConfigUpdated = true
+	}
+
 	// Flag is updated, update all nodes
-	if isIPAMFlagUpdated || isPrefixFlagUpdated {
+	if isIPAMFlagUpdated || isPrefixFlagUpdated || isPDConfigUpdated {
 		err := UpdateNodesOnConfigMapChanges(r.K8sAPI, r.NodeManager)
 		if err != nil {
 			// Error in updating nodes
@@ -102,8 +120,11 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Explicitly set MaxConcurrentReconciles to 1 to ensure concurrent reconciliation NOT supported for config map controller.
+	// Don't change to more than 1 unless the struct is guarded against concurrency issues.
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.ConfigMap{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
 		Complete(r)
 }
 

--- a/main.go
+++ b/main.go
@@ -278,8 +278,7 @@ func main() {
 	// hasPodDataStoreSynced is set to true when the custom controller has synced
 	controllerConditions := condition.NewControllerConditions(
 		ctrl.Log.WithName("controller conditions"), k8sApi)
-	//supportedResources := []string{config.ResourceNamePodENI, config.ResourceNameIPAddress, config.ResourceNameIPAddressFromPrefix}
-	supportedResources := []string{config.ResourceNamePodENI, config.ResourceNameIPAddress}
+	supportedResources := []string{config.ResourceNamePodENI, config.ResourceNameIPAddress, config.ResourceNameIPAddressFromPrefix}
 	resourceManager, err := resource.NewResourceManager(ctx, supportedResources, apiWrapper, controllerConditions)
 	if err != nil {
 		ctrl.Log.Error(err, "failed to init resources", "resources", supportedResources)

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -16,8 +16,8 @@ package config
 import (
 	"strconv"
 
+	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 const (
@@ -66,10 +66,10 @@ func LoadResourceConfig() map[string]ResourceConfig {
 	return getDefaultResourceConfig()
 }
 
-func LoadResourceConfigFromConfigMap(vpcCniConfigMap *v1.ConfigMap) map[string]ResourceConfig {
+func LoadResourceConfigFromConfigMap(log logr.Logger, vpcCniConfigMap *v1.ConfigMap) map[string]ResourceConfig {
 	resourceConfig := getDefaultResourceConfig()
 
-	warmIPTarget, minIPTarget, warmPrefixTarget := ParseWinPDTargets(vpcCniConfigMap)
+	warmIPTarget, minIPTarget, warmPrefixTarget := ParseWinPDTargets(log, vpcCniConfigMap)
 
 	// If no PD configuration is set in configMap or none is valid, return default resource config
 	if warmIPTarget == 0 && minIPTarget == 0 && warmPrefixTarget == 0 {
@@ -84,9 +84,7 @@ func LoadResourceConfigFromConfigMap(vpcCniConfigMap *v1.ConfigMap) map[string]R
 }
 
 // ParseWinPDTargets parses config map for Windows prefix delegation configurations set by users
-func ParseWinPDTargets(vpcCniConfigMap *v1.ConfigMap) (warmIPTarget int, minIPTarget int, warmPrefixTarget int) {
-	var log = ctrl.Log.WithName("parse windows prefix delegation targets from config map")
-
+func ParseWinPDTargets(log logr.Logger, vpcCniConfigMap *v1.ConfigMap) (warmIPTarget int, minIPTarget int, warmPrefixTarget int) {
 	warmIPTarget, minIPTarget, warmPrefixTarget = 0, 0, 0
 
 	if vpcCniConfigMap.Data == nil {

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 // TestLoadResourceConfig tests the default resource configurations
@@ -62,6 +63,8 @@ func TestLoadResourceConfig(t *testing.T) {
 
 // TestParseWinPDTargets parses prefix delegation configurations from a vpc cni config map
 func TestParseWinPDTargets(t *testing.T) {
+	log := zap.New(zap.UseDevMode(true)).WithName("loader test")
+
 	vpcCNIConfig := &v1.ConfigMap{
 		Data: map[string]string{
 			EnableWindowsIPAMKey:             "true",
@@ -71,7 +74,7 @@ func TestParseWinPDTargets(t *testing.T) {
 			WarmPrefixTarget:                 strconv.Itoa(IPv4PDDefaultWarmPrefixTargetSize),
 		},
 	}
-	warmIPTarget, minIPTarget, warmPrefixTarget := ParseWinPDTargets(vpcCNIConfig)
+	warmIPTarget, minIPTarget, warmPrefixTarget := ParseWinPDTargets(log, vpcCNIConfig)
 	assert.Equal(t, IPv4PDDefaultWarmIPTargetSize, warmIPTarget)
 	assert.Equal(t, IPv4PDDefaultMinIPTargetSize, minIPTarget)
 	assert.Equal(t, IPv4PDDefaultWarmPrefixTargetSize, warmPrefixTarget)
@@ -79,6 +82,8 @@ func TestParseWinPDTargets(t *testing.T) {
 
 // TestParseWinPDTargets parses prefix delegation configurations with negative values and returns the same
 func TestParseWinPDTargets_Negative(t *testing.T) {
+	log := zap.New(zap.UseDevMode(true)).WithName("loader test")
+
 	vpcCNIConfig := &v1.ConfigMap{
 		Data: map[string]string{
 			EnableWindowsIPAMKey:             "true",
@@ -88,7 +93,7 @@ func TestParseWinPDTargets_Negative(t *testing.T) {
 			WarmPrefixTarget:                 strconv.Itoa(0),
 		},
 	}
-	warmIPTarget, minIPTarget, warmPrefixTarget := ParseWinPDTargets(vpcCNIConfig)
+	warmIPTarget, minIPTarget, warmPrefixTarget := ParseWinPDTargets(log, vpcCNIConfig)
 	// negative values are still read in but processed when it's used in the warm pool
 	assert.Equal(t, -10, warmIPTarget)
 	assert.Equal(t, -100, minIPTarget)
@@ -97,6 +102,8 @@ func TestParseWinPDTargets_Negative(t *testing.T) {
 
 // TestParseWinPDTargets_Invalid parses prefix delegation configurations with invalid values and returns 0s as targets
 func TestParseWinPDTargets_Invalid(t *testing.T) {
+	log := zap.New(zap.UseDevMode(true)).WithName("loader test")
+
 	vpcCNIConfig := &v1.ConfigMap{
 		Data: map[string]string{
 			EnableWindowsIPAMKey:             "true",
@@ -106,7 +113,7 @@ func TestParseWinPDTargets_Invalid(t *testing.T) {
 			WarmPrefixTarget:                 "can't parse",
 		},
 	}
-	warmIPTarget, minIPTarget, warmPrefixTarget := ParseWinPDTargets(vpcCNIConfig)
+	warmIPTarget, minIPTarget, warmPrefixTarget := ParseWinPDTargets(log, vpcCNIConfig)
 	assert.Equal(t, 0, warmIPTarget)
 	assert.Equal(t, 0, minIPTarget)
 	assert.Equal(t, 0, warmPrefixTarget)
@@ -114,6 +121,8 @@ func TestParseWinPDTargets_Invalid(t *testing.T) {
 
 // TestLoadResourceConfigFromConfigMap tests the custom configuration for PD is loaded correctly from config map
 func TestLoadResourceConfigFromConfigMap(t *testing.T) {
+	log := zap.New(zap.UseDevMode(true)).WithName("loader test")
+
 	warmIPTarget := 2
 	minimumIPTarget := 10
 	warmPrefixTarget := 1
@@ -127,7 +136,7 @@ func TestLoadResourceConfigFromConfigMap(t *testing.T) {
 		},
 	}
 
-	resourceConfig := LoadResourceConfigFromConfigMap(vpcCNIConfig)
+	resourceConfig := LoadResourceConfigFromConfigMap(log, vpcCNIConfig)
 
 	// Verify default resource configuration for resource Pod ENI
 	podENIConfig := resourceConfig[ResourceNamePodENI]

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -14,9 +14,11 @@
 package config
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
 )
 
 // TestLoadResourceConfig tests the default resource configurations
@@ -42,4 +44,122 @@ func TestLoadResourceConfig(t *testing.T) {
 	assert.Equal(t, IPv4DefaultMaxDev, ipV4WPConfig.MaxDeviation)
 	assert.Equal(t, IPv4DefaultResSize, ipV4WPConfig.ReservedSize)
 
+	// Verify default resource configuration for prefix-deconstructed IPv4 Address
+	prefixIPv4Config := defaultResourceConfig[ResourceNameIPAddressFromPrefix]
+	assert.Equal(t, ResourceNameIPAddressFromPrefix, prefixIPv4Config.Name)
+	assert.Equal(t, IPv4PDDefaultWorker, prefixIPv4Config.WorkerCount)
+	assert.Equal(t, map[string]bool{OSLinux: false, OSWindows: true}, prefixIPv4Config.SupportedOS)
+
+	// Verify default Warm pool configuration for prefix-deconstructed IPv4 Address
+	prefixIPv4WPConfig := prefixIPv4Config.WarmPoolConfig
+	assert.Equal(t, IPv4PDDefaultWPSize, prefixIPv4WPConfig.DesiredSize)
+	assert.Equal(t, IPv4PDDefaultMaxDev, prefixIPv4WPConfig.MaxDeviation)
+	assert.Equal(t, IPv4PDDefaultResSize, prefixIPv4WPConfig.ReservedSize)
+	assert.Equal(t, IPv4PDDefaultWarmIPTargetSize, prefixIPv4WPConfig.WarmIPTarget)
+	assert.Equal(t, IPv4PDDefaultMinIPTargetSize, prefixIPv4WPConfig.MinIPTarget)
+	assert.Equal(t, IPv4PDDefaultWarmPrefixTargetSize, prefixIPv4WPConfig.WarmPrefixTarget)
+}
+
+// TestParseWinPDTargets parses prefix delegation configurations from a vpc cni config map
+func TestParseWinPDTargets(t *testing.T) {
+	vpcCNIConfig := &v1.ConfigMap{
+		Data: map[string]string{
+			EnableWindowsIPAMKey:             "true",
+			EnableWindowsPrefixDelegationKey: "true",
+			WarmIPTarget:                     strconv.Itoa(IPv4PDDefaultWarmIPTargetSize),
+			MinimumIPTarget:                  strconv.Itoa(IPv4PDDefaultMinIPTargetSize),
+			WarmPrefixTarget:                 strconv.Itoa(IPv4PDDefaultWarmPrefixTargetSize),
+		},
+	}
+	warmIPTarget, minIPTarget, warmPrefixTarget := ParseWinPDTargets(vpcCNIConfig)
+	assert.Equal(t, IPv4PDDefaultWarmIPTargetSize, warmIPTarget)
+	assert.Equal(t, IPv4PDDefaultMinIPTargetSize, minIPTarget)
+	assert.Equal(t, IPv4PDDefaultWarmPrefixTargetSize, warmPrefixTarget)
+}
+
+// TestParseWinPDTargets parses prefix delegation configurations with negative values and returns the same
+func TestParseWinPDTargets_Negative(t *testing.T) {
+	vpcCNIConfig := &v1.ConfigMap{
+		Data: map[string]string{
+			EnableWindowsIPAMKey:             "true",
+			EnableWindowsPrefixDelegationKey: "true",
+			WarmIPTarget:                     strconv.Itoa(-10),
+			MinimumIPTarget:                  strconv.Itoa(-100),
+			WarmPrefixTarget:                 strconv.Itoa(0),
+		},
+	}
+	warmIPTarget, minIPTarget, warmPrefixTarget := ParseWinPDTargets(vpcCNIConfig)
+	// negative values are still read in but processed when it's used in the warm pool
+	assert.Equal(t, -10, warmIPTarget)
+	assert.Equal(t, -100, minIPTarget)
+	assert.Equal(t, 0, warmPrefixTarget)
+}
+
+// TestParseWinPDTargets_Invalid parses prefix delegation configurations with invalid values and returns 0s as targets
+func TestParseWinPDTargets_Invalid(t *testing.T) {
+	vpcCNIConfig := &v1.ConfigMap{
+		Data: map[string]string{
+			EnableWindowsIPAMKey:             "true",
+			EnableWindowsPrefixDelegationKey: "true",
+			WarmIPTarget:                     "random",
+			MinimumIPTarget:                  "string val",
+			WarmPrefixTarget:                 "can't parse",
+		},
+	}
+	warmIPTarget, minIPTarget, warmPrefixTarget := ParseWinPDTargets(vpcCNIConfig)
+	assert.Equal(t, 0, warmIPTarget)
+	assert.Equal(t, 0, minIPTarget)
+	assert.Equal(t, 0, warmPrefixTarget)
+}
+
+// TestLoadResourceConfigFromConfigMap tests the custom configuration for PD is loaded correctly from config map
+func TestLoadResourceConfigFromConfigMap(t *testing.T) {
+	warmIPTarget := 2
+	minimumIPTarget := 10
+	warmPrefixTarget := 1
+	vpcCNIConfig := &v1.ConfigMap{
+		Data: map[string]string{
+			EnableWindowsIPAMKey:             "true",
+			EnableWindowsPrefixDelegationKey: "true",
+			WarmIPTarget:                     strconv.Itoa(warmIPTarget),
+			MinimumIPTarget:                  strconv.Itoa(minimumIPTarget),
+			WarmPrefixTarget:                 strconv.Itoa(warmPrefixTarget),
+		},
+	}
+
+	resourceConfig := LoadResourceConfigFromConfigMap(vpcCNIConfig)
+
+	// Verify default resource configuration for resource Pod ENI
+	podENIConfig := resourceConfig[ResourceNamePodENI]
+	assert.Equal(t, ResourceNamePodENI, podENIConfig.Name)
+	assert.Equal(t, PodENIDefaultWorker, podENIConfig.WorkerCount)
+	assert.Equal(t, map[string]bool{OSLinux: true, OSWindows: false}, podENIConfig.SupportedOS)
+	assert.Nil(t, podENIConfig.WarmPoolConfig)
+
+	// Verify default resource configuration for resource IPv4 Address
+	ipV4Config := resourceConfig[ResourceNameIPAddress]
+	assert.Equal(t, ResourceNameIPAddress, ipV4Config.Name)
+	assert.Equal(t, IPv4DefaultWorker, ipV4Config.WorkerCount)
+	assert.Equal(t, map[string]bool{OSLinux: false, OSWindows: true}, ipV4Config.SupportedOS)
+
+	// Verify default Warm pool configuration for IPv4 Address
+	ipV4WPConfig := ipV4Config.WarmPoolConfig
+	assert.Equal(t, IPv4DefaultWPSize, ipV4WPConfig.DesiredSize)
+	assert.Equal(t, IPv4DefaultMaxDev, ipV4WPConfig.MaxDeviation)
+	assert.Equal(t, IPv4DefaultResSize, ipV4WPConfig.ReservedSize)
+
+	// Verify default resource configuration for prefix-deconstructed IPv4 Address
+	prefixIPv4Config := resourceConfig[ResourceNameIPAddressFromPrefix]
+	assert.Equal(t, ResourceNameIPAddressFromPrefix, prefixIPv4Config.Name)
+	assert.Equal(t, IPv4PDDefaultWorker, prefixIPv4Config.WorkerCount)
+	assert.Equal(t, map[string]bool{OSLinux: false, OSWindows: true}, prefixIPv4Config.SupportedOS)
+
+	// Verify default Warm pool configuration for prefix-deconstructed IPv4 Address
+	prefixIPv4WPConfig := prefixIPv4Config.WarmPoolConfig
+	assert.Equal(t, IPv4PDDefaultWPSize, prefixIPv4WPConfig.DesiredSize)
+	assert.Equal(t, IPv4PDDefaultMaxDev, prefixIPv4WPConfig.MaxDeviation)
+	assert.Equal(t, IPv4PDDefaultResSize, prefixIPv4WPConfig.ReservedSize)
+	assert.Equal(t, warmIPTarget, prefixIPv4WPConfig.WarmIPTarget)
+	assert.Equal(t, minimumIPTarget, prefixIPv4WPConfig.MinIPTarget)
+	assert.Equal(t, warmPrefixTarget, prefixIPv4WPConfig.WarmPrefixTarget)
 }

--- a/pkg/provider/ip/provider.go
+++ b/pkg/provider/ip/provider.go
@@ -48,7 +48,7 @@ type ipv4Provider struct {
 	conditions condition.Conditions
 }
 
-// InstanceResource contains the instance's ENI manager and the resource pool
+// ResourceProviderAndPool contains the instance's ENI manager and the resource pool
 type ResourceProviderAndPool struct {
 	// lock guards the struct
 	lock         sync.RWMutex
@@ -175,9 +175,11 @@ func (p *ipv4Provider) UpdateResourceCapacity(instance ec2.EC2Instance) error {
 	// do not update the capacity as that would be done by prefix provider
 	if !resourceProviderAndPool.isPrevPDEnabled && isCurrPDEnabled {
 		resourceProviderAndPool.isPrevPDEnabled = true
-		job := resourceProviderAndPool.resourcePool.SetToDraining()
 		p.log.Info("Prefix IP provider should be active")
-		p.SubmitAsyncJob(job)
+		job := resourceProviderAndPool.resourcePool.SetToDraining()
+		if job.Operations != worker.OperationReconcileNotRequired {
+			p.SubmitAsyncJob(job)
+		}
 		return nil
 	}
 
@@ -185,7 +187,9 @@ func (p *ipv4Provider) UpdateResourceCapacity(instance ec2.EC2Instance) error {
 
 	// Set the secondary IP provider pool state to active
 	job := resourceProviderAndPool.resourcePool.SetToActive(p.config)
-	p.SubmitAsyncJob(job)
+	if job.Operations != worker.OperationReconcileNotRequired {
+		p.SubmitAsyncJob(job)
+	}
 
 	instanceType := instance.Type()
 	instanceName := instance.Name()

--- a/pkg/provider/ip/provider_test.go
+++ b/pkg/provider/ip/provider_test.go
@@ -44,7 +44,6 @@ var (
 	ip3 = "192.168.1.3"
 
 	nodeCapacity = 14
-	isPDEnabled  = false
 )
 
 // TestIpv4Provider_difference tests difference removes the difference between an array and a set
@@ -107,9 +106,10 @@ func TestIpv4Provider_putInstanceProviderAndPool(t *testing.T) {
 	mockManager := mock_eni.NewMockENIManager(ctrl)
 
 	ipProvider := getMockIpProvider()
-	ipProvider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, isPDEnabled)
+	ipProvider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, false)
 
-	assert.Equal(t, &ResourceProviderAndPool{resourcePool: mockPool, eniManager: mockManager, capacity: nodeCapacity, isPrevPDEnabled: isPDEnabled}, ipProvider.instanceProviderAndPool[nodeName])
+	assert.Equal(t, &ResourceProviderAndPool{resourcePool: mockPool, eniManager: mockManager, capacity: nodeCapacity, isPrevPDEnabled: false},
+		ipProvider.instanceProviderAndPool[nodeName])
 }
 
 // TestIpv4Provider_updatePoolAndReconcileIfRequired_NoFurtherReconcile tests pool is updated and reconciliation is not
@@ -157,7 +157,7 @@ func TestIpv4Provider_DeletePrivateIPv4AndUpdatePool(t *testing.T) {
 	ipv4Provider := getMockIpProvider()
 	mockPool := mock_pool.NewMockPool(ctrl)
 	mockManager := mock_eni.NewMockENIManager(ctrl)
-	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, isPDEnabled)
+	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, false)
 	resourcesToDelete := []string{ip1, ip2}
 
 	deleteJob := &worker.WarmPoolJob{
@@ -187,7 +187,7 @@ func TestIpv4Provider_DeletePrivateIPv4AndUpdatePool_SomeResourceFail(t *testing
 	ipv4Provider := getMockIpProvider()
 	mockPool := mock_pool.NewMockPool(ctrl)
 	mockManager := mock_eni.NewMockENIManager(ctrl)
-	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, isPDEnabled)
+	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, false)
 	resourcesToDelete := []string{ip1, ip2}
 	failedResources := []string{ip2}
 
@@ -218,7 +218,7 @@ func TestIPv4Provider_CreatePrivateIPv4AndUpdatePool(t *testing.T) {
 	ipv4Provider := getMockIpProvider()
 	mockPool := mock_pool.NewMockPool(ctrl)
 	mockManager := mock_eni.NewMockENIManager(ctrl)
-	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, isPDEnabled)
+	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, false)
 	createdResources := []string{ip1, ip2}
 
 	createJob := &worker.WarmPoolJob{
@@ -248,7 +248,7 @@ func TestIPv4Provider_CreatePrivateIPv4AndUpdatePool_Fail(t *testing.T) {
 	ipv4Provider := getMockIpProvider()
 	mockPool := mock_pool.NewMockPool(ctrl)
 	mockManager := mock_eni.NewMockENIManager(ctrl)
-	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, isPDEnabled)
+	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, false)
 	createdResources := []string{ip1, ip2}
 
 	createJob := &worker.WarmPoolJob{
@@ -276,7 +276,7 @@ func TestIpv4Provider_ReSyncPool(t *testing.T) {
 	ipv4Provider := getMockIpProvider()
 	mockPool := mock_pool.NewMockPool(ctrl)
 	mockManager := mock_eni.NewMockENIManager(ctrl)
-	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, isPDEnabled)
+	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, false)
 	resources := []string{ip1, ip2}
 
 	reSyncJob := &worker.WarmPoolJob{
@@ -330,7 +330,7 @@ func TestIPv4Provider_UpdateResourceCapacity_FromFromPDToIP(t *testing.T) {
 
 	mockPool := mock_pool.NewMockPool(ctrl)
 	mockManager := mock_eni.NewMockENIManager(ctrl)
-	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, !isPDEnabled)
+	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, true)
 	mockConditions.EXPECT().IsWindowsPrefixDelegationEnabled().Return(false)
 
 	job := &worker.WarmPoolJob{Operations: worker.OperationCreate}
@@ -360,7 +360,7 @@ func TestIPv4Provider_UpdateResourceCapacity_FromFromIPToPD(t *testing.T) {
 
 	mockPool := mock_pool.NewMockPool(ctrl)
 	mockManager := mock_eni.NewMockENIManager(ctrl)
-	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, isPDEnabled)
+	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, false)
 	mockConditions.EXPECT().IsWindowsPrefixDelegationEnabled().Return(true)
 
 	job := &worker.WarmPoolJob{Operations: worker.OperationDeleted}
@@ -386,7 +386,7 @@ func TestIPv4Provider_UpdateResourceCapacity_FromPDToPD(t *testing.T) {
 	mockPool := mock_pool.NewMockPool(ctrl)
 	mockManager := mock_eni.NewMockENIManager(ctrl)
 	mockInstance.EXPECT().Name().Return(nodeName).Times(1)
-	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, !isPDEnabled)
+	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, true)
 	mockConditions.EXPECT().IsWindowsPrefixDelegationEnabled().Return(true)
 
 	err := ipv4Provider.UpdateResourceCapacity(mockInstance)
@@ -407,7 +407,7 @@ func TestIPv4Provider_UpdateResourceCapacity_FromIPToIP(t *testing.T) {
 	mockPool := mock_pool.NewMockPool(ctrl)
 	mockManager := mock_eni.NewMockENIManager(ctrl)
 	mockInstance.EXPECT().Name().Return(nodeName).Times(1)
-	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, isPDEnabled)
+	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, false)
 	mockConditions.EXPECT().IsWindowsPrefixDelegationEnabled().Return(false)
 
 	err := ipv4Provider.UpdateResourceCapacity(mockInstance)
@@ -420,7 +420,7 @@ func TestIpv4Provider_GetPool(t *testing.T) {
 
 	ipv4Provider := getMockIpProvider()
 	mockPool := mock_pool.NewMockPool(ctrl)
-	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, nil, nodeCapacity, isPDEnabled)
+	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, nil, nodeCapacity, false)
 
 	pool, found := ipv4Provider.GetPool(nodeName)
 	assert.True(t, found)
@@ -433,7 +433,7 @@ func TestIpv4Provider_Introspect(t *testing.T) {
 
 	ipv4Provider := getMockIpProvider()
 	mockPool := mock_pool.NewMockPool(ctrl)
-	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, nil, nodeCapacity, isPDEnabled)
+	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, nil, nodeCapacity, false)
 	expectedResp := pool.IntrospectResponse{}
 
 	mockPool.EXPECT().Introspect().Return(expectedResp)

--- a/pkg/provider/prefix/provider.go
+++ b/pkg/provider/prefix/provider.go
@@ -1,0 +1,428 @@
+package prefix
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/api"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/vpc"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/condition"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/pool"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/ip/eni"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/utils"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/worker"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type ipv4PrefixProvider struct {
+	// log is the logger initialized with prefix provider details
+	log logr.Logger
+	// apiWrapper wraps all clients used by the controller
+	apiWrapper api.Wrapper
+	// workerPool with worker routine to execute asynchronous job on the prefix provider
+	workerPool worker.Worker
+	// config is the warm pool configuration for the resource prefix
+	config *config.WarmPoolConfig
+	// lock to allow multiple routines to access the cache concurrently
+	lock sync.RWMutex // guards the following
+	// instanceResources stores the ENIManager and the resource pool per instance
+	instanceProviderAndPool map[string]*ResourceProviderAndPool
+	// conditions is used to check which IP allocation mode is enabled
+	conditions condition.Conditions
+}
+
+// ResourceProviderAndPool contains the instance's ENI manager and the resource pool
+type ResourceProviderAndPool struct {
+	// lock guards the struct
+	lock         sync.RWMutex
+	eniManager   eni.ENIManager
+	resourcePool pool.Pool
+	// capacity is stored so that it can be advertised when node is updated
+	capacity int
+	// isPrevPDEnabled stores whether PD was enabled previously
+	isPrevPDEnabled bool
+}
+
+func NewIPv4PrefixProvider(log logr.Logger, apiWrapper api.Wrapper, workerPool worker.Worker,
+	resourceConfig config.ResourceConfig, conditions condition.Conditions) provider.ResourceProvider {
+	return &ipv4PrefixProvider{
+		instanceProviderAndPool: make(map[string]*ResourceProviderAndPool),
+		config:                  resourceConfig.WarmPoolConfig,
+		log:                     log,
+		apiWrapper:              apiWrapper,
+		workerPool:              workerPool,
+		conditions:              conditions,
+	}
+}
+
+func (p *ipv4PrefixProvider) InitResource(instance ec2.EC2Instance) error {
+	nodeName := instance.Name()
+
+	eniManager := eni.NewENIManager(instance)
+	ipV4Resources, err := eniManager.InitResources(p.apiWrapper.EC2API)
+	if err != nil || ipV4Resources == nil {
+		return err
+	}
+
+	presentIPs := ipV4Resources.PrivateIPv4Addresses
+	presentPrefixes := ipV4Resources.IPv4Prefixes
+
+	pods, err := p.apiWrapper.PodAPI.GetRunningPodsOnNode(nodeName)
+	if err != nil {
+		return err
+	}
+
+	// Construct map of all possible IPs to prefix for each assigned prefix
+	warmResourceIDToGroup := map[string]string{}
+	for _, prefix := range presentPrefixes {
+		ips, err := utils.DeconstructIPsFromPrefix(prefix)
+		if err != nil {
+			return err
+		}
+		for _, ip := range ips {
+			warmResourceIDToGroup[ip] = prefix
+		}
+	}
+
+	podToResourceMap := make(map[string]pool.Resource)
+
+	for _, pod := range pods {
+		annotation, present := pod.Annotations[config.ResourceNameIPAddress]
+		if !present {
+			continue
+		}
+
+		prefix, found := warmResourceIDToGroup[annotation]
+		if found {
+			// store running pod into map of used resources
+			podToResourceMap[string(pod.UID)] = pool.Resource{GroupID: prefix, ResourceID: annotation}
+			// remove running pod's IP from warm resources
+			delete(warmResourceIDToGroup, annotation)
+		} else {
+			// If running pod's IP is not constructed from an assigned prefix on the instance, ignore it
+			p.log.Info("ignoring secondary IP", "IPv4 address ", annotation)
+		}
+	}
+
+	// Construct map of warm Resources, key is prefix, value is list of Resources belonged to that prefix
+	warmResources := make(map[string][]pool.Resource)
+	for ip, prefix := range warmResourceIDToGroup {
+		warmResources[prefix] = append(warmResources[prefix], pool.Resource{GroupID: prefix, ResourceID: ip})
+	}
+
+	// Subtract number of existing secondary IP address from total number of interfaces, and then multiply by 16
+	nodeCapacity := (getCapacity(instance.Type(), instance.Os()) - len(presentIPs)) * pool.NumIPv4AddrPerPrefix
+
+	p.config = p.getPDWarmPoolConfig()
+
+	// Set warm pool config to empty if PD is not enabled
+	prefixIPWPConfig := p.config
+	isPDEnabled := p.conditions.IsWindowsPrefixDelegationEnabled()
+	if !isPDEnabled {
+		prefixIPWPConfig = &config.WarmPoolConfig{}
+	}
+
+	resourcePool := pool.NewResourcePool(p.log.WithName("prefix ipv4 address resource pool").
+		WithValues("node name", instance.Name()), prefixIPWPConfig, podToResourceMap,
+		warmResources, instance.Name(), nodeCapacity, true)
+
+	p.putInstanceProviderAndPool(nodeName, resourcePool, eniManager, nodeCapacity, isPDEnabled)
+
+	p.log.Info("initialized the resource provider for ipv4 prefix",
+		"capacity", nodeCapacity, "node name", nodeName, "instance type",
+		instance.Type(), "instance ID", instance.InstanceID(), "warmPoolConfig", p.config)
+
+	job := resourcePool.ReconcilePool()
+	if job.Operations != worker.OperationReconcileNotRequired {
+		p.SubmitAsyncJob(job)
+	}
+
+	// Submit the async job to periodically process the delete queue
+	p.SubmitAsyncJob(worker.NewWarmProcessDeleteQueueJob(nodeName))
+	return nil
+}
+
+func (p *ipv4PrefixProvider) DeInitResource(instance ec2.EC2Instance) error {
+	nodeName := instance.Name()
+	p.deleteInstanceProviderAndPool(nodeName)
+
+	return nil
+}
+
+func (p *ipv4PrefixProvider) UpdateResourceCapacity(instance ec2.EC2Instance) error {
+	resourceProviderAndPool, isPresent := p.getInstanceProviderAndPool(instance.Name())
+	if !isPresent {
+		p.log.Error(nil, "cannot find the instance provider and pool form the cache", "node-name", instance.Name())
+		return nil
+	}
+
+	resourceProviderAndPool.lock.Lock()
+	defer resourceProviderAndPool.lock.Unlock()
+
+	// Check if PD is enabled
+	isCurrPDEnabled := p.conditions.IsWindowsPrefixDelegationEnabled()
+
+	// Previous state and current state are both PD disabled, no need to update the warm pool config or node capacity for prefix IP provider
+	if !resourceProviderAndPool.isPrevPDEnabled && !isCurrPDEnabled {
+		return nil
+	}
+
+	// If prefix delegation was enabled but now disabled, then set the prefix IP pool state to draining and
+	// do not update the capacity as that would be done by secondary IP provider
+	if resourceProviderAndPool.isPrevPDEnabled && !isCurrPDEnabled {
+		resourceProviderAndPool.isPrevPDEnabled = false
+		p.log.Info("Secondary IP provider should be active")
+		job := resourceProviderAndPool.resourcePool.SetToDraining()
+		if job.Operations != worker.OperationReconcileNotRequired {
+			p.SubmitAsyncJob(job)
+		}
+		return nil
+	}
+
+	resourceProviderAndPool.isPrevPDEnabled = true
+
+	warmPoolConfig := p.getPDWarmPoolConfig()
+
+	// Set the secondary IP provider pool state to active
+	job := resourceProviderAndPool.resourcePool.SetToActive(warmPoolConfig)
+	if job.Operations != worker.OperationReconcileNotRequired {
+		p.SubmitAsyncJob(job)
+	}
+
+	instanceType := instance.Type()
+	instanceName := instance.Name()
+	os := instance.Os()
+
+	capacity := resourceProviderAndPool.capacity
+
+	// Advertise capacity of private IPv4 addresses deconstructed from prefixes
+	err := p.apiWrapper.K8sAPI.AdvertiseCapacityIfNotSet(instance.Name(), config.ResourceNameIPAddress, capacity)
+	if err != nil {
+		return err
+	}
+	p.log.V(1).Info("advertised capacity",
+		"instance", instanceName, "instance type", instanceType, "os", os, "capacity", capacity)
+
+	return nil
+}
+
+func (p *ipv4PrefixProvider) SubmitAsyncJob(job interface{}) {
+	p.workerPool.SubmitJob(job)
+}
+
+func (p *ipv4PrefixProvider) ProcessAsyncJob(job interface{}) (ctrl.Result, error) {
+	warmPoolJob, isValid := job.(*worker.WarmPoolJob)
+	if !isValid {
+		return ctrl.Result{}, fmt.Errorf("invalid job type")
+	}
+
+	switch warmPoolJob.Operations {
+	case worker.OperationCreate:
+		p.CreateIPv4PrefixAndUpdatePool(warmPoolJob)
+	case worker.OperationDeleted:
+		p.DeleteIPv4PrefixAndUpdatePool(warmPoolJob)
+	case worker.OperationReSyncPool:
+		p.ReSyncPool(warmPoolJob)
+	case worker.OperationProcessDeleteQueue:
+		return p.ProcessDeleteQueue(warmPoolJob)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// CreateIPv4PrefixAndUpdatePool executes the Create IPv4 Prefix workflow by assigning enough prefixes to satisfy
+// the desired number of prefixes required by the warm pool job
+func (p *ipv4PrefixProvider) CreateIPv4PrefixAndUpdatePool(job *worker.WarmPoolJob) {
+	instanceResource, found := p.getInstanceProviderAndPool(job.NodeName)
+	if !found {
+		p.log.Error(fmt.Errorf("cannot find the instance provider and pool form the cache"), "node", job.NodeName)
+		return
+	}
+	didSucceed := true
+	resources, err := instanceResource.eniManager.CreateIPV4Resource(job.ResourceCount, config.ResourceTypeIPv4Prefix, p.apiWrapper.EC2API,
+		p.log)
+
+	if err != nil {
+		p.log.Error(err, "failed to create all/some of the IPv4 prefixes", "created resources", resources)
+		didSucceed = false
+	}
+	job.Resources = resources
+	p.updatePoolAndReconcileIfRequired(instanceResource.resourcePool, job, didSucceed)
+}
+
+// DeleteIPv4PrefixAndUpdatePool executes the Delete IPv4 Prefix workflow for the list of prefixes provided in the warm pool job
+func (p *ipv4PrefixProvider) DeleteIPv4PrefixAndUpdatePool(job *worker.WarmPoolJob) {
+	instanceResource, found := p.getInstanceProviderAndPool(job.NodeName)
+	if !found {
+		p.log.Error(fmt.Errorf("cannot find the instance provider and pool form the cache"), "node", job.NodeName)
+		return
+	}
+
+	didSucceed := true
+	failedResources, err := instanceResource.eniManager.DeleteIPV4Resource(job.Resources, config.ResourceTypeIPv4Prefix,
+		p.apiWrapper.EC2API, p.log)
+
+	if err != nil {
+		p.log.Error(err, "failed to delete all/some of the IPv4 prefixes", "failed resources", failedResources)
+		didSucceed = false
+	}
+	job.Resources = failedResources
+	p.updatePoolAndReconcileIfRequired(instanceResource.resourcePool, job, didSucceed)
+}
+
+func (p *ipv4PrefixProvider) ReSyncPool(job *worker.WarmPoolJob) {
+	providerAndPool, found := p.instanceProviderAndPool[job.NodeName]
+	if !found {
+		p.log.Error(fmt.Errorf("instance provider not found"), "node is not initialized",
+			"name", job.NodeName)
+		return
+	}
+
+	ipV4Resources, err := providerAndPool.eniManager.InitResources(p.apiWrapper.EC2API)
+	if err != nil || ipV4Resources == nil {
+		p.log.Error(err, "failed to get init resources for the node",
+			"name", job.NodeName)
+		return
+	}
+
+	providerAndPool.resourcePool.ReSync(ipV4Resources.IPv4Prefixes)
+}
+
+func (p *ipv4PrefixProvider) ProcessDeleteQueue(job *worker.WarmPoolJob) (ctrl.Result, error) {
+	resourceProviderAndPool, isPresent := p.getInstanceProviderAndPool(job.NodeName)
+	if !isPresent {
+		p.log.Info("forgetting the delete queue processing job", "node", job.NodeName)
+		return ctrl.Result{}, nil
+	}
+	// TODO: For efficiency run only when required in next release
+	resourceProviderAndPool.resourcePool.ProcessCoolDownQueue()
+
+	// After the cool down queue is processed check if we need to do reconciliation
+	job = resourceProviderAndPool.resourcePool.ReconcilePool()
+	if job.Operations != worker.OperationReconcileNotRequired {
+		p.SubmitAsyncJob(job)
+	}
+
+	// Re-submit the job to execute after cool down period has ended
+	return ctrl.Result{Requeue: true, RequeueAfter: config.CoolDownPeriod}, nil
+}
+
+// updatePoolAndReconcileIfRequired updates the resource pool and reconcile again and submit a new job if required
+func (p *ipv4PrefixProvider) updatePoolAndReconcileIfRequired(resourcePool pool.Pool, job *worker.WarmPoolJob, didSucceed bool) {
+	// Update the pool to add the created/failed resource to the warm pool and decrement the pending count
+	shouldReconcile := resourcePool.UpdatePool(job, didSucceed)
+
+	if shouldReconcile {
+		job := resourcePool.ReconcilePool()
+		if job.Operations != worker.OperationReconcileNotRequired {
+			p.SubmitAsyncJob(job)
+		}
+	}
+}
+
+func (p *ipv4PrefixProvider) GetPool(nodeName string) (pool.Pool, bool) {
+	providerAndPool, exists := p.getInstanceProviderAndPool(nodeName)
+	if !exists {
+		return nil, false
+	}
+	return providerAndPool.resourcePool, true
+}
+
+func (p *ipv4PrefixProvider) IsInstanceSupported(instance ec2.EC2Instance) bool {
+	//TODO add check for Nitro instances
+	if instance.Os() == config.OSWindows {
+		return true
+	}
+
+	return false
+}
+
+func (p *ipv4PrefixProvider) Introspect() interface{} {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	response := make(map[string]pool.IntrospectResponse)
+	for nodeName, resource := range p.instanceProviderAndPool {
+		response[nodeName] = resource.resourcePool.Introspect()
+	}
+	return response
+}
+
+func (p *ipv4PrefixProvider) IntrospectNode(node string) interface{} {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	resource, found := p.instanceProviderAndPool[node]
+	if !found {
+		return struct{}{}
+	}
+	return resource.resourcePool.Introspect()
+}
+
+// putInstanceProviderAndPool stores the node's instance provider and pool to the cache
+func (p *ipv4PrefixProvider) putInstanceProviderAndPool(nodeName string, resourcePool pool.Pool, manager eni.ENIManager, capacity int,
+	isPrevPDEnabled bool) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	resource := &ResourceProviderAndPool{
+		eniManager:      manager,
+		resourcePool:    resourcePool,
+		capacity:        capacity,
+		isPrevPDEnabled: isPrevPDEnabled,
+	}
+
+	p.instanceProviderAndPool[nodeName] = resource
+}
+
+// getInstanceProviderAndPool returns the node's instance provider and pool from the cache
+func (p *ipv4PrefixProvider) getInstanceProviderAndPool(nodeName string) (*ResourceProviderAndPool, bool) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	resource, found := p.instanceProviderAndPool[nodeName]
+	return resource, found
+}
+
+// deleteInstanceProviderAndPool deletes the node's instance provider and pool from the cache
+func (p *ipv4PrefixProvider) deleteInstanceProviderAndPool(nodeName string) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	delete(p.instanceProviderAndPool, nodeName)
+}
+
+// getCapacity returns the capacity for IPv4 addresses deconstructed from IPv4 prefixes based on the instance type and the instance os;
+func getCapacity(instanceType string, instanceOs string) int {
+	// Assign only 1st ENIs non-primary IP
+	limits, found := vpc.Limits[instanceType]
+	if !found {
+		return 0
+	}
+	var capacity int
+	if instanceOs == config.OSWindows {
+		capacity = limits.IPv4PerInterface - 1
+	} else {
+		capacity = (limits.IPv4PerInterface - 1) * limits.Interface
+	}
+
+	return capacity
+}
+
+// Retrieve dynamic configuration for prefix delegation from config map, else use default warm pool config
+func (p *ipv4PrefixProvider) getPDWarmPoolConfig() *config.WarmPoolConfig {
+	var resourceConfig map[string]config.ResourceConfig
+	vpcCniConfigMap, err := p.apiWrapper.K8sAPI.GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace)
+	if err == nil {
+		resourceConfig = config.LoadResourceConfigFromConfigMap(vpcCniConfigMap)
+	} else {
+		p.log.Error(err, "failed to read from config map, will use default resource config")
+		resourceConfig = config.LoadResourceConfig()
+	}
+	return resourceConfig[config.ResourceNameIPAddressFromPrefix].WarmPoolConfig
+}

--- a/pkg/provider/prefix/provider.go
+++ b/pkg/provider/prefix/provider.go
@@ -419,7 +419,7 @@ func (p *ipv4PrefixProvider) getPDWarmPoolConfig() *config.WarmPoolConfig {
 	var resourceConfig map[string]config.ResourceConfig
 	vpcCniConfigMap, err := p.apiWrapper.K8sAPI.GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace)
 	if err == nil {
-		resourceConfig = config.LoadResourceConfigFromConfigMap(vpcCniConfigMap)
+		resourceConfig = config.LoadResourceConfigFromConfigMap(p.log, vpcCniConfigMap)
 	} else {
 		p.log.Error(err, "failed to read from config map, will use default resource config")
 		resourceConfig = config.LoadResourceConfig()

--- a/pkg/provider/prefix/provider_test.go
+++ b/pkg/provider/prefix/provider_test.go
@@ -1,0 +1,495 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package prefix
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"testing"
+
+	mock_ec2 "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2"
+	mock_condition "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/condition"
+	mock_k8s "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/pool"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/provider/ip/eni"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/worker"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/api"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/pool"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/ip/eni"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/worker"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	nodeName     = "node-1"
+	instanceType = "t3.medium"
+
+	prefix1 = "192.168.1.0/28"
+	prefix2 = "192.168.2.0/28"
+
+	nodeCapacity = 224
+
+	pdWarmPoolConfig = &config.WarmPoolConfig{
+		DesiredSize:      config.IPv4PDDefaultWPSize,
+		MaxDeviation:     config.IPv4PDDefaultMaxDev,
+		WarmIPTarget:     config.IPv4PDDefaultWarmIPTargetSize,
+		MinIPTarget:      config.IPv4PDDefaultMinIPTargetSize,
+		WarmPrefixTarget: config.IPv4PDDefaultWarmPrefixTargetSize,
+	}
+
+	vpcCNIConfig = &v1.ConfigMap{
+		Data: map[string]string{
+			config.EnableWindowsIPAMKey:             "true",
+			config.EnableWindowsPrefixDelegationKey: "true",
+			config.WarmIPTarget:                     strconv.Itoa(config.IPv4PDDefaultWarmIPTargetSize),
+			config.MinimumIPTarget:                  strconv.Itoa(config.IPv4PDDefaultMinIPTargetSize),
+			config.WarmPrefixTarget:                 strconv.Itoa(config.IPv4PDDefaultWarmPrefixTargetSize),
+		},
+	}
+)
+
+// TestNewIPv4PrefixProvider_getCapacity tests capacity of different os type
+func TestNewIPv4PrefixProvider_getCapacity(t *testing.T) {
+	capacityLinux := getCapacity(instanceType, config.OSLinux)
+	capacityWindows := getCapacity(instanceType, config.OSWindows)
+	capacityUnknown := getCapacity("x.large", "linux")
+
+	assert.Zero(t, capacityUnknown)
+	// IP(6) - 1(Primary) = 5
+	assert.Equal(t, 5, capacityWindows)
+	// (IP(6) - 1(Primary)) * 3(ENI) = 15
+	assert.Equal(t, 15, capacityLinux)
+}
+
+// TestNewIPv4PrefixProvider_deleteInstanceProviderAndPool tests that the ResourcePoolAndProvider for given node is removed from
+// cache after calling the API
+func TestNewIPv4PrefixProvider_deleteInstanceProviderAndPool(t *testing.T) {
+	prefixProvider := getMockIPv4PrefixProvider()
+	prefixProvider.instanceProviderAndPool[nodeName] = &ResourceProviderAndPool{}
+	prefixProvider.deleteInstanceProviderAndPool(nodeName)
+	assert.NotContains(t, prefixProvider.instanceProviderAndPool, nodeName)
+}
+
+// TestNewIPv4PrefixProvider_getInstanceProviderAndPool tests if the resource pool and provider is present in cache
+func TestNewIPv4PrefixProvider_getInstanceProviderAndPool(t *testing.T) {
+	prefixProvider := getMockIPv4PrefixProvider()
+	resourcePoolAndProvider := &ResourceProviderAndPool{}
+	prefixProvider.instanceProviderAndPool[nodeName] = resourcePoolAndProvider
+	result, found := prefixProvider.getInstanceProviderAndPool(nodeName)
+
+	assert.True(t, found)
+	assert.Equal(t, resourcePoolAndProvider, result)
+}
+
+// TestIpv4PrefixProvider_putInstanceProviderAndPool tests put stores the resource pool and provider into the cache
+func TestIpv4PrefixProvider_putInstanceProviderAndPool(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPool := mock_pool.NewMockPool(ctrl)
+	mockManager := mock_eni.NewMockENIManager(ctrl)
+
+	prefixProvider := getMockIPv4PrefixProvider()
+	prefixProvider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, true)
+
+	assert.Equal(t, &ResourceProviderAndPool{resourcePool: mockPool, eniManager: mockManager, capacity: nodeCapacity, isPrevPDEnabled: true},
+		prefixProvider.instanceProviderAndPool[nodeName])
+}
+
+// TestIpv4PrefixProvider_updatePoolAndReconcileIfRequired_NoFurtherReconcile tests pool is updated and reconciliation is not
+// performed again
+func TestIpv4PrefixProvider_updatePoolAndReconcileIfRequired_NoFurtherReconcile(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWorker := mock_worker.NewMockWorker(ctrl)
+	mockPool := mock_pool.NewMockPool(ctrl)
+	provider := ipv4PrefixProvider{workerPool: mockWorker}
+
+	job := &worker.WarmPoolJob{Operations: worker.OperationCreate}
+
+	mockPool.EXPECT().UpdatePool(job, true).Return(false)
+
+	provider.updatePoolAndReconcileIfRequired(mockPool, job, true)
+}
+
+// TestIpv4Provider_updatePoolAndReconcileIfRequired_ReconcileRequired tests pool is updated and reconciliation is
+// performed again and the job submitted to the worker
+func TestIpv4Provider_updatePoolAndReconcileIfRequired_ReconcileRequired(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWorker := mock_worker.NewMockWorker(ctrl)
+	mockPool := mock_pool.NewMockPool(ctrl)
+	provider := ipv4PrefixProvider{workerPool: mockWorker}
+
+	job := &worker.WarmPoolJob{Operations: worker.OperationCreate}
+
+	mockPool.EXPECT().UpdatePool(job, true).Return(true)
+	mockPool.EXPECT().ReconcilePool().Return(job)
+	mockWorker.EXPECT().SubmitJob(job)
+
+	provider.updatePoolAndReconcileIfRequired(mockPool, job, true)
+}
+
+// TestIpv4PrefixProvider_DeleteIPv4PrefixAndUpdatePool tests job with empty resources is passed back if some resource
+// fail to delete
+func TestIpv4PrefixProvider_DeleteIPv4PrefixAndUpdatePool(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	provider := getMockIPv4PrefixProvider()
+	mockPool := mock_pool.NewMockPool(ctrl)
+	mockManager := mock_eni.NewMockENIManager(ctrl)
+	provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, true)
+	resourcesToDelete := []string{prefix1, prefix2}
+
+	deleteJob := &worker.WarmPoolJob{
+		Operations:    worker.OperationDeleted,
+		Resources:     resourcesToDelete,
+		ResourceCount: 2,
+		NodeName:      nodeName,
+	}
+
+	mockManager.EXPECT().DeleteIPV4Resource(resourcesToDelete, config.ResourceTypeIPv4Prefix, nil, gomock.Any()).Return([]string{}, nil)
+	mockPool.EXPECT().UpdatePool(&worker.WarmPoolJob{
+		Operations:    worker.OperationDeleted,
+		Resources:     []string{},
+		ResourceCount: 2,
+		NodeName:      nodeName,
+	}, true).Return(false)
+
+	provider.DeleteIPv4PrefixAndUpdatePool(deleteJob)
+}
+
+// TestIpv4PrefixProvider_DeletePrivateIPv4AndUpdatePool_SomeResourceFail tests if some resource fail to delete those resources
+// are passed back inside the job to the resource pool
+func TestIpv4PrefixProvider_DeletePrivateIPv4AndUpdatePool_SomeResourceFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	prefixProvider := getMockIPv4PrefixProvider()
+	mockPool := mock_pool.NewMockPool(ctrl)
+	mockManager := mock_eni.NewMockENIManager(ctrl)
+	prefixProvider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, true)
+	resourcesToDelete := []string{prefix1, prefix2}
+	failedResources := []string{prefix2}
+
+	deleteJob := worker.WarmPoolJob{
+		Operations:    worker.OperationDeleted,
+		Resources:     resourcesToDelete,
+		ResourceCount: 2,
+		NodeName:      nodeName,
+	}
+
+	mockManager.EXPECT().DeleteIPV4Resource(resourcesToDelete, config.ResourceTypeIPv4Prefix, nil, gomock.Any()).Return(failedResources, nil)
+	mockPool.EXPECT().UpdatePool(&worker.WarmPoolJob{
+		Operations:    worker.OperationDeleted,
+		Resources:     failedResources,
+		ResourceCount: 2,
+		NodeName:      nodeName,
+	}, true).Return(false)
+
+	prefixProvider.DeleteIPv4PrefixAndUpdatePool(&deleteJob)
+}
+
+// TestIPv4PrefixProvider_CreateIPv4PrefixAndUpdatePool tests if resources are created then the job object is updated
+// with the resources and the pool is updated
+func TestIPv4PrefixProvider_CreateIPv4PrefixAndUpdatePool(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	prefixProvider := getMockIPv4PrefixProvider()
+	mockPool := mock_pool.NewMockPool(ctrl)
+	mockManager := mock_eni.NewMockENIManager(ctrl)
+	prefixProvider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, true)
+	createdResources := []string{prefix1, prefix2}
+
+	createJob := &worker.WarmPoolJob{
+		Operations:    worker.OperationCreate,
+		Resources:     []string{},
+		ResourceCount: 2,
+		NodeName:      nodeName,
+	}
+
+	mockManager.EXPECT().CreateIPV4Resource(2, config.ResourceTypeIPv4Prefix, nil, gomock.Any()).Return(createdResources, nil)
+	mockPool.EXPECT().UpdatePool(&worker.WarmPoolJob{
+		Operations:    worker.OperationCreate,
+		Resources:     createdResources,
+		ResourceCount: 2,
+		NodeName:      nodeName,
+	}, true).Return(false)
+
+	prefixProvider.CreateIPv4PrefixAndUpdatePool(createJob)
+}
+
+// TestIPv4PrefixProvider_CreateIPv4PrefixAndUpdatePool_Fail tests that if some create fails then the pool is
+// updated with the created resources and success status as false
+func TestIPv4PrefixProvider_CreateIPv4PrefixAndUpdatePool_Fail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	prefixProvider := getMockIPv4PrefixProvider()
+	mockPool := mock_pool.NewMockPool(ctrl)
+	mockManager := mock_eni.NewMockENIManager(ctrl)
+	prefixProvider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, true)
+	createdResources := []string{prefix1, prefix2}
+
+	createJob := &worker.WarmPoolJob{
+		Operations:    worker.OperationCreate,
+		Resources:     []string{},
+		ResourceCount: 3,
+		NodeName:      nodeName,
+	}
+
+	mockManager.EXPECT().CreateIPV4Resource(3, config.ResourceTypeIPv4Prefix, nil, gomock.Any()).Return(createdResources,
+		fmt.Errorf("failed"))
+	mockPool.EXPECT().UpdatePool(&worker.WarmPoolJob{
+		Operations:    worker.OperationCreate,
+		Resources:     createdResources,
+		ResourceCount: 3,
+		NodeName:      nodeName,
+	}, false).Return(false)
+
+	prefixProvider.CreateIPv4PrefixAndUpdatePool(createJob)
+}
+
+// TestIPv4PrefixProvider_ReSyncPool
+func TestIPv4PrefixProvider_ReSyncPool(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	prefixProvider := getMockIPv4PrefixProvider()
+	mockPool := mock_pool.NewMockPool(ctrl)
+	mockManager := mock_eni.NewMockENIManager(ctrl)
+	prefixProvider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, true)
+	resources := []string{prefix1, prefix2}
+
+	reSyncJob := &worker.WarmPoolJob{
+		Operations: worker.OperationReSyncPool,
+		NodeName:   nodeName,
+	}
+
+	// When error occurs, pool should not be re-synced
+	mockManager.EXPECT().InitResources(prefixProvider.apiWrapper.EC2API).Return(nil, fmt.Errorf(""))
+	prefixProvider.ReSyncPool(reSyncJob)
+
+	// When no error occurs, pool should be re-synced
+	ipV4Resources := &eni.IPv4Resource{IPv4Prefixes: resources}
+	mockManager.EXPECT().InitResources(prefixProvider.apiWrapper.EC2API).Return(ipV4Resources, nil)
+	mockPool.EXPECT().ReSync(resources)
+	prefixProvider.ReSyncPool(reSyncJob)
+}
+
+// TestIPv4PrefixProvider_SubmitAsyncJob tests that the job is submitted to the worker on calling SubmitAsyncJob
+func TestIPv4PrefixProvider_SubmitAsyncJob(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWorker := mock_worker.NewMockWorker(ctrl)
+	prefixProvider := ipv4PrefixProvider{workerPool: mockWorker}
+
+	job := worker.NewWarmPoolDeleteJob(nodeName, nil)
+
+	mockWorker.EXPECT().SubmitJob(job)
+
+	prefixProvider.SubmitAsyncJob(job)
+}
+
+// TestIPv4PrefixProvider_UpdateResourceCapacity_FromFromIPToPD tests the warm pool is set to active when PD mode is enabled and
+// resource capacity is updated by calling the k8s wrapper
+func TestIPv4PrefixProvider_UpdateResourceCapacity_FromFromIPToPD(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockInstance := mock_ec2.NewMockEC2Instance(ctrl)
+	mockK8sWrapper := mock_k8s.NewMockK8sWrapper(ctrl)
+	mockConditions := mock_condition.NewMockConditions(ctrl)
+	mockWorker := mock_worker.NewMockWorker(ctrl)
+
+	// prefix provider starts with empty warm pool config since PD was disabled
+	prefixProvider := ipv4PrefixProvider{apiWrapper: api.Wrapper{K8sAPI: mockK8sWrapper}, workerPool: mockWorker, config: pdWarmPoolConfig,
+		instanceProviderAndPool: map[string]*ResourceProviderAndPool{},
+		log:                     zap.New(zap.UseDevMode(true)).WithName("prefix provider"), conditions: mockConditions}
+
+	mockK8sWrapper.EXPECT().GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace).Return(vpcCNIConfig, nil)
+	mockPool := mock_pool.NewMockPool(ctrl)
+	mockManager := mock_eni.NewMockENIManager(ctrl)
+	prefixProvider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, true)
+	mockConditions.EXPECT().IsWindowsPrefixDelegationEnabled().Return(true)
+
+	job := &worker.WarmPoolJob{Operations: worker.OperationCreate}
+	mockPool.EXPECT().SetToActive(pdWarmPoolConfig).Return(job)
+	mockWorker.EXPECT().SubmitJob(job)
+
+	mockInstance.EXPECT().Name().Return(nodeName).Times(3)
+	mockInstance.EXPECT().Type().Return(instanceType)
+	mockInstance.EXPECT().Os().Return(config.OSWindows)
+	mockK8sWrapper.EXPECT().AdvertiseCapacityIfNotSet(nodeName, config.ResourceNameIPAddress, 224).Return(nil)
+
+	err := prefixProvider.UpdateResourceCapacity(mockInstance)
+	assert.NoError(t, err)
+}
+
+// TestIPv4PrefixProvider_UpdateResourceCapacity_FromFromPDToIP tests the warm pool is drained when PD is disabled
+func TestIPv4PrefixProvider_UpdateResourceCapacity_FromFromPDToIP(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockInstance := mock_ec2.NewMockEC2Instance(ctrl)
+	mockK8sWrapper := mock_k8s.NewMockK8sWrapper(ctrl)
+	mockConditions := mock_condition.NewMockConditions(ctrl)
+	mockWorker := mock_worker.NewMockWorker(ctrl)
+	prefixProvider := ipv4PrefixProvider{apiWrapper: api.Wrapper{K8sAPI: mockK8sWrapper}, workerPool: mockWorker, config: pdWarmPoolConfig,
+		instanceProviderAndPool: map[string]*ResourceProviderAndPool{},
+		log:                     zap.New(zap.UseDevMode(true)).WithName("prefix provider"), conditions: mockConditions}
+
+	mockPool := mock_pool.NewMockPool(ctrl)
+	mockManager := mock_eni.NewMockENIManager(ctrl)
+	prefixProvider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, true)
+	mockConditions.EXPECT().IsWindowsPrefixDelegationEnabled().Return(false)
+
+	job := &worker.WarmPoolJob{Operations: worker.OperationDeleted}
+	mockPool.EXPECT().SetToDraining().Return(job)
+	mockWorker.EXPECT().SubmitJob(job)
+	mockInstance.EXPECT().Name().Return(nodeName).Times(1)
+
+	err := prefixProvider.UpdateResourceCapacity(mockInstance)
+	assert.NoError(t, err)
+}
+
+// TestIPv4PrefixProvider_UpdateResourceCapacity_FromPDToPD tests the resource capacity is not updated when PD mode stays enabled
+func TestIPv4PrefixProvider_UpdateResourceCapacity_FromPDToPD(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockInstance := mock_ec2.NewMockEC2Instance(ctrl)
+	mockK8sWrapper := mock_k8s.NewMockK8sWrapper(ctrl)
+	mockConditions := mock_condition.NewMockConditions(ctrl)
+	mockWorker := mock_worker.NewMockWorker(ctrl)
+
+	prefixProvider := ipv4PrefixProvider{apiWrapper: api.Wrapper{K8sAPI: mockK8sWrapper}, workerPool: mockWorker, config: pdWarmPoolConfig,
+		instanceProviderAndPool: map[string]*ResourceProviderAndPool{},
+		log:                     zap.New(zap.UseDevMode(true)).WithName("prefix provider"), conditions: mockConditions}
+
+	mockPool := mock_pool.NewMockPool(ctrl)
+	mockManager := mock_eni.NewMockENIManager(ctrl)
+	prefixProvider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, true)
+	mockConditions.EXPECT().IsWindowsPrefixDelegationEnabled().Return(true)
+
+	mockK8sWrapper.EXPECT().GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace).Return(vpcCNIConfig, nil)
+
+	job := &worker.WarmPoolJob{Operations: worker.OperationCreate}
+	mockPool.EXPECT().SetToActive(pdWarmPoolConfig).Return(job)
+	mockWorker.EXPECT().SubmitJob(job)
+
+	mockInstance.EXPECT().Name().Return(nodeName).Times(3)
+	mockInstance.EXPECT().Type().Return(instanceType)
+	mockInstance.EXPECT().Os().Return(config.OSWindows)
+	mockK8sWrapper.EXPECT().AdvertiseCapacityIfNotSet(nodeName, config.ResourceNameIPAddress, 224).Return(nil)
+
+	err := prefixProvider.UpdateResourceCapacity(mockInstance)
+	assert.NoError(t, err)
+}
+
+// TestIPv4PrefixProvider_UpdateResourceCapacity_FromIPToIP tests the resource capacity is not updated when secondary IP mode stays enabled
+func TestIPv4PrefixProvider_UpdateResourceCapacity_FromIPToIP(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockInstance := mock_ec2.NewMockEC2Instance(ctrl)
+	mockK8sWrapper := mock_k8s.NewMockK8sWrapper(ctrl)
+	mockConditions := mock_condition.NewMockConditions(ctrl)
+	prefixProvider := ipv4PrefixProvider{apiWrapper: api.Wrapper{K8sAPI: mockK8sWrapper},
+		instanceProviderAndPool: map[string]*ResourceProviderAndPool{},
+		log:                     zap.New(zap.UseDevMode(true)).WithName("prefix provider"), conditions: mockConditions}
+
+	mockPool := mock_pool.NewMockPool(ctrl)
+	mockManager := mock_eni.NewMockENIManager(ctrl)
+	mockInstance.EXPECT().Name().Return(nodeName).Times(1)
+	prefixProvider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, false)
+	mockConditions.EXPECT().IsWindowsPrefixDelegationEnabled().Return(false)
+
+	err := prefixProvider.UpdateResourceCapacity(mockInstance)
+	assert.NoError(t, err)
+}
+
+// TestIpv4PrefixProvider_GetPool
+func TestIpv4PrefixProvider_GetPool(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	prefixProvider := getMockIPv4PrefixProvider()
+	mockPool := mock_pool.NewMockPool(ctrl)
+	prefixProvider.putInstanceProviderAndPool(nodeName, mockPool, nil, nodeCapacity, true)
+
+	pool, found := prefixProvider.GetPool(nodeName)
+	assert.True(t, found)
+	assert.Equal(t, mockPool, pool)
+}
+
+// TestIpv4PrefixProvider_Introspect
+func TestIpv4PrefixProvider_Introspect(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	prefixProvider := getMockIPv4PrefixProvider()
+	mockPool := mock_pool.NewMockPool(ctrl)
+	prefixProvider.putInstanceProviderAndPool(nodeName, mockPool, nil, nodeCapacity, true)
+	expectedResp := pool.IntrospectResponse{}
+
+	mockPool.EXPECT().Introspect().Return(expectedResp)
+	resp := prefixProvider.Introspect()
+	assert.True(t, reflect.DeepEqual(resp, map[string]pool.IntrospectResponse{nodeName: expectedResp}))
+
+	mockPool.EXPECT().Introspect().Return(expectedResp)
+	resp = prefixProvider.IntrospectNode(nodeName)
+	assert.Equal(t, resp, expectedResp)
+
+	resp = prefixProvider.IntrospectNode("unregistered-node")
+	assert.Equal(t, resp, struct{}{})
+}
+
+func getMockIPv4PrefixProvider() ipv4PrefixProvider {
+	return ipv4PrefixProvider{instanceProviderAndPool: map[string]*ResourceProviderAndPool{},
+		log: zap.New(zap.UseDevMode(true)).WithName("prefix provider")}
+}
+
+func TestGetPDWarmPoolConfig(t *testing.T) {
+	// TODO
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	//mockInstance := mock_ec2.NewMockEC2Instance(ctrl)
+	mockK8sWrapper := mock_k8s.NewMockK8sWrapper(ctrl)
+	mockConditions := mock_condition.NewMockConditions(ctrl)
+	prefixProvider := ipv4PrefixProvider{apiWrapper: api.Wrapper{K8sAPI: mockK8sWrapper},
+		instanceProviderAndPool: map[string]*ResourceProviderAndPool{},
+		log:                     zap.New(zap.UseDevMode(true)).WithName("prefix provider"), conditions: mockConditions}
+
+	mockK8sWrapper.EXPECT().GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace).Return(vpcCNIConfig, nil)
+
+	config := prefixProvider.getPDWarmPoolConfig()
+	assert.Equal(t, pdWarmPoolConfig, config)
+}
+
+func TestIsInstanceSupported(t *testing.T) {
+	// TODO
+}

--- a/pkg/resource/manager.go
+++ b/pkg/resource/manager.go
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/branch"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/ip"
-	//"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/prefix"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/prefix"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/worker"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -77,8 +77,8 @@ func NewResourceManager(ctx context.Context, resourceNames []string, wrapper api
 			resourceHandler = handler.NewWarmResourceHandler(ctrl.Log.WithName(resourceName), wrapper,
 				resourceName, resourceProvider, ctx)
 		} else if resourceName == config.ResourceNameIPAddressFromPrefix {
-			//resourceProvider = prefix.NewIPv4PrefixProvider(ctrl.Log.WithName("ipv4 prefix provider"),
-			//	wrapper, workers, resourceConfig, conditions)
+			resourceProvider = prefix.NewIPv4PrefixProvider(ctrl.Log.WithName("ipv4 prefix provider"),
+				wrapper, workers, resourceConfig, conditions)
 			resourceHandler = handler.NewWarmResourceHandler(ctrl.Log.WithName(resourceName), wrapper,
 				config.ResourceNameIPAddress, resourceProvider, ctx)
 		} else if resourceName == config.ResourceNamePodENI {

--- a/pkg/resource/manager_test.go
+++ b/pkg/resource/manager_test.go
@@ -44,8 +44,7 @@ func Test_NewResourceManager(t *testing.T) {
 	defer ctrl.Finish()
 
 	mock := NewMock(ctrl)
-	//resources := []string{config.ResourceNamePodENI, config.ResourceNameIPAddress, config.ResourceNameIPAddressFromPrefix}
-	resources := []string{config.ResourceNamePodENI, config.ResourceNameIPAddress}
+	resources := []string{config.ResourceNamePodENI, config.ResourceNameIPAddress, config.ResourceNameIPAddressFromPrefix}
 
 	mockK8s := mock_k8s.NewMockK8sWrapper(ctrl)
 	conditions := condition.NewControllerConditions(zap.New(), mockK8s)
@@ -59,12 +58,11 @@ func Test_NewResourceManager(t *testing.T) {
 	_, ok = manger.GetResourceHandler(config.ResourceNameIPAddress)
 	assert.True(t, ok)
 
-	//_, ok = manger.GetResourceHandler(config.ResourceNameIPAddressFromPrefix)
-	//assert.True(t, ok)
+	_, ok = manger.GetResourceHandler(config.ResourceNameIPAddressFromPrefix)
+	assert.True(t, ok)
 
 	providers := manger.GetResourceProviders()
-	//assert.Equal(t, len(providers), 3)
-	assert.Equal(t, len(providers), 2)
+	assert.Equal(t, len(providers), 3)
 
 	_, ok = manger.GetResourceProvider(config.ResourceNamePodENI)
 	assert.True(t, ok)
@@ -72,6 +70,6 @@ func Test_NewResourceManager(t *testing.T) {
 	_, ok = manger.GetResourceProvider(config.ResourceNameIPAddress)
 	assert.True(t, ok)
 
-	//_, ok = manger.GetResourceProvider(config.ResourceNameIPAddressFromPrefix)
-	//assert.True(t, ok)
+	_, ok = manger.GetResourceProvider(config.ResourceNameIPAddressFromPrefix)
+	assert.True(t, ok)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added logic to load PD configuration params (`warm-ip-target`, `minimum-ip-target`, `warm-prefix-target`) from vpc cni config map + unit tests
- Added prefix provider to handle job requests for prefixes + unit tests
- Minor fixes on secondary IP provider and warm pool

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
