### PR TITLE
chore: Added dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# See https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds dependabot to help us keep dependencies up to date. Dependabot will automatically open PRs -- we have the option to merge them immediately, or hold as necessary. Minimally, it helps to keep us aware of new versions as they're available.

This can help reduce time to mitigation for issues like https://github.com/aws/amazon-vpc-resource-controller-k8s/issues/238.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
