### PR TITLE
fixed unstable test case for minimum-ip-target

### DIFF
--- a/test/framework/utils/poll.go
+++ b/test/framework/utils/poll.go
@@ -25,5 +25,5 @@ const (
 	// Windows Container Images are much larger in size and pulling them the first
 	// time takes much longer, so have higher timeout for Windows Pod to be Ready
 	WindowsPodsCreationTimeout = 240 * time.Second
-	WindowsPodsDeletionTimeout = 240 * time.Second
+	WindowsPodsDeletionTimeout = 60 * time.Second
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fixed the unstable test case for `minimum-ip-target`. It passed consistently for the last 5 runs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
