### PR TITLE
fixed log statements with incorrect args

### DIFF
--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -684,11 +684,11 @@ func (p *pool) getPDDeviation() int {
 	}
 
 	if deviationPrefix != 0 {
-		p.log.Info("calculating IP deviation for prefix pool", "p.warmPoolConfig", p.warmPoolConfig,
-			"existing warm resources", numExistingWarmResources, "p.pendingCreate", p.pendingCreate, "p.pendingDelete", p.pendingDelete,
-			"numTotalResources", numTotalResources, "numCurrPrefix", numCurrPrefix, "numTotalResForWarmIPTarget", numTotalResForWarmIPTarget,
-			"numPrefixForWarmIPTarget", numPrefixForWarmIPTarget, "numPrefixForMinIPTarget", numPrefixForMinIPTarget,
-			"deviation", deviationPrefix*NumIPv4AddrPerPrefix)
+		p.log.V(1).Info("calculating IP deviation for prefix pool", "warmPoolConfig", p.warmPoolConfig,
+			"used resources", len(p.usedResources), "existing warm resources", numExistingWarmResources, "pendingCreate", p.pendingCreate,
+			"pendingDelete", p.pendingDelete, "numTotalResources", numTotalResources, "numCurrPrefix", numCurrPrefix,
+			"numTotalResForWarmIPTarget", numTotalResForWarmIPTarget, "numPrefixForWarmIPTarget", numPrefixForWarmIPTarget,
+			"numPrefixForMinIPTarget", numPrefixForMinIPTarget, "deviation", deviationPrefix*NumIPv4AddrPerPrefix)
 	}
 
 	return deviationPrefix * NumIPv4AddrPerPrefix

