### PR TITLE
Windows events were incorrectly emitted

### DIFF
--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -466,8 +466,12 @@ func (b *branchENIProvider) GetPool(_ string) (pool.Pool, bool) {
 
 // IsInstanceSupported returns true for linux node as pod eni is only supported for linux worker node
 func (b *branchENIProvider) IsInstanceSupported(instance ec2.EC2Instance) bool {
+	if instance.Os() != config.OSLinux {
+		return false
+	}
+
 	limits, found := vpc.Limits[instance.Type()]
-	supported := found && instance.Os() == config.OSLinux && limits.IsTrunkingCompatible
+	supported := found && limits.IsTrunkingCompatible
 
 	if !supported {
 		// Send a node event for users' visibility


### PR DESCRIPTION
*Issue #, if available:*
#231 
*Description of changes:*
When branch ENI provider error out from Windows provisioning, it shouldn't emit event for warning users the instance type is not supported.

Tests were done and confirmed the behavior is fixed.
- Unsupported Linux instance type node still have the warning message when trying to enable SGP feature
- Windows node no longer has the warning event when enabling Windows support through ConfigMap

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
