### PR TITLE
Fix log which causes panic

### DIFF
--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -139,7 +139,7 @@ func timeSinceMs(start time.Time) float64 {
 // cache for use in future Create/Delete Requests
 func (b *branchENIProvider) InitResource(instance ec2.EC2Instance) error {
 	nodeName := instance.Name()
-	log := b.log.WithValues("NodeName", nodeName)
+	log := b.log.WithValues("nodeName", nodeName)
 	trunkENI := trunk.NewTrunkENI(log, instance, b.apiWrapper.EC2API)
 
 	// Initialize the Trunk ENI
@@ -242,7 +242,7 @@ func (b *branchENIProvider) DeleteNode(nodeName string) (ctrl.Result, error) {
 	trunkENI.DeleteAllBranchENIs()
 	b.removeTrunkFromCache(nodeName)
 
-	b.log.Info("de-initialized resource provider successfully", "NodeName", nodeName)
+	b.log.Info("de-initialized resource provider successfully", "nodeName", nodeName)
 
 	return ctrl.Result{}, nil
 }
@@ -272,7 +272,7 @@ func (b *branchENIProvider) ReconcileNode(nodeName string) bool {
 	log := b.log.WithValues("node", nodeName)
 	if !isPresent {
 		// return true to set the node next clean up asap since we don't know why trunk is missing
-		log.Info("no trunk ENI is pointing to the given node", "NodeName", nodeName)
+		log.Info("no trunk ENI is pointing to the given node", "nodeName", nodeName)
 		return true
 	}
 	podList, err := b.apiWrapper.PodAPI.ListPods(nodeName)
@@ -284,7 +284,7 @@ func (b *branchENIProvider) ReconcileNode(nodeName string) bool {
 	}
 	foundLeakedENI := trunkENI.Reconcile(podList.Items)
 
-	log.Info("completed reconcile node cleanup on branch ENIs", "NodeName", nodeName)
+	log.Info("completed reconcile node cleanup on branch ENIs", "nodeName", nodeName)
 
 	return foundLeakedENI
 }
@@ -344,7 +344,7 @@ func (b *branchENIProvider) CreateAndAnnotateResources(podNamespace string, podN
 			"Security Groups %v", securityGroups), v1.EventTypeNormal)
 	}
 
-	log := b.log.WithValues("pod namespace", pod.Namespace, "pod name", pod.Name, "NodeName", pod.Spec.NodeName)
+	log := b.log.WithValues("pod namespace", pod.Namespace, "pod name", pod.Name, "nodeName", pod.Spec.NodeName)
 
 	start := time.Now()
 	trunkENI, isPresent := b.getTrunkFromCache(pod.Spec.NodeName)
@@ -406,7 +406,7 @@ func (b *branchENIProvider) DeleteBranchUsedByPods(nodeName string, UID string) 
 		// trunk cache is local map with lock. it shouldn't return not found error if trunk exists
 		// if the node's trunk is not found, we shouldn't retry
 		// worst case we rely on node based clean up goroutines to clean branch ENIs up
-		b.log.Info("failed to find trunk ENI for the node", "NodeName", nodeName)
+		b.log.Info("failed to find trunk ENI for the node", "nodeName", nodeName)
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -406,7 +406,7 @@ func (b *branchENIProvider) DeleteBranchUsedByPods(nodeName string, UID string) 
 		// trunk cache is local map with lock. it shouldn't return not found error if trunk exists
 		// if the node's trunk is not found, we shouldn't retry
 		// worst case we rely on node based clean up goroutines to clean branch ENIs up
-		b.log.Info("failed to find trunk ENI for the node %s", nodeName)
+		b.log.Info("failed to find trunk ENI for the node", "nodeName", nodeName)
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -139,7 +139,7 @@ func timeSinceMs(start time.Time) float64 {
 // cache for use in future Create/Delete Requests
 func (b *branchENIProvider) InitResource(instance ec2.EC2Instance) error {
 	nodeName := instance.Name()
-	log := b.log.WithValues("node name", nodeName)
+	log := b.log.WithValues("NodeName", nodeName)
 	trunkENI := trunk.NewTrunkENI(log, instance, b.apiWrapper.EC2API)
 
 	// Initialize the Trunk ENI
@@ -242,7 +242,7 @@ func (b *branchENIProvider) DeleteNode(nodeName string) (ctrl.Result, error) {
 	trunkENI.DeleteAllBranchENIs()
 	b.removeTrunkFromCache(nodeName)
 
-	b.log.Info("de-initialized resource provider successfully", "node name", nodeName)
+	b.log.Info("de-initialized resource provider successfully", "NodeName", nodeName)
 
 	return ctrl.Result{}, nil
 }
@@ -344,7 +344,7 @@ func (b *branchENIProvider) CreateAndAnnotateResources(podNamespace string, podN
 			"Security Groups %v", securityGroups), v1.EventTypeNormal)
 	}
 
-	log := b.log.WithValues("pod namespace", pod.Namespace, "pod name", pod.Name, "node name", pod.Spec.NodeName)
+	log := b.log.WithValues("pod namespace", pod.Namespace, "pod name", pod.Name, "NodeName", pod.Spec.NodeName)
 
 	start := time.Now()
 	trunkENI, isPresent := b.getTrunkFromCache(pod.Spec.NodeName)
@@ -406,7 +406,7 @@ func (b *branchENIProvider) DeleteBranchUsedByPods(nodeName string, UID string) 
 		// trunk cache is local map with lock. it shouldn't return not found error if trunk exists
 		// if the node's trunk is not found, we shouldn't retry
 		// worst case we rely on node based clean up goroutines to clean branch ENIs up
-		b.log.Info("failed to find trunk ENI for the node", "nodeName", nodeName)
+		b.log.Info("failed to find trunk ENI for the node", "NodeName", nodeName)
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Switching to logging library meant it doesn't do string formatting. The info call expects a key value pair instead of string format. When provided with odd number of arguments, this cause logger to panic

```
level: dpanic
   logger: branch eni provider
   msg: odd number of arguments passed as key-value pairs for logging
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
