### PR TITLE
Update docs to add amazon-vpc-cni configmap options for SGPP

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ The controller supports the following modes for IPv4 address management on Windo
 
 Please follow this [guide](https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html) for enabling Windows Support on your EKS cluster.
 
+## Configuring the controller via amazon-vpc-cni configmap
+
+The controller supports various configuration options for managing security groups for pods and Windows nodes which can be set via the EKS-managed configmap `amazon-vpc-cni`. For more details, refer to the security group for pods configuration options [here](docs/sgp/sgp_config_options.md) and Windows IPAM/PD related configuration options [here](docs/windows/prefix_delegation_config_options.md)
+
 ## Troubleshooting
 For troubleshooting issues related to Security group for pods or Windows IPv4 address management, please visit our troubleshooting guide [here](docs/troubleshooting.md).
 

--- a/docs/sgp/sgp_config_options.md
+++ b/docs/sgp/sgp_config_options.md
@@ -1,0 +1,16 @@
+# Configuration options for Security groups for pods
+
+Users are able to configure the controller functionality related to security group for pods by updating the `data` fields in EKS-managed configmap `amazon-vpc-cni`.
+
+* **branch-eni-cooldown**: Cooldown period for the branch ENIs, the period of time to wait before deleting the branch ENI for propagation of iptables rules for the deleted pod. The default cooldown period is 60s, and the minimum value for the cool period is 30s. If user updates configmap to a lower value than 30s, this will be overridden and set to 30s.
+
+Add `branch-eni-cooldown` field in the configmap to set the cooldown period, example:
+```
+apiVersion: v1
+data:
+  branch-eni-cooldown: "60"
+kind: ConfigMap
+metadata:
+  name: amazon-vpc-cni
+  namespace: kube-system
+```

--- a/docs/sgp/workflow.md
+++ b/docs/sgp/workflow.md
@@ -7,10 +7,10 @@ Security Group for Pods is supported only on Nitro Based Instances.
 
 ![New Nitro Based Node Create Event Diagram](../images/sgp-node-create.png)
 
-1. User adds a new supported Node or enables ENI Trunking with existing nodes present in the cluster.
-2. VPC CNI Plugin adds label `vpc.amazonaws.com/has-trunk-attached: false` if the Node has capacity to create 1 additional ENI.
-3. Controller watches for Node events and acts on node with the above label by creating a Trunk ENI. 
-4. Controller updates the resource capacity on this node to `vpc.amazonaws.com/pod-eni: # Supported Branch ENI`.
+1. User adds a new supported node or enables ENI Trunking with existing nodes present in the cluster.
+2. VPC CNI Plugin updates EKS-managed CRD `CNINode <NODE-NAME>` to add feature `SecurityGroupsForPods` if the node has capacity to create 1 additional ENI.
+3. Controller watches for node events and acts on node if the feature is added in `CNINode` CRD by creating a Trunk ENI. 
+4. Controller updates the resource capacity on this node to `vpc.amazonaws.com/pod-eni: # Supported Branch ENI`. Controller also publishes an event on the node upon successful trunk ENI creation. 
 
 ## Creating a Pod using Security Groups
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add `amazon-vpc-cni` configuration options for managing security groups for pods and update README. 
Also updated the SGPP workflow to include `CNINode` updates. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
