### PR TITLE
do not resync or reconcile pool for InsufficientCidrBlocks error and add longer wait time for retry

### DIFF
--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/pool/mock_pool.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/pool/mock_pool.go
@@ -178,15 +178,15 @@ func (mr *MockPoolMockRecorder) SetToDraining() *gomock.Call {
 }
 
 // UpdatePool mocks base method.
-func (m *MockPool) UpdatePool(arg0 *worker.WarmPoolJob, arg1 bool) bool {
+func (m *MockPool) UpdatePool(arg0 *worker.WarmPoolJob, arg1, arg2 bool) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdatePool", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdatePool", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // UpdatePool indicates an expected call of UpdatePool.
-func (mr *MockPoolMockRecorder) UpdatePool(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockPoolMockRecorder) UpdatePool(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePool", reflect.TypeOf((*MockPool)(nil).UpdatePool), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePool", reflect.TypeOf((*MockPool)(nil).UpdatePool), arg0, arg1, arg2)
 }

--- a/pkg/pool/pool_test.go
+++ b/pkg/pool/pool_test.go
@@ -221,7 +221,7 @@ func TestPool_UpdatePool_OperationCreate_Succeed(t *testing.T) {
 		Operations:    worker.OperationCreate,
 		Resources:     createdResources,
 		ResourceCount: 2,
-	}, true)
+	}, true, false)
 
 	warmResources := make(map[string][]Resource)
 	warmResources[res3] = []Resource{{GroupID: res3, ResourceID: res3}}
@@ -239,7 +239,7 @@ func TestPool_UpdatePool_OperationCreate_Failed(t *testing.T) {
 		Operations:    worker.OperationCreate,
 		Resources:     nil,
 		ResourceCount: 2,
-	}, false)
+	}, false, false)
 
 	assert.True(t, shouldReconcile)
 	assert.True(t, warmPool.reSyncRequired)
@@ -253,7 +253,7 @@ func TestPool_UpdatePool_OperationDelete_Succeed(t *testing.T) {
 		Operations:    worker.OperationDeleted,
 		Resources:     nil,
 		ResourceCount: 1,
-	}, true)
+	}, true, false)
 
 	// Assert resources are not added back to the warm pool
 	assert.Zero(t, len(warmPool.warmResources))
@@ -268,7 +268,7 @@ func TestPool_UpdatePool_OperationDelete_Failed(t *testing.T) {
 		Operations:    worker.OperationDeleted,
 		Resources:     failedResources,
 		ResourceCount: 2,
-	}, false)
+	}, false, false)
 
 	failed := make(map[string][]Resource)
 	failed[res3] = []Resource{{GroupID: res3, ResourceID: res3}}

--- a/pkg/provider/ip/provider.go
+++ b/pkg/provider/ip/provider.go
@@ -361,7 +361,7 @@ func (p *ipv4Provider) DeletePrivateIPv4AndUpdatePool(job *worker.WarmPoolJob) {
 // updatePoolAndReconcileIfRequired updates the resource pool and reconcile again and submit a new job if required
 func (p *ipv4Provider) updatePoolAndReconcileIfRequired(resourcePool pool.Pool, job *worker.WarmPoolJob, didSucceed bool) {
 	// Update the pool to add the created/failed resource to the warm pool and decrement the pending count
-	shouldReconcile := resourcePool.UpdatePool(job, didSucceed)
+	shouldReconcile := resourcePool.UpdatePool(job, didSucceed, false)
 
 	if shouldReconcile {
 		job := resourcePool.ReconcilePool()

--- a/pkg/provider/ip/provider_test.go
+++ b/pkg/provider/ip/provider_test.go
@@ -130,7 +130,7 @@ func TestIpv4Provider_updatePoolAndReconcileIfRequired_NoFurtherReconcile(t *tes
 
 	job := &worker.WarmPoolJob{Operations: worker.OperationCreate}
 
-	mockPool.EXPECT().UpdatePool(job, true).Return(false)
+	mockPool.EXPECT().UpdatePool(job, true, false).Return(false)
 
 	provider.updatePoolAndReconcileIfRequired(mockPool, job, true)
 }
@@ -147,7 +147,7 @@ func TestIpv4Provider_updatePoolAndReconcileIfRequired_ReconcileRequired(t *test
 
 	job := &worker.WarmPoolJob{Operations: worker.OperationCreate}
 
-	mockPool.EXPECT().UpdatePool(job, true).Return(true)
+	mockPool.EXPECT().UpdatePool(job, true, false).Return(true)
 	mockPool.EXPECT().ReconcilePool().Return(job)
 	mockWorker.EXPECT().SubmitJob(job)
 
@@ -179,7 +179,7 @@ func TestIpv4Provider_DeletePrivateIPv4AndUpdatePool(t *testing.T) {
 		Resources:     []string{},
 		ResourceCount: 2,
 		NodeName:      nodeName,
-	}, true).Return(false)
+	}, true, false).Return(false)
 
 	ipv4Provider.DeletePrivateIPv4AndUpdatePool(deleteJob)
 }
@@ -210,7 +210,7 @@ func TestIpv4Provider_DeletePrivateIPv4AndUpdatePool_SomeResourceFail(t *testing
 		Resources:     failedResources,
 		ResourceCount: 2,
 		NodeName:      nodeName,
-	}, true).Return(false)
+	}, true, false).Return(false)
 
 	ipv4Provider.DeletePrivateIPv4AndUpdatePool(&deleteJob)
 }
@@ -240,7 +240,7 @@ func TestIPv4Provider_CreatePrivateIPv4AndUpdatePool(t *testing.T) {
 		Resources:     createdResources,
 		ResourceCount: 2,
 		NodeName:      nodeName,
-	}, true).Return(false)
+	}, true, false).Return(false)
 
 	ipv4Provider.CreatePrivateIPv4AndUpdatePool(createJob)
 }
@@ -270,7 +270,7 @@ func TestIPv4Provider_CreatePrivateIPv4AndUpdatePool_Fail(t *testing.T) {
 		Resources:     createdResources,
 		ResourceCount: 2,
 		NodeName:      nodeName,
-	}, false).Return(false)
+	}, false, false).Return(false)
 
 	ipv4Provider.CreatePrivateIPv4AndUpdatePool(createJob)
 }

--- a/pkg/utils/errors.go
+++ b/pkg/utils/errors.go
@@ -1,9 +1,23 @@
 package utils
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 var (
 	ErrNotFound                   = errors.New("resource was not found")
 	ErrInsufficientCidrBlocks     = errors.New("InsufficientCidrBlocks: The specified subnet does not have enough free cidr blocks to satisfy the request")
 	ErrMsgProviderAndPoolNotFound = "cannot find the instance provider and pool from the cache"
+	NotRetryErrors                = []string{InsufficientCidrBlocksReason}
 )
+
+// ShouldRetryOnError returns true if the error is retryable, else returns false
+func ShouldRetryOnError(err error) bool {
+	for _, e := range NotRetryErrors {
+		if strings.HasPrefix(err.Error(), e) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Do not resync pool for `InsufficientCidrBlocks` error as it results in unnecessary calls of `DescribeInstances`.
- Change retry wait time for`InsufficientCidrBlocks` error to 2 min.
- Add a new field in pool to indicate whether prefix is available in the subnet, so that it can inform pod controller of the error and its corresponding wait time.
- Send pod event when `InsufficientCidrBlocks` happens and pod needs to retry after 2 min.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
