### PR TITLE
Increase windows test timeout

### DIFF
--- a/scripts/test/run-canary-test.sh
+++ b/scripts/test/run-canary-test.sh
@@ -110,7 +110,7 @@ function run_canary_tests() {
   # Currently the overall execution time is ~50 minutes and we will reduce it in future
   (CGO_ENABLED=0 ginkgo --no-color --focus="CANARY" $EXTRA_GINKGO_FLAGS -v --timeout 10m $GINKGO_TEST_BUILD_DIR/perpodsg.test -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID)
   if [[ -z "${SKIP_WINDOWS_TEST}" ]]; then
-    (CGO_ENABLED=0 ginkgo --no-color --focus="CANARY" $EXTRA_GINKGO_FLAGS -v --timeout 25m $GINKGO_TEST_BUILD_DIR/windows.test -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID)
+    (CGO_ENABLED=0 ginkgo --no-color --focus="CANARY" $EXTRA_GINKGO_FLAGS -v --timeout 35m $GINKGO_TEST_BUILD_DIR/windows.test -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID)
   else
     echo "skipping Windows tests"
   fi


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Increase the windows test timeout value. Seen cases of all tests passing but after suite timing out due to not enough time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
