### PR TITLE
fixed capactiy advertisement when node start on secondary IP mode

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2/api"
-	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/vpc"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/k8s"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/resource"
@@ -247,14 +246,6 @@ func (n *node) IsNitroInstance() bool {
 	n.lock.RLock()
 	defer n.lock.RUnlock()
 
-	limits, found := vpc.Limits[n.instance.Type()]
-	if !found {
-		return false
-	}
-
-	if limits.IsBareMetal || limits.Hypervisor == "nitro" {
-		return true
-	}
-
-	return false
+	isNitroInstance, err := utils.IsNitroInstance(n.instance.Type())
+	return err == nil && isNitroInstance
 }

--- a/pkg/provider/ip/provider_test.go
+++ b/pkg/provider/ip/provider_test.go
@@ -36,14 +36,21 @@ import (
 )
 
 var (
-	nodeName     = "node-1"
-	instanceType = "t3.medium"
+	nodeName             = "node-1"
+	instanceType         = "t3.medium"
+	nonNitroInstanceType = "m1.large"
 
 	ip1 = "192.168.1.1"
 	ip2 = "192.168.1.2"
 	ip3 = "192.168.1.3"
 
 	nodeCapacity = 14
+
+	ipV4WarmPoolConfig = config.WarmPoolConfig{
+		DesiredSize:  config.IPv4DefaultWPSize,
+		MaxDeviation: config.IPv4DefaultMaxDev,
+		ReservedSize: config.IPv4DefaultResSize,
+	}
 )
 
 // TestIpv4Provider_difference tests difference removes the difference between an array and a set
