### PR TITLE
fix: paginate DescribeNetworkInterfaces with deep filters

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,6 +107,7 @@ func main() {
 	var healthCheckTimeout int
 	var enableWindowsPrefixDelegation bool
 	var region string
+	var vpcID string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080",
 		"The address the metric endpoint binds to.")
@@ -141,6 +142,7 @@ func main() {
 	flag.BoolVar(&enableWindowsPrefixDelegation, "enable-windows-prefix-delegation", false,
 		"Enable the feature flag for Windows prefix delegation")
 	flag.StringVar(&region, "aws-region", "", "The aws region of the k8s cluster")
+	flag.StringVar(&vpcID, "vpc-id", "", "The vpc-id where EKS cluster is deployed")
 
 	flag.Parse()
 
@@ -180,6 +182,11 @@ func main() {
 
 	if clusterName == "" {
 		setupLog.Error(fmt.Errorf("cluster-name is a required parameter"), "unable to start the controller")
+		os.Exit(1)
+	}
+
+	if vpcID == "" {
+		setupLog.Error(fmt.Errorf("vpc-id is a required parameter"), "unable to start the controller")
 		os.Exit(1)
 	}
 
@@ -336,6 +343,7 @@ func main() {
 		EC2Wrapper:  ec2Wrapper,
 		ClusterName: clusterName,
 		Log:         ctrl.Log.WithName("eni cleaner"),
+		VPCID:       vpcID,
 	}).SetupWithManager(ctx, mgr, healthzHandler); err != nil {
 		setupLog.Error(err, "unable to start eni cleaner")
 		os.Exit(1)

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/api/mock_ec2_apihelper.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/api/mock_ec2_apihelper.go
@@ -196,18 +196,18 @@ func (mr *MockEC2APIHelperMockRecorder) DetachNetworkInterfaceFromInstance(arg0 
 }
 
 // GetBranchNetworkInterface mocks base method.
-func (m *MockEC2APIHelper) GetBranchNetworkInterface(arg0 *string) ([]*ec2.NetworkInterface, error) {
+func (m *MockEC2APIHelper) GetBranchNetworkInterface(arg0, arg1 *string) ([]*ec2.NetworkInterface, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBranchNetworkInterface", arg0)
+	ret := m.ctrl.Call(m, "GetBranchNetworkInterface", arg0, arg1)
 	ret0, _ := ret[0].([]*ec2.NetworkInterface)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBranchNetworkInterface indicates an expected call of GetBranchNetworkInterface.
-func (mr *MockEC2APIHelperMockRecorder) GetBranchNetworkInterface(arg0 interface{}) *gomock.Call {
+func (mr *MockEC2APIHelperMockRecorder) GetBranchNetworkInterface(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBranchNetworkInterface", reflect.TypeOf((*MockEC2APIHelper)(nil).GetBranchNetworkInterface), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBranchNetworkInterface", reflect.TypeOf((*MockEC2APIHelper)(nil).GetBranchNetworkInterface), arg0, arg1)
 }
 
 // GetInstanceDetails mocks base method.

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/api/mock_ec2_wrapper.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/api/mock_ec2_wrapper.go
@@ -182,6 +182,21 @@ func (mr *MockEC2WrapperMockRecorder) DescribeNetworkInterfaces(arg0 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfaces", reflect.TypeOf((*MockEC2Wrapper)(nil).DescribeNetworkInterfaces), arg0)
 }
 
+// DescribeNetworkInterfacesPages mocks base method.
+func (m *MockEC2Wrapper) DescribeNetworkInterfacesPages(arg0 *ec2.DescribeNetworkInterfacesInput) ([]*ec2.NetworkInterface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeNetworkInterfacesPages", arg0)
+	ret0, _ := ret[0].([]*ec2.NetworkInterface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeNetworkInterfacesPages indicates an expected call of DescribeNetworkInterfacesPages.
+func (mr *MockEC2WrapperMockRecorder) DescribeNetworkInterfacesPages(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacesPages", reflect.TypeOf((*MockEC2Wrapper)(nil).DescribeNetworkInterfacesPages), arg0)
+}
+
 // DescribeSubnets mocks base method.
 func (m *MockEC2Wrapper) DescribeSubnets(arg0 *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/aws/ec2/api/eni_cleanup.go
+++ b/pkg/aws/ec2/api/eni_cleanup.go
@@ -34,6 +34,7 @@ type ENICleaner struct {
 	EC2Wrapper  EC2Wrapper
 	ClusterName string
 	Log         logr.Logger
+	VPCID       string
 
 	availableENIs     map[string]struct{}
 	shutdown          bool
@@ -116,61 +117,57 @@ func (e *ENICleaner) cleanUpAvailableENIs() {
 				Values: aws.StringSlice([]string{config.NetworkInterfaceOwnerTagValue,
 					config.NetworkInterfaceOwnerVPCCNITagValue}),
 			},
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []*string{aws.String(e.VPCID)},
+			},
 		},
 	}
 
 	availableENIs := make(map[string]struct{})
 
-	for {
-		describeNetworkInterfaceOp, err := e.EC2Wrapper.DescribeNetworkInterfaces(describeNetworkInterfaceIp)
-		if err != nil {
-			e.Log.Error(err, "failed to describe network interfaces, will retry")
-			return
-		}
+	networkInterfaces, err := e.EC2Wrapper.DescribeNetworkInterfacesPages(describeNetworkInterfaceIp)
+	if err != nil {
+		e.Log.Error(err, "failed to describe network interfaces, will retry")
+		return
+	}
 
-		for _, networkInterface := range describeNetworkInterfaceOp.NetworkInterfaces {
-			if _, exists := e.availableENIs[*networkInterface.NetworkInterfaceId]; exists {
-				// Increment promethues metrics for number of leaked ENIs cleaned up
-				if tagIdx := slices.IndexFunc(networkInterface.TagSet, func(tag *ec2.Tag) bool {
-					return *tag.Key == config.NetworkInterfaceOwnerTagKey
-				}); tagIdx != -1 {
-					switch *networkInterface.TagSet[tagIdx].Value {
-					case config.NetworkInterfaceOwnerTagValue:
-						vpcrcLeakedENICleanupCnt.Inc()
-					case config.NetworkInterfaceOwnerVPCCNITagValue:
-						vpcCniLeakedENICleanupCnt.Inc()
-					default:
-						// We will not hit this case as we only filter for above two tag values, adding it for any future use cases
-						e.Log.Info("found available ENI not created by VPC-CNI/VPC-RC")
-					}
+	for _, networkInterface := range networkInterfaces {
+		if _, exists := e.availableENIs[*networkInterface.NetworkInterfaceId]; exists {
+			// Increment promethues metrics for number of leaked ENIs cleaned up
+			if tagIdx := slices.IndexFunc(networkInterface.TagSet, func(tag *ec2.Tag) bool {
+				return *tag.Key == config.NetworkInterfaceOwnerTagKey
+			}); tagIdx != -1 {
+				switch *networkInterface.TagSet[tagIdx].Value {
+				case config.NetworkInterfaceOwnerTagValue:
+					vpcrcLeakedENICleanupCnt.Inc()
+				case config.NetworkInterfaceOwnerVPCCNITagValue:
+					vpcCniLeakedENICleanupCnt.Inc()
+				default:
+					// We will not hit this case as we only filter for above two tag values, adding it for any future use cases
+					e.Log.Info("found available ENI not created by VPC-CNI/VPC-RC")
 				}
-
-				// The ENI in available state has been sitting for at least the eni clean up interval and it should
-				// be removed
-				_, err := e.EC2Wrapper.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
-					NetworkInterfaceId: networkInterface.NetworkInterfaceId,
-				})
-				if err != nil {
-					// Log and continue, if the ENI is still present it will be cleaned up in next 2 cycles
-					e.Log.Error(err, "failed to delete the dangling network interface",
-						"id", *networkInterface.NetworkInterfaceId)
-					continue
-				}
-				e.Log.Info("deleted dangling ENI successfully",
-					"eni id", networkInterface.NetworkInterfaceId)
-			} else {
-				// Seeing the ENI for the first time, add it to the new list of available network interfaces
-				availableENIs[*networkInterface.NetworkInterfaceId] = struct{}{}
-				e.Log.V(1).Info("adding eni to to the map of available ENIs, will be removed if present in "+
-					"next run too", "id", *networkInterface.NetworkInterfaceId)
 			}
-		}
 
-		if describeNetworkInterfaceOp.NextToken == nil {
-			break
+			// The ENI in available state has been sitting for at least the eni clean up interval and it should
+			// be removed
+			_, err := e.EC2Wrapper.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
+				NetworkInterfaceId: networkInterface.NetworkInterfaceId,
+			})
+			if err != nil {
+				// Log and continue, if the ENI is still present it will be cleaned up in next 2 cycles
+				e.Log.Error(err, "failed to delete the dangling network interface",
+					"id", *networkInterface.NetworkInterfaceId)
+				continue
+			}
+			e.Log.Info("deleted dangling ENI successfully",
+				"eni id", networkInterface.NetworkInterfaceId)
+		} else {
+			// Seeing the ENI for the first time, add it to the new list of available network interfaces
+			availableENIs[*networkInterface.NetworkInterfaceId] = struct{}{}
+			e.Log.V(1).Info("adding eni to to the map of available ENIs, will be removed if present in "+
+				"next run too", "id", *networkInterface.NetworkInterfaceId)
 		}
-
-		describeNetworkInterfaceIp.NextToken = describeNetworkInterfaceOp.NextToken
 	}
 
 	// Set the available ENIs to the list of ENIs seen in the current cycle

--- a/pkg/aws/ec2/api/helper.go
+++ b/pkg/aws/ec2/api/helper.go
@@ -79,7 +79,7 @@ type EC2APIHelper interface {
 		ipResourceCount *config.IPResourceCount, interfaceType *string) (*ec2.NetworkInterface, error)
 	DeleteNetworkInterface(interfaceId *string) error
 	GetSubnet(subnetId *string) (*ec2.Subnet, error)
-	GetBranchNetworkInterface(trunkID *string) ([]*ec2.NetworkInterface, error)
+	GetBranchNetworkInterface(trunkID *string, subnetID *string) ([]*ec2.NetworkInterface, error)
 	GetInstanceNetworkInterface(instanceId *string) ([]*ec2.InstanceNetworkInterface, error)
 	DescribeNetworkInterfaces(nwInterfaceIds []*string) ([]*ec2.NetworkInterface, error)
 	DescribeTrunkInterfaceAssociation(trunkInterfaceId *string) ([]*ec2.TrunkInterfaceAssociation, error)
@@ -562,43 +562,20 @@ func (h *ec2APIHelper) UnassignIPv4Resources(eniID string, resourceType config.R
 	return err
 }
 
-func (h *ec2APIHelper) GetBranchNetworkInterface(trunkID *string) ([]*ec2.NetworkInterface, error) {
-	filters := []*ec2.Filter{{
-		Name:   aws.String("tag:" + config.TrunkENIIDTag),
-		Values: []*string{trunkID},
-	}}
-
-	describeNetworkInterfacesInput := &ec2.DescribeNetworkInterfacesInput{Filters: filters}
-	var nwInterfaces []*ec2.NetworkInterface
-	for {
-		describeNetworkInterfaceOutput, err := h.ec2Wrapper.DescribeNetworkInterfaces(describeNetworkInterfacesInput)
-		if err != nil {
-			return nil, err
-		}
-
-		if describeNetworkInterfaceOutput == nil || describeNetworkInterfaceOutput.NetworkInterfaces == nil ||
-			len(describeNetworkInterfaceOutput.NetworkInterfaces) == 0 {
-			// No more interface associated with the trunk, return the result
-			break
-		}
-
-		// One or more interface associated with the trunk, return the result
-		for _, nwInterface := range describeNetworkInterfaceOutput.NetworkInterfaces {
-			// Only attach the required details to avoid consuming extra memory
-			nwInterfaces = append(nwInterfaces, &ec2.NetworkInterface{
-				NetworkInterfaceId: nwInterface.NetworkInterfaceId,
-				TagSet:             nwInterface.TagSet,
-			})
-		}
-
-		if describeNetworkInterfaceOutput.NextToken == nil {
-			break
-		}
-
-		describeNetworkInterfacesInput.NextToken = describeNetworkInterfaceOutput.NextToken
+func (h *ec2APIHelper) GetBranchNetworkInterface(trunkID *string, subnetID *string) ([]*ec2.NetworkInterface, error) {
+	filters := []*ec2.Filter{
+		{
+			Name:   aws.String("tag:" + config.TrunkENIIDTag),
+			Values: []*string{trunkID},
+		},
+		{
+			Name:   aws.String("subnet-id"),
+			Values: []*string{subnetID},
+		},
 	}
 
-	return nwInterfaces, nil
+	describeNetworkInterfacesInput := &ec2.DescribeNetworkInterfacesInput{Filters: filters}
+	return h.ec2Wrapper.DescribeNetworkInterfacesPages(describeNetworkInterfacesInput)
 }
 
 // DetachAndDeleteNetworkInterface detaches the network interface first and then deletes it

--- a/pkg/aws/ec2/api/helper_test.go
+++ b/pkg/aws/ec2/api/helper_test.go
@@ -179,27 +179,20 @@ var (
 
 	tokenID = "token"
 
-	describeTrunkInterfaceInput1 = &ec2.DescribeNetworkInterfacesInput{
-		Filters: []*ec2.Filter{{
-			Name:   aws.String("tag:" + config.TrunkENIIDTag),
-			Values: []*string{&trunkInterfaceId},
-		}},
-	}
-	describeTrunkInterfaceInput2 = &ec2.DescribeNetworkInterfacesInput{
-		Filters: []*ec2.Filter{{
-			Name:   aws.String("tag:" + config.TrunkENIIDTag),
-			Values: []*string{&trunkInterfaceId},
-		}},
-		NextToken: &tokenID,
+	describeTrunkInterfaceInput = &ec2.DescribeNetworkInterfacesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag:" + config.TrunkENIIDTag),
+				Values: []*string{&trunkInterfaceId},
+			},
+			{
+				Name:   aws.String("subnet-id"),
+				Values: aws.StringSlice([]string{subnetId}),
+			},
+		},
 	}
 
-	describeTrunkInterfaceOutput1 = &ec2.DescribeNetworkInterfacesOutput{
-		NetworkInterfaces: []*ec2.NetworkInterface{&networkInterface1},
-		NextToken:         &tokenID,
-	}
-	describeTrunkInterfaceOutput2 = &ec2.DescribeNetworkInterfacesOutput{
-		NetworkInterfaces: []*ec2.NetworkInterface{&networkInterface2},
-	}
+	describeTrunkInterfaceOutput = []*ec2.NetworkInterface{&networkInterface1, &networkInterface2}
 
 	describeTrunkInterfaceAssociationsInput = &ec2.DescribeTrunkInterfaceAssociationsInput{
 		Filters: []*ec2.Filter{{
@@ -1178,16 +1171,15 @@ func TestEC2APIHelper_AssignIPv4ResourcesAndWaitTillReady_TypeIPv4Prefix_Describ
 }
 
 // TestEc2APIHelper_GetBranchNetworkInterface_PaginatedResults returns the branch interface when paginated results is returned
-func TestEc2APIHelper_GetBranchNetworkInterface_PaginatedResults(t *testing.T) {
+func TestEc2APIHelper_GetBranchNetworkInterface(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	ec2ApiHelper, mockWrapper := getMockWrapper(ctrl)
 
-	mockWrapper.EXPECT().DescribeNetworkInterfaces(describeTrunkInterfaceInput1).Return(describeTrunkInterfaceOutput1, nil)
-	mockWrapper.EXPECT().DescribeNetworkInterfaces(describeTrunkInterfaceInput2).Return(describeTrunkInterfaceOutput2, nil)
+	mockWrapper.EXPECT().DescribeNetworkInterfacesPages(describeTrunkInterfaceInput).Return(describeTrunkInterfaceOutput, nil)
 
-	branchInterfaces, err := ec2ApiHelper.GetBranchNetworkInterface(&trunkInterfaceId)
+	branchInterfaces, err := ec2ApiHelper.GetBranchNetworkInterface(&trunkInterfaceId, &subnetId)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []*ec2.NetworkInterface{&networkInterface1, &networkInterface2}, branchInterfaces)
 }

--- a/pkg/aws/ec2/api/wrapper.go
+++ b/pkg/aws/ec2/api/wrapper.go
@@ -360,8 +360,9 @@ func prometheusRegister() {
 			ec2modifyNetworkInterfaceAttributeAPICallCnt,
 			ec2modifyNetworkInterfaceAttributeAPIErrCnt,
 			ec2APICallLatencies,
-			vpcCniLeakedENICleanupCnt,
-			vpcrcLeakedENICleanupCnt,
+			vpccniAvailableENICnt,
+			vpcrcAvailableENICnt,
+			leakedENICnt,
 			ec2DescribeNetworkInterfacesPagesAPICallCnt,
 			ec2DescribeNetworkInterfacesPagesAPIErrCnt,
 		)
@@ -661,7 +662,7 @@ func (e *ec2Wrapper) DescribeNetworkInterfaces(input *ec2.DescribeNetworkInterfa
 // Only required fields, network interface ID and tag set, is populated to avoid consuming extra memory
 func (e *ec2Wrapper) DescribeNetworkInterfacesPages(input *ec2.DescribeNetworkInterfacesInput) ([]*ec2.NetworkInterface, error) {
 	var networkInterfaces []*ec2.NetworkInterface
-	input.MaxResults = aws.Int64(1000)
+	input.MaxResults = aws.Int64(config.DescribeNetworkInterfacesMaxResults)
 
 	start := time.Now()
 	if err := e.userServiceClient.DescribeNetworkInterfacesPages(input, func(output *ec2.DescribeNetworkInterfacesOutput, _ bool) bool {

--- a/pkg/aws/ec2/api/wrapper.go
+++ b/pkg/aws/ec2/api/wrapper.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/utils"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -52,6 +53,7 @@ type EC2Wrapper interface {
 	AssignPrivateIPAddresses(input *ec2.AssignPrivateIpAddressesInput) (*ec2.AssignPrivateIpAddressesOutput, error)
 	UnassignPrivateIPAddresses(input *ec2.UnassignPrivateIpAddressesInput) (*ec2.UnassignPrivateIpAddressesOutput, error)
 	DescribeNetworkInterfaces(input *ec2.DescribeNetworkInterfacesInput) (*ec2.DescribeNetworkInterfacesOutput, error)
+	DescribeNetworkInterfacesPages(input *ec2.DescribeNetworkInterfacesInput) ([]*ec2.NetworkInterface, error)
 	CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error)
 	DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
 	AssociateTrunkInterface(input *ec2.AssociateTrunkInterfaceInput) (*ec2.AssociateTrunkInterfaceOutput, error)
@@ -307,6 +309,19 @@ var (
 		},
 	)
 
+	ec2DescribeNetworkInterfacesPagesAPICallCnt = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "ec2_describe_network_interfaces_pages_api_call_count",
+			Help: "The number of calls made to describe network interfaces (paginated)",
+		},
+	)
+	ec2DescribeNetworkInterfacesPagesAPIErrCnt = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "ec2_describe_network_interfaces_pages_api_err_count",
+			Help: "The number of errors encountered while making call to describe network interfaces (paginated)",
+		},
+	)
+
 	prometheusRegistered = false
 )
 
@@ -347,6 +362,8 @@ func prometheusRegister() {
 			ec2APICallLatencies,
 			vpcCniLeakedENICleanupCnt,
 			vpcrcLeakedENICleanupCnt,
+			ec2DescribeNetworkInterfacesPagesAPICallCnt,
+			ec2DescribeNetworkInterfacesPagesAPIErrCnt,
 		)
 
 		prometheusRegistered = true
@@ -637,6 +654,38 @@ func (e *ec2Wrapper) DescribeNetworkInterfaces(input *ec2.DescribeNetworkInterfa
 	}
 
 	return describeNetworkInterfacesOutput, err
+}
+
+// DescribeNetworkInterfacesPages returns network interfaces that match the filters specified in the input with MaxResult set to 1000(max value)
+// This API is used during periodic ENI cleanup routine and trunk initialization to list all network interfaces that match the given filters (vpc-id or subnet-id, and tag)
+// Only required fields, network interface ID and tag set, is populated to avoid consuming extra memory
+func (e *ec2Wrapper) DescribeNetworkInterfacesPages(input *ec2.DescribeNetworkInterfacesInput) ([]*ec2.NetworkInterface, error) {
+	var networkInterfaces []*ec2.NetworkInterface
+	input.MaxResults = aws.Int64(1000)
+
+	start := time.Now()
+	if err := e.userServiceClient.DescribeNetworkInterfacesPages(input, func(output *ec2.DescribeNetworkInterfacesOutput, _ bool) bool {
+		ec2APICallCnt.Inc()
+		ec2DescribeNetworkInterfacesPagesAPICallCnt.Inc()
+		//Currently only network interface ID and the tag set is require, only add required details to avoid consuming extra memory
+		for _, nwInterface := range output.NetworkInterfaces {
+			networkInterfaces = append(networkInterfaces, &ec2.NetworkInterface{
+				NetworkInterfaceId: nwInterface.NetworkInterfaceId,
+				TagSet:             nwInterface.TagSet,
+			})
+		}
+		// Add jitter to avoid EC2 API throttling in the account
+		time.Sleep(wait.Jitter(500*time.Millisecond, 0.5))
+		return true
+
+	}); err != nil {
+		ec2APIErrCnt.Inc()
+		ec2DescribeNetworkInterfacesPagesAPIErrCnt.Inc()
+		return nil, err
+	}
+	ec2APICallLatencies.WithLabelValues("describe_network_interfaces_pages").Observe(timeSinceMs(start))
+
+	return networkInterfaces, nil
 }
 
 func (e *ec2Wrapper) AssignPrivateIPAddresses(input *ec2.AssignPrivateIpAddressesInput) (*ec2.AssignPrivateIpAddressesOutput, error) {

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -86,6 +86,8 @@ const (
 	VpcCNIDaemonSetName            = "aws-node"
 	OldVPCControllerDeploymentName = "vpc-resource-controller"
 	BranchENICooldownPeriodKey     = "branch-eni-cooldown"
+	// DescribeNetworkInterfacesMaxResults defines the max number of requests to return for DescribeNetworkInterfaces API call
+	DescribeNetworkInterfacesMaxResults = int64(1000)
 )
 
 type ResourceType string

--- a/pkg/provider/branch/trunk/trunk.go
+++ b/pkg/provider/branch/trunk/trunk.go
@@ -232,7 +232,7 @@ func (t *trunkENI) InitTrunk(instance ec2.EC2Instance, podList []v1.Pod) error {
 	}
 
 	// Get the list of branch ENIs
-	branchInterfaces, err := t.ec2ApiHelper.GetBranchNetworkInterface(&t.trunkENIId)
+	branchInterfaces, err := t.ec2ApiHelper.GetBranchNetworkInterface(&t.trunkENIId, aws.String(t.instance.SubnetID()))
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/branch/trunk/trunk_test.go
+++ b/pkg/provider/branch/trunk/trunk_test.go
@@ -647,7 +647,8 @@ func TestTrunkENI_InitTrunk(t *testing.T) {
 				f.mockInstance.EXPECT().InstanceID().Return(InstanceId)
 				f.mockEC2APIHelper.EXPECT().GetInstanceNetworkInterface(&InstanceId).Return(instanceNwInterfaces, nil)
 				f.mockEC2APIHelper.EXPECT().WaitForNetworkInterfaceStatusChange(&trunkId, awsEc2.AttachmentStatusAttached).Return(nil)
-				f.mockEC2APIHelper.EXPECT().GetBranchNetworkInterface(&trunkId).Return(branchInterfaces, nil)
+				f.mockInstance.EXPECT().SubnetID().Return(SubnetId)
+				f.mockEC2APIHelper.EXPECT().GetBranchNetworkInterface(&trunkId, &SubnetId).Return(branchInterfaces, nil)
 			},
 			args:    args{instance: FakeInstance, podList: []v1.Pod{*MockPod1, *MockPod2}},
 			wantErr: false,
@@ -675,7 +676,8 @@ func TestTrunkENI_InitTrunk(t *testing.T) {
 				f.mockInstance.EXPECT().InstanceID().Return(InstanceId)
 				f.mockEC2APIHelper.EXPECT().GetInstanceNetworkInterface(&InstanceId).Return(instanceNwInterfaces, nil)
 				f.mockEC2APIHelper.EXPECT().WaitForNetworkInterfaceStatusChange(&trunkId, awsEc2.AttachmentStatusAttached).Return(nil)
-				f.mockEC2APIHelper.EXPECT().GetBranchNetworkInterface(&trunkId).Return(branchInterfaces, nil)
+				f.mockInstance.EXPECT().SubnetID().Return(SubnetId)
+				f.mockEC2APIHelper.EXPECT().GetBranchNetworkInterface(&trunkId, &SubnetId).Return(branchInterfaces, nil)
 			},
 			args:    args{instance: FakeInstance, podList: []v1.Pod{*MockPod2}},
 			wantErr: false,


### PR DESCRIPTION
*Issue #, if available:*
Fixes #188 
*Description of changes:*
Paginate DescribeNetworkInterfaces API call by specifying a deep filter like vpc-id and subnet-id as unpaginated API call causes the operation to fail when there is a large number of network interfaces. 
https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-network-interfaces.html

Unpaginated calls were used in the periodic leaked ENI cleanup routine and during trunk initialization to fetch all branch ENIs on the node. These are now paginated to use vpc-id and subnet-id respectively, and also added jitter to avoid EC2 API throttling and increased call volume to address earlier issue with pagination.

Testing:
Security group for pods test succeeded:
```
Ran 19 of 23 Specs in 975.331 seconds
SUCCESS! -- 19 Passed | 0 Failed | 0 Pending | 4 Skipped
PASS

Ginkgo ran 1 suite in 16m18.325964387s
Test Suite Passed
```

Manual tests:
* Node scale up/down
* Pods using security groups scale up/down
* Created 500+ ENIs in same VPC to confirm call volume has not increased drastically
```
ec2_describe_network_interfaces_pages_api_call_count 4
ec2_describe_network_interfaces_pages_api_err_count 0
```
* Soak test with 100 nodes and scaling up pods using to security group from 0 to 1000 every 15mins. Did not observe a drastic increase in the API call volume. 

Release notes:

```
Paginate DescribeNetworkInterfaces API call
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
