### PR TITLE
Update README on how to support more than 5 Security Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ ENI Trunking is a private feature even though the APIs are publicly accessible u
 
 Please follow the [guide](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html) for enabling Security Group for Pods on your EKS Cluster. 
 
+Note: The SecurityGroupPolicy CRD only supports up to 5 security groups per custom resource. If you need more than 5 security groups for a pod, please consider to use more than one custom resources. For example, you can have two custom resources to associate up to 10 security groups to a pod. Please be aware when you are doing so: 
+
+1, you need to request increasing the limit since the default limit is 5 security groups per interface and there is a hard limit of 16 currently.
+
+2, currently Fargate only allows up to 5 security groups. If you are using Fargate, you can only use up to 5 security groups per pod.
+
 ## Windows IPv4 Address Management
 
 The controller manages the IPv4 Addresses for all the Windows Node in EKS Cluster and allocates IPv4 Address to Windows Pods. The Networking on the host is setup by [amazon-vpc-cni-plugins](https://github.com/aws/amazon-vpc-cni-plugins).


### PR DESCRIPTION
*Issue #, if available:*
#155 
*Description of changes:*
In some use case, customers may need associate more than 5 security groups per pod. We updated README to describe how it can work with current limits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
