### PR TITLE
add make apply-dependencies and update developer guide

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -8,7 +8,8 @@ make toolchain # Install required to develop the project
 
 ## Testing a code change
 
-Deploy your changes to a local development cluster and run the tests against it.
+Deploy your changes to a local development cluster and run the tests against it. You will need to allowlist your account
+for ENI trunking before the deployment.
 
 ```sh
 make apply-dependencies # install the cert manager and certificate

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -11,6 +11,7 @@ make toolchain # Install required to develop the project
 Deploy your changes to a local development cluster and run the tests against it.
 
 ```sh
+make apply-dependencies # install the cert manager and certificate
 make apply # Apply your changes
 make e2etest # Run the integration test suite
 ```

--- a/Makefile
+++ b/Makefile
@@ -96,3 +96,4 @@ build-test-binaries:
 
 apply-dependencies:
 	bash ${MAKEFILE_PATH}/scripts/test/install-cert-manager.sh
+	kubectl set env daemonset aws-node -n kube-system ENABLE_POD_ENI=true

--- a/Makefile
+++ b/Makefile
@@ -93,3 +93,6 @@ build-test-binaries:
 	mkdir -p ${MAKEFILE_PATH}build
 	find ${MAKEFILE_PATH} -name '*suite_test.go' -type f  | xargs dirname  | xargs ginkgo build
 	find ${MAKEFILE_PATH} -name "*.test" -print0 | xargs -0 -I {} mv {} ${MAKEFILE_PATH}build
+
+apply-dependencies:
+	bash ${MAKEFILE_PATH}/scripts/test/install-cert-manager.sh


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds `apply-dependencies` to Makefile to install the cert manager and certificate. Also updates the developer's guide for this change. Tested in dev setup.
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
