### PR TITLE
increase pod ENI workers count

### DIFF
--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -26,7 +26,7 @@ const (
 	WorkQueueDefaultMaxRetries = 5
 
 	// Default Configuration for Pod ENI resource type
-	PodENIDefaultWorker = 7
+	PodENIDefaultWorker = 20
 
 	// Default Configuration for IPv4 resource type
 	IPv4DefaultWorker  = 2


### PR DESCRIPTION
*Issue #, if available:*
Related to #295 

*Description of changes:*
We have seen poor performance through metrics in large clusters when creating pods using security group for pods. Bump up the number of pod ENI workers to improve performance. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
