### PR TITLE
pin envtest version due to an upstream bug

### DIFF
--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -10,7 +10,7 @@ main() {
 }
 
 tools() {
-    go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+    go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230216140739-c98506dc3b8e
     go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.0
     go install github.com/google/ko@latest
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We have to pin the envtest version before [the upstream issue](https://github.com/kubernetes-sigs/controller-runtime/issues/2720#issuecomment-2016461180) is fixed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
