### PR TITLE
rename windows flags

### DIFF
--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -92,8 +92,17 @@ func ParseWinPDTargets(log logr.Logger, vpcCniConfigMap *v1.ConfigMap) (warmIPTa
 	}
 
 	warmIPTargetStr, foundWarmIP := vpcCniConfigMap.Data[WarmIPTarget]
+	if !foundWarmIP {
+		warmIPTargetStr, foundWarmIP = vpcCniConfigMap.Data[WinWarmIPTarget]
+	}
 	minIPTargetStr, foundMinIP := vpcCniConfigMap.Data[MinimumIPTarget]
+	if !foundMinIP {
+		minIPTargetStr, foundMinIP = vpcCniConfigMap.Data[WinMinimumIPTarget]
+	}
 	warmPrefixTargetStr, foundWarmPrefix := vpcCniConfigMap.Data[WarmPrefixTarget]
+	if !foundWarmPrefix {
+		warmPrefixTargetStr, foundWarmPrefix = vpcCniConfigMap.Data[WinWarmPrefixTarget]
+	}
 
 	// If no configuration is found, return 0
 	if !foundWarmIP && !foundMinIP && !foundWarmPrefix {

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -73,9 +73,14 @@ const (
 	VpcCniConfigMapName              = "amazon-vpc-cni"
 	EnableWindowsIPAMKey             = "enable-windows-ipam"
 	EnableWindowsPrefixDelegationKey = "enable-windows-prefix-delegation"
-	WarmPrefixTarget                 = "warm-prefix-target"
-	WarmIPTarget                     = "warm-ip-target"
-	MinimumIPTarget                  = "minimum-ip-target"
+	// TODO: we will deprecate the confusing naming of Windows flags eventually
+	WarmPrefixTarget = "warm-prefix-target"
+	WarmIPTarget     = "warm-ip-target"
+	MinimumIPTarget  = "minimum-ip-target"
+	// these windows prefixed flags will be used for Windows support only eventully
+	WinWarmPrefixTarget = "windows-warm-prefix-target"
+	WinWarmIPTarget     = "windows-warm-ip-target"
+	WinMinimumIPTarget  = "windows-minimum-ip-target"
 	// Since LeaderElectionNamespace and VpcCniConfigMapName may be different in the future
 	KubeSystemNamespace            = "kube-system"
 	VpcCNIDaemonSetName            = "aws-node"


### PR DESCRIPTION
*Issue #, if available:*
#370 
*Description of changes:*
Current Windows' flags name can cause confusion for Linux users. We need rename them with prefix `windows` without breaking current users' setting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
