### PR TITLE
Define environment variable and set it to empty by default

### DIFF
--- a/scripts/test/run-integration-tests.sh
+++ b/scripts/test/run-integration-tests.sh
@@ -19,6 +19,7 @@ SECONDS=0
 : "${RUN_DEVEKS_TEST:=false}"
 : "${ENDPOINT:=""}"
 : "${SKIP_WINDOWS_TEST:=""}"
+: "${EXTRA_GINKGO_FLAGS:=""}"
 
 source "$SCRIPT_DIR"/lib/cluster.sh
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Script fails if `EXTRA_GINKGO_FLAGS` parameters is not defined. We are using `set -u` in this file which treats this as an error. With this change, we define the variable as empty if it is not defined/passed to the script


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
