### PR TITLE
handle the placeholder

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,9 +59,10 @@ import (
 )
 
 var (
-	scheme     = runtime.NewScheme()
-	setupLog   = ctrl.Log.WithName("setup")
-	syncPeriod = time.Minute * 30
+	scheme            = runtime.NewScheme()
+	setupLog          = ctrl.Log.WithName("setup")
+	syncPeriod        = time.Minute * 30
+	regionPlaceHolder = "CLUSTER_REGION"
 )
 
 func init() {
@@ -257,6 +258,12 @@ func main() {
 	}
 
 	ctx := ctrl.SetupSignalHandler()
+
+	// if the region wasn't replaced from place holder
+	// we need to make it to empty
+	if region == regionPlaceHolder {
+		region = ""
+	}
 
 	ec2Wrapper, err := ec2API.NewEC2Wrapper(roleARN, clusterName, region, setupLog)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Due to the deployment gaps between systems, we may face the placeholder instead of real region in manifest. In that case, we want to use empty string to create default client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
