### PR TITLE
fixed incorrect node event for Linux instances emitted from prefix provider

### DIFF
--- a/pkg/provider/ip/provider.go
+++ b/pkg/provider/ip/provider.go
@@ -90,7 +90,7 @@ func (p *ipv4Provider) InitResource(instance ec2.EC2Instance) error {
 	if err != nil || ipV4Resources == nil {
 		if errors.Is(err, utils.ErrNotFound) {
 			msg := fmt.Sprintf("The instance type %s is not supported for Windows", instance.Type())
-			utils.SendNodeEvent(p.apiWrapper.K8sAPI, instance.Name(), "Unsupported", msg, v1.EventTypeWarning, p.log)
+			utils.SendNodeEvent(p.apiWrapper.K8sAPI, instance.Name(), utils.UnsupportedInstanceTypeReason, msg, v1.EventTypeWarning, p.log)
 		}
 
 		return err

--- a/pkg/provider/prefix/provider_test.go
+++ b/pkg/provider/prefix/provider_test.go
@@ -544,11 +544,7 @@ func TestIsInstanceSupported_Linux(t *testing.T) {
 	prefixProvider := ipv4PrefixProvider{apiWrapper: api.Wrapper{K8sAPI: mockK8sWrapper},
 		instanceProviderAndPool: map[string]*ResourceProviderAndPool{},
 		log:                     zap.New(zap.UseDevMode(true)).WithName("prefix provider"), conditions: mockConditions}
-	mockInstance.EXPECT().Type().Return(instanceType)
 	mockInstance.EXPECT().Os().Return(config.OSLinux)
-	mockInstance.EXPECT().Name().Return(nodeName)
-	mockK8sWrapper.EXPECT().GetNode(nodeName).Return(node, nil).Times(1)
-	mockK8sWrapper.EXPECT().BroadcastEvent(node, "Unsupported", gomock.Any(), v1.EventTypeWarning).Times(1)
 
 	assert.Equal(t, false, prefixProvider.IsInstanceSupported(mockInstance))
 }
@@ -585,6 +581,7 @@ func TestIsInstanceSupported_NotFound(t *testing.T) {
 		instanceProviderAndPool: map[string]*ResourceProviderAndPool{},
 		log:                     zap.New(zap.UseDevMode(true)).WithName("prefix provider"), conditions: mockConditions}
 	mockInstance.EXPECT().Type().Return("zzz")
+	mockInstance.EXPECT().Os().Return(config.OSWindows)
 	mockInstance.EXPECT().Name().Return(nodeName)
 	mockK8sWrapper.EXPECT().GetNode(nodeName).Return(node, nil).Times(1)
 	mockK8sWrapper.EXPECT().BroadcastEvent(node, "Unsupported", gomock.Any(), v1.EventTypeWarning).Times(1)

--- a/pkg/utils/events.go
+++ b/pkg/utils/events.go
@@ -7,14 +7,14 @@ import (
 )
 
 var (
-	unsupportedInstanceTypeReason = "Unsupported"
+	UnsupportedInstanceTypeReason = "Unsupported"
 )
 
 func SendNodeEvent(client k8s.K8sWrapper, nodeName, reason, msg, eventType string, logger logr.Logger) {
 	if node, err := client.GetNode(nodeName); err == nil {
 		// set UID to node name for kubelet filter the event to node description
 		node.SetUID(types.UID(nodeName))
-		client.BroadcastEvent(node, unsupportedInstanceTypeReason, msg, eventType)
+		client.BroadcastEvent(node, reason, msg, eventType)
 	} else {
 		logger.Error(err, "had an error to get the node for sending unsupported event", "Node", nodeName)
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Don't emit node event for Linux instance when checking `IsInstanceSupported` for prefix provider

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
