### PR TITLE
use individual cninode controller to avoid latency

### DIFF
--- a/controllers/core/node_controller.go
+++ b/controllers/core/node_controller.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1alpha1"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/condition"
 	rcHealthz "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/healthz"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/k8s"
@@ -113,7 +112,7 @@ func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager, healthzHandler *rcHe
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Node{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: MaxNodeConcurrentReconciles}).
-		Owns(&v1alpha1.CNINode{}).Complete(r)
+		Complete(r)
 }
 
 func (r *NodeReconciler) Check() healthz.Checker {

--- a/controllers/crds/cninode_controller.go
+++ b/controllers/crds/cninode_controller.go
@@ -1,0 +1,51 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package crds
+
+import (
+	"context"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1alpha1"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/k8s"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/node/manager"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type CNINodeController struct {
+	Log         logr.Logger
+	NodeManager manager.Manager
+	K8sAPI      k8s.K8sWrapper
+}
+
+const MaxNodeConcurrentReconciles = 3
+
+func (c *CNINodeController) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.CNINode{}).WithOptions(
+		controller.Options{
+			MaxConcurrentReconciles: MaxNodeConcurrentReconciles,
+		},
+	).Complete(reconcile.Func(func(ctx context.Context, r reconcile.Request) (reconcile.Result, error) {
+		// check local datastore if the node was cached/added
+		if _, found := c.NodeManager.GetNode(r.Name); found {
+			return ctrl.Result{}, c.NodeManager.UpdateNode(r.Name)
+		} else {
+			return ctrl.Result{}, c.NodeManager.AddNode(r.Name)
+		}
+	}))
+}

--- a/controllers/crds/cninode_controller_test.go
+++ b/controllers/crds/cninode_controller_test.go
@@ -1,0 +1,76 @@
+package crds
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1alpha1"
+	mock_k8s "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s"
+	mock_node "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/node"
+	mock_manager "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/node/manager"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	mockNodeName     = "node-name"
+	reconcileRequest = reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name: mockNodeName,
+		},
+	}
+	mockNodeObj = &v1.Node{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: mockNodeName,
+		},
+	}
+)
+
+type CNINodeMock struct {
+	Manager    *mock_manager.MockManager
+	MockNode   *mock_node.MockNode
+	Controller CNINodeController
+	MockK8sAPI *mock_k8s.MockK8sWrapper
+	Scheme     runtime.Scheme
+}
+
+func NewCNINodeMock(ctrl *gomock.Controller, mockObjects ...runtime.Object) CNINodeMock {
+	mockManager := mock_manager.NewMockManager(ctrl)
+	mockNode := mock_node.NewMockNode(ctrl)
+
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+	return CNINodeMock{
+		Manager:  mockManager,
+		MockNode: mockNode,
+		Controller: CNINodeController{
+			Log:         zap.New(),
+			NodeManager: mockManager,
+		},
+		Scheme: *scheme,
+	}
+}
+
+func TestSetupWithManager(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testenv := &envtest.Environment{}
+	cfg, err := testenv.Start()
+	assert.NoError(t, err)
+
+	mock := NewCNINodeMock(ctrl, mockNodeObj)
+	m, err := manager.New(cfg, manager.Options{Scheme: &mock.Scheme})
+	assert.NoError(t, err)
+	err = mock.Controller.SetupWithManager(m)
+	assert.NoError(t, err)
+}

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	vpcresourcesv1beta1 "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/controllers/apps"
 	corecontroller "github.com/aws/amazon-vpc-resource-controller-k8s/controllers/core"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/controllers/crds"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/api"
 	ec2API "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2/api"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/condition"
@@ -341,6 +342,15 @@ func main() {
 		Context:    ctx,
 	}).SetupWithManager(mgr, healthzHandler); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Node")
+		os.Exit(1)
+	}
+
+	if err := (&crds.CNINodeController{
+		K8sAPI:      k8sApi,
+		Log:         ctrl.Log.WithName("controller").WithName("CNINode"),
+		NodeManager: nodeManager,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "CNINode")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We are seeing some latency when using Owns() or Watches() CNINode from node controller. This PR is changing to independent CNINode controller to reconcile on the CRD and trigger node process.

Tests:
- using Owns(): initializing 200 nodes in EKS 1.25 cluster used ~ 7 min 30 sec
- using independent CNINode reconciler: initializing 200 nodes in EKS 1.25 cluster used ~ 2 min 30 sec which is same as the old way that CNI labels node to signal this controller.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
