### PR TITLE
Update cooldown period in test

### DIFF
--- a/test/integration/perpodsg/job_test.go
+++ b/test/integration/perpodsg/job_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/branch/cooldown"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/manifest"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/controller"
 	sgpWrapper "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/sgp"
@@ -321,7 +322,7 @@ func VerifyJobNetworkingRemovedOnCompletion(jobs map[string][]*batchV1.Job,
 
 	By("waiting for the ENI to be cooled down and deleted")
 	// Need to account for actual deletion of ENI + Cool down Period
-	time.Sleep(config.CoolDownPeriod * 2)
+	time.Sleep(cooldown.DefaultCoolDownPeriod * 2)
 
 	By("verifying the deleted Pod have their ENI deleted")
 	verify.VerifyPodENIDeletedForAllPods(namespace, podLabelKey, podLabelVal)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The default cooldown for branch ENIs as been updated to 60s now #342 
Update test to fix intermittent failures due to incorrect cooldown period. 

*Testing*
Focus test run
```
Ran 1 of 23 Specs in 649.832 seconds
SUCCESS! — 1 Passed | 0 Failed | 0 Pending | 22 Skipped
PASS | FOCUSED
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
