### PR TITLE
updated to not create new secondary ENI for Windows

### DIFF
--- a/pkg/aws/ec2/api/helper.go
+++ b/pkg/aws/ec2/api/helper.go
@@ -467,10 +467,9 @@ func (h *ec2APIHelper) AssignIPv4ResourcesAndWaitTillReady(eniID string, resourc
 		return assignedResources, err
 	}
 
-	if (resourceType == config.ResourceNameIPAddress && assignPrivateIPOutput.AssignedPrivateIpAddresses != nil &&
-		len(assignPrivateIPOutput.AssignedPrivateIpAddresses) == 0) ||
-		(resourceType == config.ResourceTypeIPv4Prefix && assignPrivateIPOutput.AssignedIpv4Prefixes != nil &&
-			len(assignPrivateIPOutput.AssignedIpv4Prefixes) == 0) {
+	if assignPrivateIPOutput == nil ||
+		(resourceType == config.ResourceNameIPAddress && len(assignPrivateIPOutput.AssignedPrivateIpAddresses) == 0) ||
+		(resourceType == config.ResourceTypeIPv4Prefix && len(assignPrivateIPOutput.AssignedIpv4Prefixes) == 0) {
 		return assignedResources, fmt.Errorf("failed to create %v %s to eni %s", count, resourceType, eniID)
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Since Windows doesn't support multi-ENI yet, we don't want to create a new ENI when the resource request cannot be fulfilled. The check for OS can be removed once multi-ENI is supported.
- Modified unit tests for above changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
