### PR TITLE
isolate node cleanup from worker queue

### DIFF
--- a/controllers/core/node_controller_test.go
+++ b/controllers/core/node_controller_test.go
@@ -16,6 +16,7 @@ package controllers
 import (
 	"context"
 	"testing"
+	"time"
 
 	mock_condition "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/condition"
 	mock_node "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/node"
@@ -83,8 +84,9 @@ func TestNodeReconciler_Reconcile_AddNode(t *testing.T) {
 	mock := NewNodeMock(ctrl, mockNodeObj)
 
 	mock.Conditions.EXPECT().GetPodDataStoreSyncStatus().Return(true)
-	mock.Manager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, false)
+	mock.Manager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, false).Times(1)
 	mock.Manager.EXPECT().AddNode(mockNodeName).Return(nil)
+	mock.Manager.EXPECT().CheckNodeForLeakedENIs(mockNodeName).Times(0)
 
 	res, err := mock.Reconciler.Reconcile(context.TODO(), reconcileRequest)
 	assert.NoError(t, err)
@@ -98,10 +100,12 @@ func TestNodeReconciler_Reconcile_UpdateNode(t *testing.T) {
 	mock := NewNodeMock(ctrl, mockNodeObj)
 
 	mock.Conditions.EXPECT().GetPodDataStoreSyncStatus().Return(true)
-	mock.Manager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, true)
+	mock.Manager.EXPECT().GetNode(mockNodeName).Return(mock.MockNode, true).Times(1)
 	mock.Manager.EXPECT().UpdateNode(mockNodeName).Return(nil)
+	mock.Manager.EXPECT().CheckNodeForLeakedENIs(mockNodeName).Times(1)
 
 	res, err := mock.Reconciler.Reconcile(context.TODO(), reconcileRequest)
+	time.Sleep(time.Second)
 	assert.NoError(t, err)
 	assert.Equal(t, res, reconcile.Result{})
 }

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/node/manager/mock_manager.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/node/manager/mock_manager.go
@@ -61,6 +61,18 @@ func (mr *MockManagerMockRecorder) AddNode(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNode", reflect.TypeOf((*MockManager)(nil).AddNode), arg0)
 }
 
+// CheckNodeForLeakedENIs mocks base method.
+func (m *MockManager) CheckNodeForLeakedENIs(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "CheckNodeForLeakedENIs", arg0)
+}
+
+// CheckNodeForLeakedENIs indicates an expected call of CheckNodeForLeakedENIs.
+func (mr *MockManagerMockRecorder) CheckNodeForLeakedENIs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckNodeForLeakedENIs", reflect.TypeOf((*MockManager)(nil).CheckNodeForLeakedENIs), arg0)
+}
+
 // DeleteNode mocks base method.
 func (m *MockManager) DeleteNode(arg0 string) error {
 	m.ctrl.T.Helper()

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/node/mock_node.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/node/mock_node.go
@@ -19,6 +19,7 @@ package mock_node
 
 import (
 	reflect "reflect"
+	time "time"
 
 	resource "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/resource"
 	gomock "github.com/golang/mock/gomock"
@@ -61,6 +62,20 @@ func (mr *MockNodeMockRecorder) DeleteResources(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResources", reflect.TypeOf((*MockNode)(nil).DeleteResources), arg0)
 }
 
+// GetNextReconciliationTime mocks base method.
+func (m *MockNode) GetNextReconciliationTime() time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNextReconciliationTime")
+	ret0, _ := ret[0].(time.Time)
+	return ret0
+}
+
+// GetNextReconciliationTime indicates an expected call of GetNextReconciliationTime.
+func (mr *MockNodeMockRecorder) GetNextReconciliationTime() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextReconciliationTime", reflect.TypeOf((*MockNode)(nil).GetNextReconciliationTime))
+}
+
 // GetNodeInstanceID mocks base method.
 func (m *MockNode) GetNodeInstanceID() string {
 	m.ctrl.T.Helper()
@@ -73,6 +88,20 @@ func (m *MockNode) GetNodeInstanceID() string {
 func (mr *MockNodeMockRecorder) GetNodeInstanceID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeInstanceID", reflect.TypeOf((*MockNode)(nil).GetNodeInstanceID))
+}
+
+// GetReconciliationInterval mocks base method.
+func (m *MockNode) GetReconciliationInterval() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetReconciliationInterval")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// GetReconciliationInterval indicates an expected call of GetReconciliationInterval.
+func (mr *MockNodeMockRecorder) GetReconciliationInterval() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReconciliationInterval", reflect.TypeOf((*MockNode)(nil).GetReconciliationInterval))
 }
 
 // HasInstance mocks base method.
