### PR TITLE
Annotate pods with IPv6 details from branch ENI when available

### DIFF
--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/mock_instance.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/mock_instance.go
@@ -212,6 +212,34 @@ func (mr *MockEC2InstanceMockRecorder) SubnetMask() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubnetMask", reflect.TypeOf((*MockEC2Instance)(nil).SubnetMask))
 }
 
+// SubnetV6CidrBlock mocks base method.
+func (m *MockEC2Instance) SubnetV6CidrBlock() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SubnetV6CidrBlock")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// SubnetV6CidrBlock indicates an expected call of SubnetV6CidrBlock.
+func (mr *MockEC2InstanceMockRecorder) SubnetV6CidrBlock() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubnetV6CidrBlock", reflect.TypeOf((*MockEC2Instance)(nil).SubnetV6CidrBlock))
+}
+
+// SubnetV6Mask mocks base method.
+func (m *MockEC2Instance) SubnetV6Mask() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SubnetV6Mask")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// SubnetV6Mask indicates an expected call of SubnetV6Mask.
+func (mr *MockEC2InstanceMockRecorder) SubnetV6Mask() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubnetV6Mask", reflect.TypeOf((*MockEC2Instance)(nil).SubnetV6Mask))
+}
+
 // Type mocks base method.
 func (m *MockEC2Instance) Type() string {
 	m.ctrl.T.Helper()

--- a/pkg/provider/branch/trunk/trunk.go
+++ b/pkg/provider/branch/trunk/trunk.go
@@ -111,12 +111,14 @@ type ENIDetails struct {
 	ID string `json:"eniId"`
 	// MacAdd is the MAC address of the network interface
 	MACAdd string `json:"ifAddress"`
-	// BranchIp is the primary IP of the branch Network interface
+	// IPv4 and/or IPv6 address assigned to the branch Network interface
 	IPV4Addr string `json:"privateIp"`
+	IPV6Addr string `json:"ipv6Addr"`
 	// VlanId is the VlanId of the branch network interface
 	VlanID int `json:"vlanId"`
 	// SubnetCIDR is the CIDR block of the subnet
-	SubnetCIDR string `json:"subnetCidr"`
+	SubnetCIDR   string `json:"subnetCidr"`
+	SubnetV6CIDR string `json:"subnetV6Cidr"`
 	// deletionTimeStamp is the time when the pod was marked deleted.
 	deletionTimeStamp time.Time
 	// deleteRetryCount is the
@@ -358,9 +360,17 @@ func (t *trunkENI) CreateAndAssociateBranchENIs(pod *v1.Pod, securityGroups []st
 			break
 		}
 
+		// Branch ENI can have an IPv4 address, IPv6 address, or both
+		var v4Addr, v6Addr string
+		if nwInterface.PrivateIpAddress != nil {
+			v4Addr = *nwInterface.PrivateIpAddress
+		}
+		if nwInterface.Ipv6Address != nil {
+			v6Addr = *nwInterface.Ipv6Address
+		}
 		newENI := &ENIDetails{ID: *nwInterface.NetworkInterfaceId, MACAdd: *nwInterface.MacAddress,
-			IPV4Addr: *nwInterface.PrivateIpAddress, SubnetCIDR: t.instance.SubnetCidrBlock(), VlanID: vlanID}
-
+			IPV4Addr: v4Addr, IPV6Addr: v6Addr, SubnetCIDR: t.instance.SubnetCidrBlock(),
+			SubnetV6CIDR: t.instance.SubnetV6CidrBlock(), VlanID: vlanID}
 		newENIs = append(newENIs, newENI)
 
 		// Associate Branch to trunk
@@ -521,9 +531,10 @@ func (t *trunkENI) GetBranchInterfacesFromEC2() (eniDetails []*ENIDetails, err e
 	// For each association build the map of branch ENIs with the interface id and the vlan id
 	for _, association := range associations {
 		eniDetail := &ENIDetails{
-			ID:         *association.BranchInterfaceId,
-			VlanID:     int(*association.VlanId),
-			SubnetCIDR: t.instance.SubnetCidrBlock(),
+			ID:           *association.BranchInterfaceId,
+			VlanID:       int(*association.VlanId),
+			SubnetCIDR:   t.instance.SubnetCidrBlock(),
+			SubnetV6CIDR: t.instance.SubnetV6CidrBlock(),
 		}
 		eniDetails = append(eniDetails, eniDetail)
 	}

--- a/scripts/gen_mocks.sh
+++ b/scripts/gen_mocks.sh
@@ -21,7 +21,7 @@ mockgen -destination=../mocks/amazon-vcp-resource-controller-k8s/pkg/node/mock_n
 mockgen -destination=../mocks/amazon-vcp-resource-controller-k8s/pkg/utils/mock_k8shelper.go github.com/aws/amazon-vpc-resource-controller-k8s/pkg/utils SecurityGroupForPodsAPI
 # package pool mocks
 mockgen -destination=../mocks/amazon-vcp-resource-controller-k8s/pkg/pool/mock_pool.go github.com/aws/amazon-vpc-resource-controller-k8s/pkg/pool Pool
-# package resource maocks
+# package resource mocks
 mockgen -destination=../mocks/amazon-vcp-resource-controller-k8s/pkg/resource/mock_resources.go github.com/aws/amazon-vpc-resource-controller-k8s/pkg/resource ResourceManager
-# package condition maocks
+# package condition mocks
 mockgen -destination=../mocks/amazon-vcp-resource-controller-k8s/pkg/condition/mock_condition.go github.com/aws/amazon-vpc-resource-controller-k8s/pkg/condition Conditions


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
In order to support Security Groups for Pods in IPv6 clusters, the VPC Resource Controller must create trunk and branch ENIs with IPv6 addresses assigned. This happens already based on the subnet used in an IPv6 cluster, so VPC Resource Controller's next role is to annotate pods with branch ENI information.

This PR annotates pods with the IPv6 address and CIDR that is configured for the branch ENI, if there is one. The reason that IPv6 fields are added in-addition, instead of in-place is two-fold:
1. VPC Resource Controller must support older VPC CNI versions, so it cannot change existing JSON names.
2. If dual-stack is eventually supported, the pod will need IPv4 and IPv6 fields, so this change facilitates that.

I tested this code against an IPv4 and an IPv6 cluster to verify that it works. In an IPv4 cluster, the annotation looks as follows:
```
k get pod nginx-deployment-6c4d879f6c-7ktc5 -n sg-test -o jsonpath='{.metadata.annotations}'
{"vpc.amazonaws.com/pod-eni":"[{\"eniId\":\"eni-0f11cb35d7d5bf4d6\",\"ifAddress\":\"0e:ee:16:bd:41:31\",\"privateIp\":\"192.168.19.148\",\"ipv6Addr\":\"\",\"vlanId\":1,\"subnetCidr\":\"192.16
8.0.0/19\",\"subnetV6Cidr\":\"\"}]"}
```

In an IPv6 cluster, it looks as follows:
```
{"vpc.amazonaws.com/pod-eni":"[{\"eniId\":\"eni-0f11cb35d7d5bf4d6\",\"ifAddress\":\"0e:ee:16:bd:41:31\",\"privateIp\":\"192.168.19.148\",\"ipv6Addr\":\"2600::\",\"vlanId\":1,\"subnetCidr\":\"192.16
8.0.0/19\",\"subnetV6Cidr\":\"2600::/64\"}]"}
```

There are no backward-incompatible changes here, but I am still awaiting results from integration tests for further coverage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
