### PR TITLE
Inject extra keys to STS client request header

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ func main() {
 	var leaseOnly bool
 	var healthCheckTimeout int
 	var enableWindowsPrefixDelegation bool
+	var region string
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080",
 		"The address the metric endpoint binds to.")
@@ -135,6 +136,7 @@ func main() {
 	flag.BoolVar(&leaseOnly, "lease-only", false, "Controller uses lease only for leader election")
 	flag.BoolVar(&enableWindowsPrefixDelegation, "enable-windows-prefix-delegation", false,
 		"Enable the feature flag for Windows prefix delegation")
+	flag.StringVar(&region, "aws-region", "", "The aws region of the k8s cluster")
 
 	flag.Parse()
 
@@ -256,7 +258,7 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 
-	ec2Wrapper, err := ec2API.NewEC2Wrapper(roleARN, setupLog)
+	ec2Wrapper, err := ec2API.NewEC2Wrapper(roleARN, clusterName, region, setupLog)
 	if err != nil {
 		setupLog.Error(err, "unable to create ec2 wrapper")
 	}

--- a/pkg/aws/ec2/api/wrapper.go
+++ b/pkg/aws/ec2/api/wrapper.go
@@ -15,6 +15,7 @@ package api
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -22,10 +23,12 @@ import (
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/utils"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -37,6 +40,8 @@ import (
 const (
 	MaxRetries = 3
 	AppName    = "amazon-vpc-resource-controller-k8s"
+	SourceKey  = "x-amz-source-arn"
+	AccountKey = "x-amz-source-account"
 )
 
 type EC2Wrapper interface {
@@ -355,7 +360,7 @@ type ec2Wrapper struct {
 
 // NewEC2Wrapper takes the roleARN that will be assumed to make all the EC2 API Calls, if no roleARN
 // is passed then the ec2 client will be initialized with the instance's service role account.
-func NewEC2Wrapper(roleARN string, log logr.Logger) (EC2Wrapper, error) {
+func NewEC2Wrapper(roleARN, clusterName, region string, log logr.Logger) (EC2Wrapper, error) {
 	// Register the metrics
 	prometheusRegister()
 
@@ -379,7 +384,7 @@ func NewEC2Wrapper(roleARN string, log logr.Logger) (EC2Wrapper, error) {
 
 		// Create the user service client with higher QPS, this will be used to make rest of the EC2 API Calls
 		log.Info("Creating USER service client with configured QPS", "QPS", config.UserServiceClientQPS, "Burst", config.UserServiceClientQPSBurst)
-		userServiceClient, err := ec2Wrapper.getClientUsingAssumedRole(*instanceSession.Config.Region, roleARN,
+		userServiceClient, err := ec2Wrapper.getClientUsingAssumedRole(*instanceSession.Config.Region, roleARN, clusterName, region,
 			config.UserServiceClientQPS, config.UserServiceClientQPSBurst)
 		if err != nil {
 			return nil, err
@@ -433,7 +438,7 @@ func (e *ec2Wrapper) getInstanceServiceClient(qps int, burst int, instanceSessio
 		WithRegion(*instanceSession.Config.Region).WithHTTPClient(instanceClient)), nil
 }
 
-func (e *ec2Wrapper) getClientUsingAssumedRole(instanceRegion string, roleARN string, qps int, burst int) (*ec2.EC2, error) {
+func (e *ec2Wrapper) getClientUsingAssumedRole(instanceRegion, roleARN, clusterName, region string, qps, burst int) (*ec2.EC2, error) {
 	var providers []credentials.Provider
 
 	userStsSession := session.Must(session.NewSession())
@@ -456,10 +461,14 @@ func (e *ec2Wrapper) getClientUsingAssumedRole(instanceRegion string, roleARN st
 	}
 
 	roleARN = strings.Trim(roleARN, "\"")
-	// Add the regional sts end point
+
+	sourceAcct, sourceArn, err := utils.GetSourceAcctAndArn(roleARN, region, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
 	regionalProvider := &stscreds.AssumeRoleProvider{
-		Client: sts.New(userStsSession, aws.NewConfig().WithHTTPClient(client).
-			WithEndpoint(regionalSTSEndpoint.URL).WithMaxRetries(MaxRetries)),
+		Client:          e.createSTSClient(userStsSession, client, regionalSTSEndpoint, sourceAcct, sourceArn),
 		RoleARN:         roleARN,
 		Duration:        time.Minute * 60,
 		RoleSessionName: AppName,
@@ -467,6 +476,9 @@ func (e *ec2Wrapper) getClientUsingAssumedRole(instanceRegion string, roleARN st
 	providers = append(providers, regionalProvider)
 
 	// Get the global sts end point
+	// TODO: we should revisit the global sts endpoint and check if we should remove global endpoint
+	// we are not using it since the concern on availability and performance
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html
 	globalSTSEndpoint, err := endpoints.DefaultResolver().
 		EndpointFor("sts", aws.StringValue(userStsSession.Config.Region))
 	if err != nil {
@@ -477,8 +489,7 @@ func (e *ec2Wrapper) getClientUsingAssumedRole(instanceRegion string, roleARN st
 	// If the regional STS endpoint is different than the global STS endpoint then add the global sts endpoint
 	if regionalSTSEndpoint.URL != globalSTSEndpoint.URL {
 		globalProvider := &stscreds.AssumeRoleProvider{
-			Client: sts.New(userStsSession, aws.NewConfig().WithHTTPClient(client).
-				WithEndpoint(regionalSTSEndpoint.URL).WithMaxRetries(MaxRetries)),
+			Client:   e.createSTSClient(userStsSession, client, regionalSTSEndpoint, sourceAcct, sourceArn),
 			RoleARN:  roleARN,
 			Duration: time.Minute * 60,
 		}
@@ -490,6 +501,31 @@ func (e *ec2Wrapper) getClientUsingAssumedRole(instanceRegion string, roleARN st
 
 	return ec2.New(userStsSession, aws.NewConfig().WithHTTPClient(client)), nil
 
+}
+
+func (e *ec2Wrapper) createSTSClient(
+	userStsSession *session.Session,
+	client *http.Client,
+	endpoint endpoints.ResolvedEndpoint,
+	sourceAcct, sourceArn string) *sts.STS {
+
+	stsClient := sts.New(userStsSession, aws.NewConfig().WithHTTPClient(client).
+		WithEndpoint(endpoint.URL).WithMaxRetries(MaxRetries))
+
+	// if region is not specified, we fallback to the default client
+	parsedArn, err := arn.Parse(sourceArn)
+	if err == nil && parsedArn.Region != "" {
+		stsClient.Handlers.Sign.PushFront(func(s *request.Request) {
+			s.ApplyOptions(request.WithSetRequestHeaders(map[string]string{
+				SourceKey:  sourceArn,
+				AccountKey: sourceAcct,
+			}))
+		})
+	} else {
+		e.log.Info("Will use default STS client since unexpected error or cluster ARN", "Errors", err, "ParsedARN", parsedArn)
+	}
+
+	return stsClient
 }
 
 func timeSinceMs(start time.Time) float64 {

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -220,6 +220,8 @@ func GetSourceAcctAndArn(roleARN, region, clusterName string) (string, string, e
 	// arn:aws:iam::account:role/role-name-with-path
 	if !arn.IsARN(roleARN) {
 		return "", "", fmt.Errorf("incorrect ARN format for role %s", roleARN)
+	} else if region == "" {
+		return "", "", nil
 	}
 
 	parsedArn, err := arn.Parse(roleARN)

--- a/pkg/utils/helper_test.go
+++ b/pkg/utils/helper_test.go
@@ -531,3 +531,32 @@ func TestIsNitroInstance_NonNitro(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, isNitro)
 }
+
+// TestGetSourceAcctAndArn tests that generating account ID and cluster ARN
+func TestGetSourceAcctAndArn(t *testing.T) {
+	accountID := "123456789876"
+	clusterName := "test-cluster"
+	region := "us-west-2"
+	clusterARN := "arn:aws:eks:us-west-2:123456789876:cluster/test-cluster"
+
+	roleARN := "arn:aws:iam::123456789876:role/test-cluster"
+
+	// test correct inputs
+	acct, arn, err := GetSourceAcctAndArn(roleARN, region, clusterName)
+	assert.NoError(t, err, "no error should be returned with accurate role arn")
+	assert.Equal(t, accountID, acct, "correct account ID should be retrieved")
+	assert.Equal(t, clusterARN, arn, "correct cluster arn should be retrieved")
+
+	region = "us-gov-west-1"
+	roleARN = "arn:aws-us-gov:iam::123456789876:role/test-cluster"
+	clusterARN = "arn:aws-us-gov:eks:us-gov-west-1:123456789876:cluster/test-cluster"
+	acct, arn, err = GetSourceAcctAndArn(roleARN, region, clusterName)
+	assert.NoError(t, err, "no error should be returned with accurate aws-us-gov partition role arn")
+	assert.Equal(t, accountID, acct, "correct account ID should be retrieved")
+	assert.Equal(t, clusterARN, arn, "correct gov partition cluster arn should be retrieved")
+
+	// test error handling
+	roleARN = "arn:aws:iam::123456789876"
+	_, _, err = GetSourceAcctAndArn(roleARN, region, clusterName)
+	assert.Error(t, err, "error should be returned with inaccurate role arn is given")
+}

--- a/pkg/utils/helper_test.go
+++ b/pkg/utils/helper_test.go
@@ -560,3 +560,17 @@ func TestGetSourceAcctAndArn(t *testing.T) {
 	_, _, err = GetSourceAcctAndArn(roleARN, region, clusterName)
 	assert.Error(t, err, "error should be returned with inaccurate role arn is given")
 }
+
+// TestGetSourceAcctAndArn_NoRegion test empty region
+func TestGetSourceAcctAndArn_NoRegion(t *testing.T) {
+	clusterName := "test-cluster"
+	region := ""
+
+	roleARN := "arn:aws:iam::123456789876:role/test-cluster"
+
+	// test correct inputs
+	acct, arn, err := GetSourceAcctAndArn(roleARN, region, clusterName)
+	assert.NoError(t, err, "no error should be returned with accurate role arn")
+	assert.Equal(t, "", acct, "correct account ID should be retrieved")
+	assert.Equal(t, "", arn, "correct cluster arn should be retrieved")
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We want to add two extra context keys to header.

Tests have been done with extra condition in role and negative tests with incorrect key for account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
