### PR TITLE
add CNINode integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/go-cmp v0.6.0
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -17,6 +17,7 @@ import (
 	eniConfig "github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	cninode "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1alpha1"
 	sgp "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/aws/autoscaling"
 	ec2Manager "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/aws/ec2"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/configmap"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/controller"
@@ -42,21 +43,22 @@ import (
 )
 
 type Framework struct {
-	Options           Options
-	K8sClient         client.Client
-	ec2Client         *ec2.EC2
-	DeploymentManager deployment.Manager
-	PodManager        pod.Manager
-	EC2Manager        *ec2Manager.Manager
-	SAManager         serviceaccount.Manager
-	NSManager         namespace.Manager
-	SGPManager        *sgpManager.Manager
-	SVCManager        service.Manager
-	JobManager        jobs.Manager
-	NodeManager       node.Manager
-	ControllerManager controller.Manager
-	RBACManager       rbac.Manager
-	ConfigMapManager  configmap.Manager
+	Options            Options
+	K8sClient          client.Client
+	ec2Client          *ec2.EC2
+	DeploymentManager  deployment.Manager
+	PodManager         pod.Manager
+	EC2Manager         *ec2Manager.Manager
+	SAManager          serviceaccount.Manager
+	NSManager          namespace.Manager
+	SGPManager         *sgpManager.Manager
+	SVCManager         service.Manager
+	JobManager         jobs.Manager
+	NodeManager        node.Manager
+	ControllerManager  controller.Manager
+	RBACManager        rbac.Manager
+	ConfigMapManager   configmap.Manager
+	AutoScalingManager autoscaling.Manager
 }
 
 func New(options Options) *Framework {
@@ -91,20 +93,21 @@ func New(options Options) *Framework {
 	ec2 := ec2.New(sess, &aws.Config{Region: aws.String(options.AWSRegion)})
 
 	return &Framework{
-		K8sClient:         k8sClient,
-		ec2Client:         ec2,
-		PodManager:        pod.NewManager(k8sClient, k8sSchema, config),
-		DeploymentManager: deployment.NewManager(k8sClient),
-		EC2Manager:        ec2Manager.NewManager(ec2, options.AWSVPCID),
-		SAManager:         serviceaccount.NewManager(k8sClient, config),
-		NSManager:         namespace.NewManager(k8sClient),
-		SGPManager:        sgpManager.NewManager(k8sClient),
-		SVCManager:        service.NewManager(k8sClient),
-		JobManager:        jobs.NewManager(k8sClient),
-		NodeManager:       node.NewManager(k8sClient),
-		ControllerManager: controller.NewManager(k8sClient),
-		RBACManager:       rbac.NewManager(k8sClient),
-		ConfigMapManager:  configmap.NewManager(k8sClient),
-		Options:           options,
+		K8sClient:          k8sClient,
+		ec2Client:          ec2,
+		PodManager:         pod.NewManager(k8sClient, k8sSchema, config),
+		DeploymentManager:  deployment.NewManager(k8sClient),
+		EC2Manager:         ec2Manager.NewManager(ec2, options.AWSVPCID),
+		SAManager:          serviceaccount.NewManager(k8sClient, config),
+		NSManager:          namespace.NewManager(k8sClient),
+		SGPManager:         sgpManager.NewManager(k8sClient),
+		SVCManager:         service.NewManager(k8sClient),
+		JobManager:         jobs.NewManager(k8sClient),
+		NodeManager:        node.NewManager(k8sClient),
+		ControllerManager:  controller.NewManager(k8sClient),
+		RBACManager:        rbac.NewManager(k8sClient),
+		ConfigMapManager:   configmap.NewManager(k8sClient),
+		AutoScalingManager: autoscaling.NewManager(sess),
+		Options:            options,
 	}
 }

--- a/test/framework/resource/aws/autoscaling/manager.go
+++ b/test/framework/resource/aws/autoscaling/manager.go
@@ -1,0 +1,64 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package autoscaling
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
+)
+
+type Manager interface {
+	DescribeAutoScalingGroup(autoScalingGroupName string) ([]*autoscaling.Group, error)
+	UpdateAutoScalingGroup(asgName string, minSize, maxSize int64) error
+}
+
+type defaultManager struct {
+	autoscalingiface.AutoScalingAPI
+}
+
+func NewManager(session *session.Session) Manager {
+	return &defaultManager{
+		AutoScalingAPI: autoscaling.New(session),
+	}
+}
+
+func (d defaultManager) DescribeAutoScalingGroup(autoScalingGroupName string) ([]*autoscaling.Group, error) {
+	describeAutoScalingGroupIp := &autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: aws.StringSlice([]string{autoScalingGroupName}),
+	}
+	asg, err := d.AutoScalingAPI.DescribeAutoScalingGroups(describeAutoScalingGroupIp)
+	if err != nil {
+		return nil, err
+	}
+	if len(asg.AutoScalingGroups) == 0 {
+		return nil, fmt.Errorf("failed to find asg %s", autoScalingGroupName)
+	}
+
+	return asg.AutoScalingGroups, nil
+}
+
+func (d defaultManager) UpdateAutoScalingGroup(asgName string, minSize, maxSize int64) error {
+	updateASGInput := &autoscaling.UpdateAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String(asgName),
+		DesiredCapacity:      aws.Int64(minSize), // Set DesiredCapacity to minSize
+		MaxSize:              aws.Int64(maxSize),
+		MinSize:              aws.Int64(minSize),
+	}
+	_, err := d.AutoScalingAPI.UpdateAutoScalingGroup(updateASGInput)
+	return err
+}

