### PR TITLE
add github action to run gosec static analysis

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -58,8 +58,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+      - name: Setup Go Version
+        run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
+      - uses: actions/setup-go@v4
         with:
-          args: -exclude-dir test -exclude-generated -severity medium -exclude=G108,G114 ./...
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
+      - name: Install `gosec`
+        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+      - name: Run Gosec Security Scanner
+        run: ~/go/bin/gosec -exclude-dir test -exclude-generated -severity medium -exclude=G108,G114 ./...
 

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -53,3 +53,13 @@ jobs:
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run `govulncheck`
         run: ~/go/bin/govulncheck ./...
+  static-security-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: -exclude-dir test -exclude-generated -severity medium -exclude=G108,G114 ./...
+

--- a/pkg/k8s/pod/converter.go
+++ b/pkg/k8s/pod/converter.go
@@ -56,6 +56,7 @@ func (c *PodConverter) ConvertList(originalList interface{}) (convertedList inte
 		},
 	}
 	for _, pod := range podList.Items {
+		pod := pod // Fix gosec G601, so we can use &node
 		strippedPod := c.StripDownPod(&pod)
 		strippedPodList.Items = append(strippedPodList.Items, *strippedPod)
 	}

--- a/pkg/provider/branch/trunk/trunk.go
+++ b/pkg/provider/branch/trunk/trunk.go
@@ -245,6 +245,7 @@ func (t *trunkENI) InitTrunk(instance ec2.EC2Instance, podList []v1.Pod) error {
 
 	// From the list of pods on the given node, and the branch ENIs from EC2 API call rebuild the internal cache
 	for _, pod := range podList {
+		pod := pod // Fix gosec G601, so we can use &node
 		eniListFromPod := t.getBranchInterfacesUsedByPod(&pod)
 		if len(eniListFromPod) == 0 {
 			continue

--- a/pkg/utils/events.go
+++ b/pkg/utils/events.go
@@ -48,6 +48,7 @@ func SendNodeEventWithNodeObject(client k8s.K8sWrapper, node *v1.Node, reason, m
 func SendBroadcastNodeEvent(client k8s.K8sWrapper, reason, msg, eventType string, logger logr.Logger) {
 	if nodeList, err := client.ListNodes(); err == nil {
 		for _, node := range nodeList.Items {
+			node := node // Fix gosec G601, so we can use &node
 			client.BroadcastEvent(&node, reason, msg, eventType)
 		}
 	} else {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add `gosec` static analysis check in github actions. 
By default, this scans for high & medium issues. Excluding low issues as they are not very useful to fix(only low issues reported from local scan were many unhandled errors), also excludes test and generated files. 

Note on G108,G114: The go profiler is not enabled listening on a port be default, it is wrapped by an optional flag `enable-profiling`. This complies with a security best practice:
* only expose to localhost at a port which is not used for http server
* the controller doesn't open any endpoint to internet as a server
* the controller runs in isolated EKS control plane instance and doesn't server any traffic to/from outside world


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
