### PR TITLE
Modify SecurityGroups Maxitems

### DIFF
--- a/apis/vpcresources/v1beta1/securitygrouppolicy_types.go
+++ b/apis/vpcresources/v1beta1/securitygrouppolicy_types.go
@@ -30,7 +30,7 @@ type SecurityGroupPolicySpec struct {
 type GroupIds struct {
 	// Groups is the list of EC2 Security Groups Ids that need to be applied to the ENI of a Pod.
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=5
+	// +kubebuilder:validation:MaxItems=16
 	Groups []string `json:"groupIds,omitempty"`
 }
 

--- a/config/crd/bases/vpcresources.k8s.aws_securitygrouppolicies.yaml
+++ b/config/crd/bases/vpcresources.k8s.aws_securitygrouppolicies.yaml
@@ -99,7 +99,7 @@ spec:
                       need to be applied to the ENI of a Pod.
                     items:
                       type: string
-                    maxItems: 5
+                    maxItems: 16
                     minItems: 1
                     type: array
                 type: object


### PR DESCRIPTION
*Issue #, if available:*
Modify the maxitems in SecurityGroups.
According to "Amazon VPC Quotas," it should be able to use up to 16.

*Description of changes:*
We need to use more than 10 security groups.
Increase the maxitems to the maximum number of allowable (16), and modify the descritions.
https://docs.aws.amazon.com/vpc/latest/userguide/amazon-vpc-limits.html#vpc-limits-security-groups

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