--- a/test/framework/resource/k8s/node/wrapper.go
+++ b/test/framework/resource/k8s/node/wrapper.go
@@ -15,30 +15,61 @@ package node
 
 import (
 	"context"
+	"fmt"
 
+	cninode "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1alpha1"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-func GetNodeAndWaitTillCapacityPresent(manager Manager, ctx context.Context, os string, expectedResource string) *v1.NodeList {
-
+func GetNodeAndWaitTillCapacityPresent(manager Manager, os string, expectedResource string) *v1.NodeList {
 	observedNodeList := &v1.NodeList{}
 	var err error
-	err = wait.Poll(utils.PollIntervalShort, utils.ResourceCreationTimeout, func() (bool, error) {
-		By("checking nodes have capacity present")
-		observedNodeList, err = manager.GetNodesWithOS(os)
-		Expect(err).ToNot(HaveOccurred())
-		for _, node := range observedNodeList.Items {
-			_, found := node.Status.Allocatable[v1.ResourceName(expectedResource)]
-			if !found {
-				return false, nil
+	err = wait.PollUntilContextTimeout(context.Background(), utils.PollIntervalShort, utils.ResourceCreationTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			By("checking nodes have capacity present")
+			observedNodeList, err = manager.GetNodesWithOS(os)
+			Expect(err).ToNot(HaveOccurred())
+			for _, node := range observedNodeList.Items {
+				_, found := node.Status.Allocatable[v1.ResourceName(expectedResource)]
+				if !found {
+					return false, nil
+				}
 			}
-		}
-		return true, nil
-	})
+			return true, nil
+		})
 	Expect(err).ToNot(HaveOccurred())
 	return observedNodeList
+}
+
+// VerifyCNINodeCount checks if the number of CNINodes is equal to number of nodes in the cluster, and verifies 1:1 mapping between CNINode and Node objects
+// Returns nil if count and 1:1 mapping exists, else returns error
+func VerifyCNINodeCount(manager Manager) error {
+	cniNodes, err := manager.GetCNINodeList()
+	Expect(err).NotTo(HaveOccurred())
+	nodes, err := manager.GetNodeList()
+	Expect(err).NotTo(HaveOccurred())
+	By("checking number of CNINodes match number of nodes in the cluster")
+	isEqual := len(nodes.Items) == len(cniNodes.Items)
+	if !isEqual {
+		return fmt.Errorf("number of CNINodes does not match number of nodes in the cluster")
+	}
+
+	By("checking CNINode list matches node list")
+	nameMatched := true
+	for _, node := range nodes.Items {
+		if !lo.ContainsBy(cniNodes.Items, func(cniNode cninode.CNINode) bool {
+			return cniNode.Name == node.Name
+		}) {
+			nameMatched = false
+		}
+	}
+	if !nameMatched {
+		return fmt.Errorf("CNINode list does not match node list")
+	}
+	return nil
 }

--- a/test/integration/cninode/cninode_suite_test.go
+++ b/test/integration/cninode/cninode_suite_test.go
@@ -1,0 +1,45 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cninode_test
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/node"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCNINode(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CNINode Test Suite")
+}
+
+var frameWork *framework.Framework
+var _ = BeforeSuite(func() {
+	By("creating a framework")
+	frameWork = framework.New(framework.GlobalOptions)
+
+	By("verify CNINode count")
+	err := node.VerifyCNINodeCount(frameWork.NodeManager)
+	Expect(err).ToNot(HaveOccurred())
+})
+
+// Verify CNINode count before and after test remains same
+var _ = AfterSuite(func() {
+	By("verify CNINode count")
+	err := node.VerifyCNINodeCount(frameWork.NodeManager)
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/test/integration/cninode/cninode_test.go
+++ b/test/integration/cninode/cninode_test.go
@@ -1,0 +1,183 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cninode_test
+
+import (
+	"time"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1alpha1"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/utils"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/node"
+	testUtils "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+var _ = Describe("CNINode test", func() {
+	Describe("CNINode count verification on adding or removing node", func() {
+		var oldMinSize int64
+		var oldMaxSize int64
+		var newMinSize int64
+		var newMaxSize int64
+		var asgName string
+		BeforeEach(func() {
+			By("getting autoscaling group name")
+			asgName = ListNodesAndGetAutoScalingGroupName()
+			asg, err := frameWork.AutoScalingManager.DescribeAutoScalingGroup(asgName)
+			Expect(err).ToNot(HaveOccurred())
+			oldMinSize = *asg[0].MinSize
+			oldMaxSize = *asg[0].MaxSize
+		})
+		AfterEach(func() {
+			By("restoring ASG minSize & maxSize after test")
+			err := frameWork.AutoScalingManager.UpdateAutoScalingGroup(asgName, oldMinSize, oldMaxSize)
+			Expect(err).ToNot(HaveOccurred())
+			// sleep to allow ASG to be updated
+			time.Sleep(testUtils.ResourceCreationTimeout)
+		})
+
+		Context("when new node is added", func() {
+			It("it should create new CNINode", func() {
+				newMinSize = oldMinSize + 1
+				newMaxSize = oldMaxSize + 1
+				// Update ASG to set new minSize and new maxSize
+				By("adding new node")
+				err := frameWork.AutoScalingManager.UpdateAutoScalingGroup(asgName, newMinSize, newMaxSize)
+				Expect(err).ToNot(HaveOccurred())
+				// sleep to allow ASG to be updated
+				time.Sleep(testUtils.ResourceCreationTimeout)
+
+				err = node.VerifyCNINodeCount(frameWork.NodeManager)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+		Context("when existing node is removed", func() {
+			It("it should delete CNINode", func() {
+				newMinSize = oldMinSize - 1
+				newMaxSize = oldMaxSize - 1
+				// Update ASG to set new minSize and new maxSize
+				By("removing existing node")
+				err := frameWork.AutoScalingManager.UpdateAutoScalingGroup(asgName, newMinSize, newMaxSize)
+				Expect(err).ToNot(HaveOccurred())
+				// sleep to allow ASG to be updated
+				time.Sleep(testUtils.ResourceCreationTimeout)
+				err = node.VerifyCNINodeCount(frameWork.NodeManager)
+				Expect(err).ToNot(HaveOccurred())
+
+			})
+		})
+	})
+
+	Describe("CNINode is re-created when node exists", func() {
+		Context("when CNINode is deleted but node exists", func() {
+			It("it should re-create CNINode", func() {
+				nodeList, err := frameWork.NodeManager.GetNodesWithOS(config.OSLinux)
+				Expect(err).ToNot(HaveOccurred())
+				cniNode, err := frameWork.NodeManager.GetCNINode(&nodeList.Items[0])
+				Expect(err).ToNot(HaveOccurred())
+				err = frameWork.NodeManager.DeleteCNINode(cniNode)
+				Expect(err).ToNot(HaveOccurred())
+				time.Sleep(testUtils.PollIntervalShort) // allow time to re-create CNINode
+				_, err = frameWork.NodeManager.GetCNINode(&nodeList.Items[0])
+				Expect(err).ToNot(HaveOccurred())
+				VerifyCNINodeFields(cniNode)
+			})
+		})
+
+	})
+
+	Describe("CNINode update tests", func() {
+		var cniNode *v1alpha1.CNINode
+		var node *v1.Node
+		BeforeEach(func() {
+			nodeList, err := frameWork.NodeManager.GetNodesWithOS(config.OSLinux)
+			Expect(err).ToNot(HaveOccurred())
+			node = &nodeList.Items[0]
+			cniNode, err = frameWork.NodeManager.GetCNINode(node)
+			Expect(err).ToNot(HaveOccurred())
+			VerifyCNINodeFields(cniNode)
+		})
+		AfterEach(func() {
+			time.Sleep(testUtils.PollIntervalShort)
+			newCNINode, err := frameWork.NodeManager.GetCNINode(node)
+			Expect(err).ToNot(HaveOccurred())
+			// Verify CNINode after update matches CNINode before update
+			Expect(newCNINode).To(BeComparableTo(cniNode, cmp.Options{
+				cmpopts.IgnoreTypes(metav1.TypeMeta{}),
+				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion", "Generation", "ManagedFields"),
+			}))
+		})
+
+		Context("when finalizer is removed", func() {
+			It("it should add the finalizer", func() {
+				cniNodeCopy := cniNode.DeepCopy()
+				controllerutil.RemoveFinalizer(cniNodeCopy, config.NodeTerminationFinalizer)
+				err := frameWork.NodeManager.UpdateCNINode(cniNode, cniNodeCopy)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+		Context("when Tags is removed", func() {
+			It("it should add the Tags", func() {
+				cniNodeCopy := cniNode.DeepCopy()
+				cniNodeCopy.Spec.Tags = map[string]string{}
+				err := frameWork.NodeManager.UpdateCNINode(cniNode, cniNodeCopy)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+		Context("when Label is removed", func() {
+			It("it should add the label", func() {
+				cniNodeCopy := cniNode.DeepCopy()
+				cniNodeCopy.ObjectMeta.Labels = map[string]string{}
+				err := frameWork.NodeManager.UpdateCNINode(cniNode, cniNodeCopy)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+})
+
+func ListNodesAndGetAutoScalingGroupName() string {
+	By("getting instance details")
+	nodeList, err := frameWork.NodeManager.GetNodesWithOS(config.OSLinux)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(nodeList.Items).ToNot(BeEmpty())
+	instanceID := frameWork.NodeManager.GetInstanceID(&nodeList.Items[0])
+	Expect(instanceID).ToNot(BeEmpty())
+	instance, err := frameWork.EC2Manager.GetInstanceDetails(instanceID)
+	Expect(err).ToNot(HaveOccurred())
+	tags := utils.GetTagKeyValueMap(instance.Tags)
+	val, ok := tags["aws:autoscaling:groupName"]
+	Expect(ok).To(BeTrue())
+	return val
+}
+
+// Verify finalizer, tag, and label is set on new CNINode
+func VerifyCNINodeFields(cniNode *v1alpha1.CNINode) {
+	By("verifying finalizer is set")
+	Expect(cniNode.ObjectMeta.Finalizers).To(ContainElement(config.NodeTerminationFinalizer))
+	// For maps, ContainElement searches through the map's values.
+	By("verifying cluster name tag is set")
+	Expect(cniNode.Spec.Tags).To(ContainElement(frameWork.Options.ClusterName))
+	Expect(config.CNINodeClusterNameKey).To(BeKeyOf(cniNode.Spec.Tags))
+
+	By("verifying node OS label is set")
+	Expect(cniNode.ObjectMeta.Labels).To(ContainElement(config.OSLinux))
+	Expect(config.NodeLabelOS).To(BeKeyOf(cniNode.ObjectMeta.Labels))
+}

--- a/test/integration/perpodsg/perpodsg_suite_test.go
+++ b/test/integration/perpodsg/perpodsg_suite_test.go
@@ -50,8 +50,10 @@ var _ = BeforeSuite(func() {
 	securityGroupID1 = reCreateSGIfAlreadyExists(utils.ResourceNamePrefix + "sg-1")
 	securityGroupID2 = reCreateSGIfAlreadyExists(utils.ResourceNamePrefix + "sg-2")
 
-	nodeList = node.GetNodeAndWaitTillCapacityPresent(frameWork.NodeManager, ctx, "linux",
+	nodeList = node.GetNodeAndWaitTillCapacityPresent(frameWork.NodeManager, "linux",
 		config.ResourceNamePodENI)
+	err = node.VerifyCNINodeCount(frameWork.NodeManager)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {

--- a/test/integration/perpodsg/perpodsg_test.go
+++ b/test/integration/perpodsg/perpodsg_test.go
@@ -37,29 +37,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("CNINode Veification", func() {
-	Describe("verify CNINode mapping to nodes", func() {
-		Context("when nodes are ready", func() {
-			It("should have same number of CNINode no matter which mode", func() {
-				cniNodes, err := frameWork.NodeManager.GetCNINodeList()
-				Expect(err).NotTo(HaveOccurred())
-				nodes, err := frameWork.NodeManager.GetNodeList()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(len(nodes.Items)).To(Equal(len(cniNodes.Items)))
-				nameMatched := true
-				for _, node := range nodes.Items {
-					if !lo.ContainsBy(cniNodes.Items, func(cniNode cninode.CNINode) bool {
-						return cniNode.Name == node.Name
-					}) {
-						nameMatched = false
-					}
-				}
-				Expect(nameMatched).To(BeTrue())
-			})
-		})
-	})
-})
-
 var _ = Describe("Branch ENI Pods", func() {
 	var (
 		securityGroupPolicy *v1beta1.SecurityGroupPolicy

--- a/test/integration/windows/windows_suite_test.go
+++ b/test/integration/windows/windows_suite_test.go
@@ -67,7 +67,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	By("getting the list of Windows node")
-	windowsNodeList = node.GetNodeAndWaitTillCapacityPresent(frameWork.NodeManager, ctx, "windows",
+	windowsNodeList = node.GetNodeAndWaitTillCapacityPresent(frameWork.NodeManager, "windows",
 		config.ResourceNameIPAddress)
 
 	By("getting the instance ID for the first node")

--- a/test/integration/windows/windows_test.go
+++ b/test/integration/windows/windows_test.go
@@ -219,7 +219,7 @@ var _ = Describe("Windows Integration Test", func() {
 
 			bufferForCoolDown = time.Second * 30
 
-			windowsNodeList = node.GetNodeAndWaitTillCapacityPresent(frameWork.NodeManager, ctx, "windows",
+			windowsNodeList = node.GetNodeAndWaitTillCapacityPresent(frameWork.NodeManager, "windows",
 				config.ResourceNameIPAddress)
 			instanceID = manager.GetNodeInstanceID(&windowsNodeList.Items[0])
 			nodeName = windowsNodeList.Items[0].Name


### PR DESCRIPTION
*Issue #, if available:*
NA
*Description of changes:*
Adding CNINode integration tests. 

```
[AfterSuite] 
/local/home/ravsushm/go/src/github.com/aws/amazon-vpc-resource-controller-k8s/test/integration/cninode/cninode_suite_test.go:41
  STEP: verify CNINode count @ 03/28/24 08:48:55.193
  STEP: checking number of CNINodes match number of nodes in the cluster @ 03/28/24 08:48:55.193
  STEP: checking CNINode list matches node list @ 03/28/24 08:48:55.193
[AfterSuite] PASSED [0.000 seconds]
------------------------------

Ran 6 of 6 Specs in 491.652 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 8m14.282438665s
Test Suite Passed
```

SGP tests:
```
Ran 19 of 23 Specs in 913.416 seconds
SUCCESS! -- 19 Passed | 0 Failed | 0 Pending | 4 Skipped
PASS

Ginkgo ran 1 suite in 15m28.783849393s
Test Suite Passed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
