### PR TITLE
add missing lock when ENI manager init resources

### DIFF
--- a/pkg/provider/ip/eni/eni.go
+++ b/pkg/provider/ip/eni/eni.go
@@ -70,6 +70,8 @@ func NewENIManager(instance ec2.EC2Instance) *eniManager {
 
 // InitResources loads the list of ENIs, secondary IPs and prefixes, associated with the instance
 func (e *eniManager) InitResources(ec2APIHelper api.EC2APIHelper) (*IPv4Resource, error) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
 
 	nwInterfaces, err := ec2APIHelper.GetInstanceNetworkInterface(aws.String(e.instance.InstanceID()))
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- In `eniManage.InitResources`, the method didn't lock around the shared `resourceToENIMap`.  This could cause concurrency issue when the same map is used by another goroutine. For example, the same `eniManage.InitResources` could be called by `ipv4Provider.InitResource` and `ipv4Provider.ReSyncPool`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
