### PR TITLE
add node os label in CNINode and run finalizer routine for linux only

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.16.1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/protobuf v1.32.0 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=
-google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -10,7 +10,7 @@ main() {
 }
 
 tools() {
-    go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+    go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230216140739-c98506dc3b8e
     go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.0
     go install github.com/google/ko@latest
 

--- a/pkg/k8s/finalizer.go
+++ b/pkg/k8s/finalizer.go
@@ -49,6 +49,7 @@ func (m *defaultFinalizerManager) AddFinalizers(ctx context.Context, obj client.
 		needsUpdate := false
 		for _, finalizer := range finalizers {
 			if !controllerutil.ContainsFinalizer(obj, finalizer) {
+				m.log.Info("adding finalizer", "object", obj.GetObjectKind().GroupVersionKind().Kind, "name", obj.GetName(), "finalizer", finalizer)
 				controllerutil.AddFinalizer(obj, finalizer)
 				needsUpdate = true
 			}
@@ -70,6 +71,7 @@ func (m *defaultFinalizerManager) RemoveFinalizers(ctx context.Context, obj clie
 		needsUpdate := false
 		for _, finalizer := range finalizers {
 			if controllerutil.ContainsFinalizer(obj, finalizer) {
+				m.log.Info("removing finalizer", "object", obj.GetObjectKind().GroupVersionKind().Kind, "name", obj.GetName(), "finalizer", finalizer)
 				controllerutil.RemoveFinalizer(obj, finalizer)
 				needsUpdate = true
 			}

--- a/pkg/k8s/wrapper_test.go
+++ b/pkg/k8s/wrapper_test.go
@@ -46,6 +46,9 @@ var (
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
+			Labels: map[string]string{
+				config.NodeLabelOS: config.OSLinux,
+			},
 		},
 		Spec: v1.NodeSpec{},
 		Status: v1.NodeStatus{

--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -406,7 +406,7 @@ func (b *branchENIProvider) DeleteBranchUsedByPods(nodeName string, UID string) 
 		// trunk cache is local map with lock. it shouldn't return not found error if trunk exists
 		// if the node's trunk is not found, we shouldn't retry
 		// worst case we rely on node based clean up goroutines to clean branch ENIs up
-		b.log.Info("failed to find trunk ENI for the node %s", nodeName)
+		b.log.Info("failed to find trunk ENI for the node", "nodeName", nodeName)
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
1. Adding node OS label to CNINodes to run the finalizer routine for Linux nodes only. 
2. Added retry to get CNINode during node reconcile: When CNINode is deleted, node update is triggered and since CNINode is not immediately found, the controller updates the node to be unmanaged and adds node to delete queue and removes the trunk, this is a regression bug. CNINode is shortly re-created by the CNINode controller, so added retry with backoff to GetCNINode which prevents node being unmanaged. 

Tests:
1. CNINode creation: Validated new CNINodes are created with required fields
3. Node deletion: Validated finalizer routine is only run for Linux nodes
4. Reconcile tests: Edit CNINode to remove required fields and validated it is updated correctly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
