### PR TITLE
fix:update cluster tag name in CNINode

### DIFF
--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -68,6 +68,7 @@ const (
 	NetworkInterfaceOwnerTagValue       = "eks-vpc-resource-controller"
 	NetworkInterfaceOwnerVPCCNITagValue = "amazon-vpc-cni"
 	NetworkInterfaceNodenameKey         = "node.k8s.amazonaws.com/nodename"
+	CNINodeClusterNameKey               = "cluster.k8s.amazonaws.com/name"
 )
 
 const (

--- a/pkg/k8s/wrapper.go
+++ b/pkg/k8s/wrapper.go
@@ -253,7 +253,7 @@ func (k *k8sWrapper) CreateCNINode(node *v1.Node, clusterName string) error {
 		},
 		Spec: rcv1alpha1.CNINodeSpec{
 			Tags: map[string]string{
-				fmt.Sprintf(config.ClusterNameTagKeyFormat, clusterName): config.ClusterNameTagValue,
+				fmt.Sprintf(config.CNINodeClusterNameKey): clusterName,
 			},
 		},
 	}


### PR DESCRIPTION
*Issue #, if available:*
NA
*Description of changes:*

Update the cluster tag key to be deterministic in the CNINode CRD for use in other components like VPC-CNI where cluster name might be unknown.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
