### PR TITLE
remove global exclusion for G108,G114 and add nosec in code

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -67,5 +67,5 @@ jobs:
       - name: Install `gosec`
         run: go install github.com/securego/gosec/v2/cmd/gosec@latest
       - name: Run Gosec Security Scanner
-        run: ~/go/bin/gosec -exclude-dir test -exclude-generated -severity medium -exclude=G108,G114 ./...
+        run: ~/go/bin/gosec -exclude-dir test -exclude-generated -severity medium ./...
 

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
+	_ "net/http/pprof" // #nosec G108
 	"os"
 	"time"
 
@@ -194,8 +194,7 @@ func main() {
 	if enableProfiling {
 		// To use the profiler - https://golang.org/pkg/net/http/pprof/
 		go func() {
-			setupLog.Info("starting profiler",
-				"error", http.ListenAndServe("localhost:6060", nil))
+			setupLog.Info("starting profiler", "error", http.ListenAndServe("localhost:6060", nil)) // #nosec G114
 		}()
 	}
 

--- a/pkg/resource/introspect.go
+++ b/pkg/resource/introspect.go
@@ -46,7 +46,7 @@ func (i *IntrospectHandler) Start(_ context.Context) error {
 	mux.HandleFunc(GetResourcesSummaryPath, i.ResourceSummaryHandler)
 
 	// Should this be a fatal error?
-	err := http.ListenAndServe(i.BindAddress, mux)
+	err := http.ListenAndServe(i.BindAddress, mux) // #nosec G114
 	if err != nil {
 		i.Log.Error(err, "failed to run introspect API")
 	}


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Remove global exclusion of G108, G114 from github action and add `nosec` annotation in code to suppress current known false positives. 

```
gosec -exclude-dir test -exclude-generated -severity medium ./...
Summary:
  Gosec  : dev
  Files  : 53
  Lines  : 11404
  Nosec  : 3
  Issues : 0
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
