### PR TITLE
fix: Add controller=true to ownerreferences to correctly reconcile on .Owns()

### DIFF
--- a/controllers/core/node_controller.go
+++ b/controllers/core/node_controller.go
@@ -113,7 +113,8 @@ func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager, healthzHandler *rcHe
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Node{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: MaxNodeConcurrentReconciles}).
-		Owns(&v1alpha1.CNINode{}).Complete(r)
+		Owns(&v1alpha1.CNINode{}).
+		Complete(r)
 }
 
 func (r *NodeReconciler) Check() healthz.Checker {

--- a/pkg/k8s/wrapper.go
+++ b/pkg/k8s/wrapper.go
@@ -21,6 +21,7 @@ import (
 	rcv1alpha1 "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1alpha1"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/samber/lo"
 
 	appv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -244,6 +245,7 @@ func (k *k8sWrapper) CreateCNINode(node *v1.Node) error {
 					Kind:       node.Kind,
 					Name:       node.Name,
 					UID:        node.UID,
+					Controller: lo.ToPtr(true),
 				},
 			},
 		},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently the node_controller is not correctly wired up with CNINode Updates. It only triggers on node events. We're currently saved by the 5 minute node heartbeat, which happens to trigger attachment trunk attachment when it happens. This can cause trunk attachment tot take between 0-5 minutes instead of near-immediate reconciliation.

Controller-runtime expects controller=true on ownerreferences for `.Owns` to correctly enqueue the node keys. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
