### PR TITLE
support version notice to nodes

### DIFF
--- a/main.go
+++ b/main.go
@@ -314,7 +314,7 @@ func main() {
 	nodeManagerWorkers := asyncWorkers.NewDefaultWorkerPool("node async workers",
 		10, 1, ctrl.Log.WithName("node async workers"), ctx)
 	nodeManager, err := manager.NewNodeManager(ctrl.Log.WithName("node manager"), resourceManager,
-		apiWrapper, nodeManagerWorkers, controllerConditions, healthzHandler)
+		apiWrapper, nodeManagerWorkers, controllerConditions, version.GitVersion, healthzHandler)
 
 	if err != nil {
 		ctrl.Log.Error(err, "failed to init node manager")

--- a/pkg/utils/events.go
+++ b/pkg/utils/events.go
@@ -27,6 +27,7 @@ const (
 	NodeTrunkInitiatedReason            = "NodeTrunkInitiated"
 	NodeTrunkFailedInitializationReason = "NodeTrunkFailedInit"
 	EniConfigNameNotFoundReason         = "EniConfigNameNotFound"
+	VersionNotice                       = "ControllerVersionNotice"
 )
 
 func SendNodeEventWithNodeName(client k8s.K8sWrapper, nodeName, reason, msg, eventType string, logger logr.Logger) {


### PR DESCRIPTION
*Issue #, if available:*
#216 
*Description of changes:*
If the node is manageable (SGP or Windows), the controller will send one time event to the node with its version. Although we have mapping between EKS platform version and the controller version in every release note, this event can be a convenient way for customers to check from any client, such as `kubectl describe node`, in some use cases, such as automated workflows.

```
Events:
  Type    Reason                   Age   From                     Message
  ----    ------                   ----  ----                     -------
  Normal  ControllerVersionNotice  22s   vpc-resource-controller  The node is managed by VPC resource controller version v1.3.0
  Normal  NodeTrunkInitiated       21s   vpc-resource-controller  The node has trunk interface initialized successfully
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