--- a/pkg/provider/ip/provider.go
+++ b/pkg/provider/ip/provider.go
@@ -192,7 +192,7 @@ func (p *ipv4Provider) DeInitResource(instance ec2.EC2Instance) error {
 func (p *ipv4Provider) UpdateResourceCapacity(instance ec2.EC2Instance) error {
 	resourceProviderAndPool, isPresent := p.getInstanceProviderAndPool(instance.Name())
 	if !isPresent {
-		p.log.Error(nil, "cannot find the instance provider and pool form the cache", "node-name", instance.Name())
+		p.log.Error(utils.ErrNotFound, utils.ErrMsgProviderAndPoolNotFound, "node name", instance.Name())
 		return nil
 	}
 
@@ -304,7 +304,7 @@ func (p *ipv4Provider) ProcessAsyncJob(job interface{}) (ctrl.Result, error) {
 func (p *ipv4Provider) CreatePrivateIPv4AndUpdatePool(job *worker.WarmPoolJob) {
 	instanceResource, found := p.getInstanceProviderAndPool(job.NodeName)
 	if !found {
-		p.log.Error(fmt.Errorf("cannot find the instance provider and pool form the cache"), "node", job.NodeName)
+		p.log.Error(utils.ErrNotFound, utils.ErrMsgProviderAndPoolNotFound, "node name", job.NodeName)
 		return
 	}
 	didSucceed := true
@@ -320,15 +320,13 @@ func (p *ipv4Provider) CreatePrivateIPv4AndUpdatePool(job *worker.WarmPoolJob) {
 func (p *ipv4Provider) ReSyncPool(job *worker.WarmPoolJob) {
 	providerAndPool, found := p.instanceProviderAndPool[job.NodeName]
 	if !found {
-		p.log.Error(fmt.Errorf("instance provider not found"), "node is not initialized",
-			"name", job.NodeName)
+		p.log.Error(utils.ErrNotFound, "node is not initialized", "node name", job.NodeName)
 		return
 	}
 
 	ipV4Resources, err := providerAndPool.eniManager.InitResources(p.apiWrapper.EC2API)
 	if err != nil || ipV4Resources == nil {
-		p.log.Error(err, "failed to get init resources for the node",
-			"name", job.NodeName)
+		p.log.Error(err, "failed to get init resources for the node", "node name", job.NodeName)
 		return
 	}
 
@@ -339,7 +337,7 @@ func (p *ipv4Provider) ReSyncPool(job *worker.WarmPoolJob) {
 func (p *ipv4Provider) DeletePrivateIPv4AndUpdatePool(job *worker.WarmPoolJob) {
 	instanceResource, found := p.getInstanceProviderAndPool(job.NodeName)
 	if !found {
-		p.log.Error(fmt.Errorf("cannot find the instance provider and pool form the cache"), "node", job.NodeName)
+		p.log.Error(utils.ErrNotFound, utils.ErrMsgProviderAndPoolNotFound, "node name", job.NodeName)
 		return
 	}
 	didSucceed := true

--- a/pkg/provider/prefix/provider.go
+++ b/pkg/provider/prefix/provider.go
@@ -193,7 +193,7 @@ func (p *ipv4PrefixProvider) DeInitResource(instance ec2.EC2Instance) error {
 func (p *ipv4PrefixProvider) UpdateResourceCapacity(instance ec2.EC2Instance) error {
 	resourceProviderAndPool, isPresent := p.getInstanceProviderAndPool(instance.Name())
 	if !isPresent {
-		p.log.Error(nil, "cannot find the instance provider and pool form the cache", "node-name", instance.Name())
+		p.log.Error(utils.ErrNotFound, utils.ErrMsgProviderAndPoolNotFound, "node name", instance.Name())
 		return nil
 	}
 
@@ -279,7 +279,7 @@ func (p *ipv4PrefixProvider) ProcessAsyncJob(job interface{}) (ctrl.Result, erro
 func (p *ipv4PrefixProvider) CreateIPv4PrefixAndUpdatePool(job *worker.WarmPoolJob) {
 	instanceResource, found := p.getInstanceProviderAndPool(job.NodeName)
 	if !found {
-		p.log.Error(fmt.Errorf("cannot find the instance provider and pool form the cache"), "node", job.NodeName)
+		p.log.Error(utils.ErrNotFound, utils.ErrMsgProviderAndPoolNotFound, "node name", job.NodeName)
 		return
 	}
 	didSucceed := true
@@ -303,7 +303,7 @@ func (p *ipv4PrefixProvider) CreateIPv4PrefixAndUpdatePool(job *worker.WarmPoolJ
 func (p *ipv4PrefixProvider) DeleteIPv4PrefixAndUpdatePool(job *worker.WarmPoolJob) {
 	instanceResource, found := p.getInstanceProviderAndPool(job.NodeName)
 	if !found {
-		p.log.Error(fmt.Errorf("cannot find the instance provider and pool form the cache"), "node", job.NodeName)
+		p.log.Error(utils.ErrNotFound, utils.ErrMsgProviderAndPoolNotFound, "node name", job.NodeName)
 		return
 	}
 
@@ -322,15 +322,13 @@ func (p *ipv4PrefixProvider) DeleteIPv4PrefixAndUpdatePool(job *worker.WarmPoolJ
 func (p *ipv4PrefixProvider) ReSyncPool(job *worker.WarmPoolJob) {
 	providerAndPool, found := p.instanceProviderAndPool[job.NodeName]
 	if !found {
-		p.log.Error(fmt.Errorf("instance provider not found"), "node is not initialized",
-			"name", job.NodeName)
+		p.log.Error(utils.ErrNotFound, "node is not initialized", "node name", job.NodeName)
 		return
 	}
 
 	ipV4Resources, err := providerAndPool.eniManager.InitResources(p.apiWrapper.EC2API)
 	if err != nil || ipV4Resources == nil {
-		p.log.Error(err, "failed to get init resources for the node",
-			"name", job.NodeName)
+		p.log.Error(err, "failed to get init resources for the node", "node name", job.NodeName)
 		return
 	}
 
@@ -340,7 +338,7 @@ func (p *ipv4PrefixProvider) ReSyncPool(job *worker.WarmPoolJob) {
 func (p *ipv4PrefixProvider) ProcessDeleteQueue(job *worker.WarmPoolJob) (ctrl.Result, error) {
 	resourceProviderAndPool, isPresent := p.getInstanceProviderAndPool(job.NodeName)
 	if !isPresent {
-		p.log.Info("forgetting the delete queue processing job", "node", job.NodeName)
+		p.log.Info("forgetting the delete queue processing job", "node name", job.NodeName)
 		return ctrl.Result{}, nil
 	}
 	// TODO: For efficiency run only when required in next release

--- a/pkg/utils/errors.go
+++ b/pkg/utils/errors.go
@@ -3,6 +3,7 @@ package utils
 import "errors"
 
 var (
-	ErrNotFound               = errors.New("resource was not found")
-	ErrInsufficientCidrBlocks = errors.New("InsufficientCidrBlocks: The specified subnet does not have enough free cidr blocks to satisfy the request")
+	ErrNotFound                   = errors.New("resource was not found")
+	ErrInsufficientCidrBlocks     = errors.New("InsufficientCidrBlocks: The specified subnet does not have enough free cidr blocks to satisfy the request")
+	ErrMsgProviderAndPoolNotFound = "cannot find the instance provider and pool from the cache"
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Some log statements have incorrect number of args. Replaced `fmt.Errorf` with package-defined `utils.ErrNotFound` to be consistent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
