### PR TITLE
Fix prometheus metric

### DIFF
--- a/pkg/aws/ec2/api/wrapper.go
+++ b/pkg/aws/ec2/api/wrapper.go
@@ -491,7 +491,7 @@ func timeSinceMs(start time.Time) float64 {
 func (e *ec2Wrapper) DescribeInstances(input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
 	start := time.Now()
 	describeInstancesOutput, err := e.userServiceClient.DescribeInstances(input)
-	ec2APICallLatencies.WithLabelValues("describe_network_interface").Observe(timeSinceMs(start))
+	ec2APICallLatencies.WithLabelValues("describe_instances").Observe(timeSinceMs(start))
 
 	// Metric updates
 	ec2APICallCnt.Inc()


### PR DESCRIPTION
This prometheus metric is named incorrectly

*Issue #, if available:*

*Description of changes:*
Fixing prometheus label to match the right API call

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