@@ -143,6 +172,30 @@ func (m *MockNode) IsReady() bool {
 func (mr *MockNodeMockRecorder) IsReady() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsReady", reflect.TypeOf((*MockNode)(nil).IsReady))
+}
+
+// SetNextReconciliationTime mocks base method.
+func (m *MockNode) SetNextReconciliationTime(arg0 time.Time) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetNextReconciliationTime", arg0)
+}
+
+// SetNextReconciliationTime indicates an expected call of SetNextReconciliationTime.
+func (mr *MockNodeMockRecorder) SetNextReconciliationTime(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNextReconciliationTime", reflect.TypeOf((*MockNode)(nil).SetNextReconciliationTime), arg0)
+}
+
+// SetReconciliationInterval mocks base method.
+func (m *MockNode) SetReconciliationInterval(arg0 time.Duration) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetReconciliationInterval", arg0)
+}
+
+// SetReconciliationInterval indicates an expected call of SetReconciliationInterval.
+func (mr *MockNodeMockRecorder) SetReconciliationInterval(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReconciliationInterval", reflect.TypeOf((*MockNode)(nil).SetReconciliationInterval), arg0)
 }
 
 // UpdateCustomNetworkingSpecs mocks base method.

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/provider/branch/trunk/mock_trunk.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/provider/branch/trunk/mock_trunk.go
@@ -141,10 +141,10 @@ func (mr *MockTrunkENIMockRecorder) PushENIsToFrontOfDeleteQueue(arg0, arg1 inte
 }
 
 // Reconcile mocks base method.
-func (m *MockTrunkENI) Reconcile(arg0 []v1.Pod) error {
+func (m *MockTrunkENI) Reconcile(arg0 []v1.Pod) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Reconcile", arg0)
-	ret0, _ := ret[0].(error)
+	ret0, _ := ret[0].(bool)
 	return ret0
 }
 

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/provider/mock_provider.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/provider/mock_provider.go
@@ -178,6 +178,20 @@ func (mr *MockResourceProviderMockRecorder) ProcessAsyncJob(arg0 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessAsyncJob", reflect.TypeOf((*MockResourceProvider)(nil).ProcessAsyncJob), arg0)
 }
 
+// ReconcileNode mocks base method.
+func (m *MockResourceProvider) ReconcileNode(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileNode", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ReconcileNode indicates an expected call of ReconcileNode.
+func (mr *MockResourceProviderMockRecorder) ReconcileNode(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileNode", reflect.TypeOf((*MockResourceProvider)(nil).ReconcileNode), arg0)
+}
+
 // SubmitAsyncJob mocks base method.
 func (m *MockResourceProvider) SubmitAsyncJob(arg0 interface{}) {
 	m.ctrl.T.Helper()

--- a/pkg/aws/errors/ec2_errors.go
+++ b/pkg/aws/errors/ec2_errors.go
@@ -1,0 +1,6 @@
+package errors
+
+const (
+	NotFoundAssociationID = "InvalidAssociationID.NotFound"
+	NotFoundInterfaceID   = "InvalidNetworkInterfaceID.NotFound"
+)

--- a/pkg/provider/ip/provider.go
+++ b/pkg/provider/ip/provider.go
@@ -508,3 +508,8 @@ func (p *ipv4Provider) check() healthz.Checker {
 func (p *ipv4Provider) GetHealthChecker() healthz.Checker {
 	return p.checker
 }
+
+// ReconcileNode implements provider.ResourceProvider.
+func (*ipv4Provider) ReconcileNode(nodeName string) bool {
+	return false
+}

--- a/pkg/provider/prefix/provider.go
+++ b/pkg/provider/prefix/provider.go
@@ -538,3 +538,8 @@ func (p *ipv4PrefixProvider) check() healthz.Checker {
 func (p *ipv4PrefixProvider) GetHealthChecker() healthz.Checker {
 	return p.checker
 }
+
+// ReconcileNode implements provider.ResourceProvider.
+func (*ipv4PrefixProvider) ReconcileNode(nodeName string) bool {
+	return false
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -44,4 +44,5 @@ type ResourceProvider interface {
 	GetHealthChecker() healthz.Checker
 	// IntrospectSummary allows introspection of resources summary per node
 	IntrospectSummary() interface{}
+	ReconcileNode(nodeName string) bool
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Isolating the node based reconciliation/cleaning from worker queue to an independent one-off goroutine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
