### PR TITLE
Add metrics for leaked ENI cleanup routine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ MAKEFILE_PATH = $(dir $(realpath -s $(firstword $(MAKEFILE_LIST))))
 VERSION ?= $(GIT_VERSION)
 IMAGE ?= $(REPO):$(VERSION)
 BASE_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest.2
-BUILD_IMAGE ?= public.ecr.aws/bitnami/golang:1.20.5
+BUILD_IMAGE ?= public.ecr.aws/bitnami/golang:1.21.3
 GOARCH ?= amd64
 PLATFORM ?= linux/amd64
 

--- a/pkg/aws/ec2/api/eni_cleanup.go
+++ b/pkg/aws/ec2/api/eni_cleanup.go
@@ -141,7 +141,7 @@ func (e *ENICleaner) cleanUpAvailableENIs() {
 						vpcCniLeakedENICleanupCnt.Inc()
 					default:
 						// We will not hit this case as we only filter for above two tag values, adding it for any future use cases
-						e.Log.Info("found leaked NI not owned by VPC-CNI/VPC-RC")
+						e.Log.Info("found available ENI not created by VPC-CNI/VPC-RC")
 					}
 				}
 

--- a/pkg/aws/ec2/api/wrapper.go
+++ b/pkg/aws/ec2/api/wrapper.go
@@ -344,7 +344,10 @@ func prometheusRegister() {
 			ec2describeTrunkInterfaceAssociationAPIErrCnt,
 			ec2modifyNetworkInterfaceAttributeAPICallCnt,
 			ec2modifyNetworkInterfaceAttributeAPIErrCnt,
-			ec2APICallLatencies)
+			ec2APICallLatencies,
+			vpcCniLeakedENICleanupCnt,
+			vpcrcLeakedENICleanupCnt,
+		)
 
 		prometheusRegistered = true
 	}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adding new metrics for number of leaked ENIs created by VPC-RC and VPC-CNI, and cleaned up by the controller.
Also updated the golang build image in Makefile for local builds. 

*Testing:*

Manually created an ENI with tags:
```
kubernetes.io/cluster/vpcrc-release: owned
eks:eni:owner: eks-vpc-resource-controller
```

Restarted controller, waiting for 30 mins and verified the ENI is deleted. 

Metrics output: 
```
# HELP vpc_cni_created_leaked_eni_cleanup_count The number of leaked ENIs created by VPC-CNI that is cleaned up by the controller
# TYPE vpc_cni_created_leaked_eni_cleanup_count counter
vpc_cni_created_leaked_eni_cleanup_count 0
# HELP vpc_rc_created_leaked_eni_cleanup_count The number of leaked ENIs created by VPC-RC that is cleaned up by the controller
# TYPE vpc_rc_created_leaked_eni_cleanup_count counter
vpc_rc_created_leaked_eni_cleanup_count 1

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