@@ -338,7 +345,7 @@ func TestIPv4Provider_UpdateResourceCapacity_FromFromPDToIP(t *testing.T) {
 	mockWorker.EXPECT().SubmitJob(job)
 
 	mockInstance.EXPECT().Name().Return(nodeName).Times(3)
-	mockInstance.EXPECT().Type().Return(instanceType)
+	mockInstance.EXPECT().Type().Return(instanceType).Times(2)
 	mockInstance.EXPECT().Os().Return(config.OSWindows)
 	mockK8sWrapper.EXPECT().AdvertiseCapacityIfNotSet(nodeName, config.ResourceNameIPAddress, 14).Return(nil)
 
@@ -366,7 +373,38 @@ func TestIPv4Provider_UpdateResourceCapacity_FromFromIPToPD(t *testing.T) {
 	job := &worker.WarmPoolJob{Operations: worker.OperationDeleted}
 	mockPool.EXPECT().SetToDraining().Return(job)
 	mockWorker.EXPECT().SubmitJob(job)
-	mockInstance.EXPECT().Name().Return(nodeName).Times(1)
+	mockInstance.EXPECT().Name().Return(nodeName)
+	mockInstance.EXPECT().Type().Return(instanceType)
+
+	err := ipv4Provider.UpdateResourceCapacity(mockInstance)
+	assert.NoError(t, err)
+}
+
+// TestIPv4Provider_UpdateResourceCapacity_FromFromIPToPD_NonNitro tests that even if PD is enabled, non-nitro instances continue to use
+// secondary IP mode
+func TestIPv4Provider_UpdateResourceCapacity_FromFromIPToPD_NonNitro(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockInstance := mock_ec2.NewMockEC2Instance(ctrl)
+	mockK8sWrapper := mock_k8s.NewMockK8sWrapper(ctrl)
+	mockConditions := mock_condition.NewMockConditions(ctrl)
+	mockWorker := mock_worker.NewMockWorker(ctrl)
+	ipv4Provider := ipv4Provider{apiWrapper: api.Wrapper{K8sAPI: mockK8sWrapper}, workerPool: mockWorker, config: &ipV4WarmPoolConfig,
+		instanceProviderAndPool: map[string]*ResourceProviderAndPool{}, log: zap.New(zap.UseDevMode(true)).WithName("ip provider"), conditions: mockConditions}
+
+	mockPool := mock_pool.NewMockPool(ctrl)
+	mockManager := mock_eni.NewMockENIManager(ctrl)
+	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, false)
+	mockConditions.EXPECT().IsWindowsPrefixDelegationEnabled().Return(true)
+
+	job := &worker.WarmPoolJob{Operations: worker.OperationCreate}
+	mockPool.EXPECT().SetToActive(&ipV4WarmPoolConfig).Return(job)
+	mockWorker.EXPECT().SubmitJob(job)
+	mockInstance.EXPECT().Name().Return(nodeName).Times(4)
+	mockInstance.EXPECT().Type().Return(nonNitroInstanceType).Times(3)
+	mockInstance.EXPECT().Os().Return(config.OSWindows)
+	mockK8sWrapper.EXPECT().AdvertiseCapacityIfNotSet(nodeName, config.ResourceNameIPAddress, 14).Return(nil)
 
 	err := ipv4Provider.UpdateResourceCapacity(mockInstance)
 	assert.NoError(t, err)
@@ -385,7 +423,8 @@ func TestIPv4Provider_UpdateResourceCapacity_FromPDToPD(t *testing.T) {
 
 	mockPool := mock_pool.NewMockPool(ctrl)
 	mockManager := mock_eni.NewMockENIManager(ctrl)
-	mockInstance.EXPECT().Name().Return(nodeName).Times(1)
+	mockInstance.EXPECT().Name().Return(nodeName)
+	mockInstance.EXPECT().Type().Return(instanceType)
 	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, true)
 	mockConditions.EXPECT().IsWindowsPrefixDelegationEnabled().Return(true)
 
@@ -401,14 +440,23 @@ func TestIPv4Provider_UpdateResourceCapacity_FromIPToIP(t *testing.T) {
 	mockInstance := mock_ec2.NewMockEC2Instance(ctrl)
 	mockK8sWrapper := mock_k8s.NewMockK8sWrapper(ctrl)
 	mockConditions := mock_condition.NewMockConditions(ctrl)
-	ipv4Provider := ipv4Provider{apiWrapper: api.Wrapper{K8sAPI: mockK8sWrapper}, instanceProviderAndPool: map[string]*ResourceProviderAndPool{},
-		log: zap.New(zap.UseDevMode(true)).WithName("ip provider"), conditions: mockConditions}
+	mockWorker := mock_worker.NewMockWorker(ctrl)
+	ipv4Provider := ipv4Provider{apiWrapper: api.Wrapper{K8sAPI: mockK8sWrapper}, workerPool: mockWorker, config: &ipV4WarmPoolConfig,
+		instanceProviderAndPool: map[string]*ResourceProviderAndPool{}, log: zap.New(zap.UseDevMode(true)).WithName("ip provider"), conditions: mockConditions}
 
 	mockPool := mock_pool.NewMockPool(ctrl)
 	mockManager := mock_eni.NewMockENIManager(ctrl)
-	mockInstance.EXPECT().Name().Return(nodeName).Times(1)
 	ipv4Provider.putInstanceProviderAndPool(nodeName, mockPool, mockManager, nodeCapacity, false)
 	mockConditions.EXPECT().IsWindowsPrefixDelegationEnabled().Return(false)
+
+	job := &worker.WarmPoolJob{Operations: worker.OperationCreate}
+	mockPool.EXPECT().SetToActive(&ipV4WarmPoolConfig).Return(job)
+	mockWorker.EXPECT().SubmitJob(job)
+
+	mockInstance.EXPECT().Name().Return(nodeName).Times(3)
+	mockInstance.EXPECT().Type().Return(instanceType).Times(2)
+	mockInstance.EXPECT().Os().Return(config.OSWindows)
+	mockK8sWrapper.EXPECT().AdvertiseCapacityIfNotSet(nodeName, config.ResourceNameIPAddress, 14).Return(nil)
 
 	err := ipv4Provider.UpdateResourceCapacity(mockInstance)
 	assert.NoError(t, err)

--- a/pkg/provider/prefix/provider_test.go
+++ b/pkg/provider/prefix/provider_test.go
@@ -348,7 +348,7 @@ func TestIPv4PrefixProvider_UpdateResourceCapacity_FromFromIPToPD(t *testing.T) 
 	mockPool.EXPECT().SetToActive(pdWarmPoolConfig).Return(job)
 	mockWorker.EXPECT().SubmitJob(job)
 
-	mockInstance.EXPECT().Name().Return(nodeName).Times(3)
+	mockInstance.EXPECT().Name().Return(nodeName).Times(2)
 	mockInstance.EXPECT().Type().Return(instanceType)
 	mockInstance.EXPECT().Os().Return(config.OSWindows)
 	mockK8sWrapper.EXPECT().AdvertiseCapacityIfNotSet(nodeName, config.ResourceNameIPAddress, 224).Return(nil)
@@ -409,7 +409,7 @@ func TestIPv4PrefixProvider_UpdateResourceCapacity_FromPDToPD(t *testing.T) {
 	mockPool.EXPECT().SetToActive(pdWarmPoolConfig).Return(job)
 	mockWorker.EXPECT().SubmitJob(job)
 
-	mockInstance.EXPECT().Name().Return(nodeName).Times(3)
+	mockInstance.EXPECT().Name().Return(nodeName).Times(2)
 	mockInstance.EXPECT().Type().Return(instanceType)
 	mockInstance.EXPECT().Os().Return(config.OSWindows)
 	mockK8sWrapper.EXPECT().AdvertiseCapacityIfNotSet(nodeName, config.ResourceNameIPAddress, 224).Return(nil)
@@ -508,6 +508,7 @@ func TestIsInstanceSupported(t *testing.T) {
 	prefixProvider := ipv4PrefixProvider{apiWrapper: api.Wrapper{K8sAPI: mockK8sWrapper},
 		instanceProviderAndPool: map[string]*ResourceProviderAndPool{},
 		log:                     zap.New(zap.UseDevMode(true)).WithName("prefix provider"), conditions: mockConditions}
+	mockInstance.EXPECT().Name().Return(nodeName)
 	mockInstance.EXPECT().Type().Return(instanceType)
 	mockInstance.EXPECT().Os().Return(config.OSWindows)
 
@@ -525,6 +526,7 @@ func TestIsInstanceSupported_BareMetal(t *testing.T) {
 	prefixProvider := ipv4PrefixProvider{apiWrapper: api.Wrapper{K8sAPI: mockK8sWrapper},
 		instanceProviderAndPool: map[string]*ResourceProviderAndPool{},
 		log:                     zap.New(zap.UseDevMode(true)).WithName("prefix provider"), conditions: mockConditions}
+	mockInstance.EXPECT().Name().Return(nodeName)
 	mockInstance.EXPECT().Type().Return(bareMetalInstanceType)
 	mockInstance.EXPECT().Os().Return(config.OSWindows)
 

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	vpcresourcesv1beta1 "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
-
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/vpc"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -201,4 +201,15 @@ func DeconstructIPsFromPrefix(prefix string) ([]string, error) {
 		deconstructedIPs = append(deconstructedIPs, ipAddr)
 	}
 	return deconstructedIPs, nil
+}
+
+func IsNitroInstance(instanceType string) (bool, error) {
+	limits, found := vpc.Limits[instanceType]
+	if !found {
+		return false, ErrNotFound
+	}
+	if limits.IsBareMetal || limits.Hypervisor == "nitro" {
+		return true, nil
+	}
+	return false, nil
 }

--- a/pkg/utils/helper_test.go
+++ b/pkg/utils/helper_test.go
@@ -525,3 +525,24 @@ func TestDeconstructIPsFromPrefix_InvalidPrefix(t *testing.T) {
 		})
 	}
 }
+
+func TestIsNitroInstance(t *testing.T) {
+	instanceType := "a1.2xlarge"
+	isNitro, err := IsNitroInstance(instanceType)
+	assert.NoError(t, err)
+	assert.True(t, isNitro)
+}
+
+func TestIsNitroInstance_ErrorNotFound(t *testing.T) {
+	instanceType := "random"
+	isNitro, err := IsNitroInstance(instanceType)
+	assert.Error(t, err)
+	assert.False(t, isNitro)
+}
+
+func TestIsNitroInstance_NonNitro(t *testing.T) {
+	instanceType := "c1.medium"
+	isNitro, err := IsNitroInstance(instanceType)
+	assert.NoError(t, err)
+	assert.False(t, isNitro)
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fixed the issue of missing node capacity advertisement when node start on secondary IP mode. The cause was an incorrect condition resulting in returning the function too early and skipping capacity advertisement.
- Added license statement to prefix provider file.
- Added node event for error in `InitResources` to prefix provider to be consistent with secondary IP provider.
- Added a check for nitro status when toggling from PD to secondary IP
- Refactored common code for nitro check

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
