### PR TITLE
Add introspecting summary to minimize the output for pods

### DIFF
--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/provider/mock_provider.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/provider/mock_provider.go
@@ -135,6 +135,20 @@ func (mr *MockResourceProviderMockRecorder) IntrospectNode(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IntrospectNode", reflect.TypeOf((*MockResourceProvider)(nil).IntrospectNode), arg0)
 }
 
+// IntrospectSummary mocks base method.
+func (m *MockResourceProvider) IntrospectSummary() interface{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IntrospectSummary")
+	ret0, _ := ret[0].(interface{})
+	return ret0
+}
+
+// IntrospectSummary indicates an expected call of IntrospectSummary.
+func (mr *MockResourceProviderMockRecorder) IntrospectSummary() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IntrospectSummary", reflect.TypeOf((*MockResourceProvider)(nil).IntrospectSummary))
+}
+
 // IsInstanceSupported mocks base method.
 func (m *MockResourceProvider) IsInstanceSupported(arg0 ec2.EC2Instance) bool {
 	m.ctrl.T.Helper()

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -104,6 +104,12 @@ type IntrospectResponse struct {
 	CoolingResources []CoolDownResource
 }
 
+type IntrospectSummaryResponse struct {
+	UsedResourcesCount    int
+	WarmResourcesCount    int
+	CoolingResourcesCount int
+}
+
 func NewResourcePool(log logr.Logger, poolConfig *config.WarmPoolConfig, usedResources map[string]Resource,
 	warmResources map[string][]Resource, nodeName string, capacity int, isPDPool bool) Pool {
 	pool := &pool{

--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -496,6 +496,28 @@ func (b *branchENIProvider) Introspect() interface{} {
 	return allResponse
 }
 
+func (b *branchENIProvider) IntrospectSummary() interface{} {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
+	allResponse := make(map[string]trunk.IntrospectSummaryResponse)
+
+	for nodeName, trunkENI := range b.trunkENICache {
+		response := trunkENI.Introspect()
+		allResponse[nodeName] = changeToIntrospectSummary(response)
+	}
+	return allResponse
+}
+
+func changeToIntrospectSummary(details trunk.IntrospectResponse) trunk.IntrospectSummaryResponse {
+	return trunk.IntrospectSummaryResponse{
+		TrunkENIID:     details.TrunkENIID,
+		InstanceID:     details.InstanceID,
+		BranchENICount: len(details.PodToBranchENI),
+		DeleteQueueLen: len(details.DeleteQueue),
+	}
+}
+
 func (b *branchENIProvider) IntrospectNode(nodeName string) interface{} {
 	b.lock.RLock()
 	defer b.lock.RUnlock()

--- a/pkg/provider/branch/trunk/trunk.go
+++ b/pkg/provider/branch/trunk/trunk.go
@@ -130,6 +130,13 @@ type IntrospectResponse struct {
 	DeleteQueue    []ENIDetails
 }
 
+type IntrospectSummaryResponse struct {
+	TrunkENIID     string
+	InstanceID     string
+	BranchENICount int
+	DeleteQueueLen int
+}
+
 // NewTrunkENI returns a new Trunk ENI interface.
 func NewTrunkENI(logger logr.Logger, instance ec2.EC2Instance, helper api.EC2APIHelper) TrunkENI {
 

--- a/pkg/provider/ip/provider.go
+++ b/pkg/provider/ip/provider.go
@@ -460,6 +460,26 @@ func (p *ipv4Provider) Introspect() interface{} {
 	return response
 }
 
+func (p *ipv4Provider) IntrospectSummary() interface{} {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	response := make(map[string]pool.IntrospectSummaryResponse)
+	for nodeName, resource := range p.instanceProviderAndPool {
+		response[nodeName] = ChangeToIntrospectSummary(resource.resourcePool.Introspect())
+
+	}
+	return response
+}
+
+func ChangeToIntrospectSummary(details pool.IntrospectResponse) pool.IntrospectSummaryResponse {
+	return pool.IntrospectSummaryResponse{
+		WarmResourcesCount:    len(details.WarmResources),
+		CoolingResourcesCount: len(details.CoolingResources),
+		UsedResourcesCount:    len(details.UsedResources),
+	}
+}
+
 func (p *ipv4Provider) IntrospectNode(nodeName string) interface{} {
 	p.lock.RLock()
 	defer p.lock.RUnlock()

--- a/pkg/provider/prefix/provider.go
+++ b/pkg/provider/prefix/provider.go
@@ -28,6 +28,7 @@ import (
 	rcHealthz "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/healthz"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/pool"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/ip"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/ip/eni"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/utils"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/worker"
@@ -431,6 +432,17 @@ func (p *ipv4PrefixProvider) Introspect() interface{} {
 	response := make(map[string]pool.IntrospectResponse)
 	for nodeName, resource := range p.instanceProviderAndPool {
 		response[nodeName] = resource.resourcePool.Introspect()
+	}
+	return response
+}
+
+func (p *ipv4PrefixProvider) IntrospectSummary() interface{} {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	response := make(map[string]pool.IntrospectSummaryResponse)
+	for nodeName, resource := range p.instanceProviderAndPool {
+		response[nodeName] = ip.ChangeToIntrospectSummary(resource.resourcePool.Introspect())
 	}
 	return response
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -42,4 +42,6 @@ type ResourceProvider interface {
 	IntrospectNode(node string) interface{}
 	// GetHealthChecker provider a health check subpath for pinging provider
 	GetHealthChecker() healthz.Checker
+	// IntrospectSummary allows introspection of resources summary per node
+	IntrospectSummary() interface{}
 }

--- a/pkg/resource/introspect_test.go
+++ b/pkg/resource/introspect_test.go
@@ -19,8 +19,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/provider"
-	"github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/resource"
+	mock_provider "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/provider"
+	mock_resource "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/resource"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider"
 
@@ -87,6 +87,24 @@ func TestIntrospectHandler_ResourceHandler(t *testing.T) {
 	mock.mockProvider.EXPECT().Introspect().Return(response)
 
 	mock.handler.ResourceHandler(rr, req)
+	VerifyResponse(t, rr, mock.response)
+}
+
+func TestIntrospectHandler_SummaryHandler(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := NewMockIntrospectHandler(ctrl)
+
+	req, err := http.NewRequest("GET", GetAllResourcesPath+nodeName, nil)
+	assert.NoError(t, err)
+	rr := httptest.NewRecorder()
+
+	mock.mockManager.EXPECT().GetResourceProviders().
+		Return(map[string]provider.ResourceProvider{resourceName: mock.mockProvider})
+	mock.mockProvider.EXPECT().IntrospectSummary().Return(response)
+
+	mock.handler.ResourceSummaryHandler(rr, req)
 	VerifyResponse(t, rr, mock.response)
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We should provide a summary of resource to scrape instead of full deployed pods, especially in a large clusters. 

Tests:
```
$ curl localhost:22775/resources/all
{
	"vpc.amazonaws.com/PrivateIPv4Address": {},
	"vpc.amazonaws.com/PrivateIPv4AddressFromPrefix": {},
	"vpc.amazonaws.com/pod-eni": {
		"ip-192-168-xx-x.us-west-2.compute.internal": {
			"TrunkENIID": "eni-08bfxxxxxxxxxx",
			"InstanceID": "i-0428xxxxxxxxxx",
			"PodToBranchENI": {
				"ce4bfcdf-1137-4662-b279-79d937838ac6": [
					{
						"eniId": "eni-0314xxxxxxxxxx",
						"ifAddress": "02:8e:xx:xx:xx:xx",
						"privateIp": "192.168.xx.xxx",
						"vlanId": 2,
						"subnetCidr": "192.168.32.0/19"
					}
				],
				"ff42c15a-23c9-4e86-9823-731916db0d3d": [
					{
						"eniId": "eni-01bbxxxxxxxxxx",
						"ifAddress": "02:f6:xx:xx:xx:xx",
						"privateIp": "192.168.xx.xxx",
						"vlanId": 3,
						"subnetCidr": "192.168.32.0/19"
					}
				]
			},
			"DeleteQueue": null
		},
		"ip-192-168-xx-xx.us-west-2.compute.internal": {
			"TrunkENIID": "eni-0535xxxxxxxxxx",
			"InstanceID": "i-0c0axxxxxxxxxx",
			"PodToBranchENI": {},
			"DeleteQueue": null
		}
	}
}
```
```
 curl localhost:22775/resources/summary
{
	"vpc.amazonaws.com/PrivateIPv4Address": {},
	"vpc.amazonaws.com/PrivateIPv4AddressFromPrefix": {},
	"vpc.amazonaws.com/pod-eni": {
		"ip-192-168-xx-x.us-west-2.compute.internal": {
			"TrunkENIID": "eni-08bfxxxxxxxxxx",
			"InstanceID": "i-0428xxxxxxxxxx",
			"BranchENICount": 2,
			"DeleteQueueLen": 0
		},
		"ip-192-168-xx-xx.us-west-2.compute.internal": {
			"TrunkENIID": "eni-0535xxxxxxxxxx",
			"InstanceID": "i-0c0axxxxxxxxxx",
			"BranchENICount": 0,
			"DeleteQueueLen": 0
		}
	}
}

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
