### PR TITLE
added integration tests for Windows prefix delegation

### DIFF
--- a/test/framework/verify/pod.go
+++ b/test/framework/verify/pod.go
@@ -155,6 +155,15 @@ func (v *PodVerification) WindowsPodHaveIPv4Address(pod *v1.Pod) {
 
 }
 
+func (v *PodVerification) WindowsPodHaveIPv4AddressFromPrefix(pod *v1.Pod) {
+	By("matching the prefix-deconstructed IPv4 from annotation to the pod IP")
+	ipAddWithCidr, found := pod.Annotations["vpc.amazonaws.com/PrivateIPv4Address"]
+	Expect(found).To(BeTrue())
+	// Remove the CIDR and compare pod IP with the IP annotated from VPC Controller
+	Expect(pod.Status.PodIP).To(Equal(strings.Split(ipAddWithCidr, "/")[0]))
+	Expect(strings.Split(ipAddWithCidr, "/")[1]).To(Equal("32"))
+}
+
 func (v *PodVerification) WindowsPodHaveResourceLimits(pod *v1.Pod, expected bool) {
 
 	if pod.Spec.Containers[0].Resources.Limits == nil && expected {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added test cases for when PD is enabled, basic pod deployment works
- Added test cases for when PD is enabled initially, then toggled to secondary IP mode, prefixes should be released while secondary IPs are added to warm pool
- Added test cases for when PD is enabled, `warm-prefix-target` works
- Added test cases for when PD is enabled, if the old VPC RC is deployed, pod deployment should fail

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
