### PR TITLE
add pod datastore to introspect, add logs for pod events

### DIFF
--- a/controllers/custom/builder.go
+++ b/controllers/custom/builder.go
@@ -134,7 +134,7 @@ func (b *Builder) Complete(reconciler Reconciler) (healthz.Checker, error) {
 				if !ok {
 					return fmt.Errorf("failed to get object meta %v", obj)
 				}
-				b.log.Info("processing item", "objName", metaObj.GetName(), "deltaType", d.Type)
+				b.log.Info("processing item", "objName", metaObj.GetName(), "namespace", metaObj.GetNamespace(), "deltaType", d.Type)
 				switch d.Type {
 				case cache.Sync, cache.Added, cache.Updated:
 
@@ -165,8 +165,9 @@ func (b *Builder) Complete(reconciler Reconciler) (healthz.Checker, error) {
 					})
 
 				case cache.Deleted:
+					b.log.Info("deleting item", "objName", metaObj.GetName(), "namespace", metaObj.GetNamespace())
 					if err := b.dataStore.Delete(convertedObj); err != nil {
-						b.log.Error(err, "failed to add object to datastore, returning error", "obj", metaObj.GetName())
+						b.log.Error(err, "failed to delete object from datastore, returning error", "obj", metaObj.GetName())
 						return err
 					}
 					// Add entire object instead of namespace/name as from this

--- a/controllers/custom/builder.go
+++ b/controllers/custom/builder.go
@@ -130,23 +130,29 @@ func (b *Builder) Complete(reconciler Reconciler) (healthz.Checker, error) {
 				if err != nil {
 					return err
 				}
+				metaObj, ok := convertedObj.(metav1.Object)
+				if !ok {
+					return fmt.Errorf("failed to get object meta %v", obj)
+				}
+				b.log.Info("processing item", "objName", metaObj.GetName(), "deltaType", d.Type)
 				switch d.Type {
 				case cache.Sync, cache.Added, cache.Updated:
-					if _, exists, err := b.dataStore.Get(convertedObj); err == nil && exists {
-						if err := b.dataStore.Update(convertedObj); err != nil {
-							return err
+
+					if _, exists, err := b.dataStore.Get(convertedObj); err == nil {
+						if exists {
+							if err := b.dataStore.Update(convertedObj); err != nil {
+								b.log.Error(err, "failed to update object in datastore, returning error", "obj", metaObj.GetName())
+								return err
+							}
+						} else {
+							if err := b.dataStore.Add(convertedObj); err != nil {
+								b.log.Error(err, "failed to add object to datastore, returning error", "obj", metaObj.GetName())
+								return err
+							}
 						}
 					} else {
-						if err := b.dataStore.Add(convertedObj); err != nil {
-							return err
-						}
-					}
-					if err != nil {
+						b.log.Error(err, "failed to get object", "error", err.Error())
 						return err
-					}
-					metaObj, ok := convertedObj.(metav1.Object)
-					if !ok {
-						return fmt.Errorf("failed to get object meta %v", obj)
 					}
 
 					// Add the namespace/name to the queue so multiple
@@ -160,6 +166,7 @@ func (b *Builder) Complete(reconciler Reconciler) (healthz.Checker, error) {
 
 				case cache.Deleted:
 					if err := b.dataStore.Delete(convertedObj); err != nil {
+						b.log.Error(err, "failed to add object to datastore, returning error", "obj", metaObj.GetName())
 						return err
 					}
 					// Add entire object instead of namespace/name as from this

--- a/main.go
+++ b/main.go
@@ -285,11 +285,12 @@ func main() {
 	dataStore := clientgocache.NewIndexer(podConverter.Indexer, pod.NodeNameIndexer())
 
 	k8sApi := k8s.NewK8sWrapper(mgr.GetClient(), clientSet.CoreV1(), ctx)
+	podApi := pod.NewPodAPIWrapper(dataStore, mgr.GetClient(), clientSet.CoreV1())
 
 	apiWrapper := api.Wrapper{
 		EC2API: ec2APIHelper,
 		K8sAPI: k8sApi,
-		PodAPI: pod.NewPodAPIWrapper(dataStore, mgr.GetClient(), clientSet.CoreV1()),
+		PodAPI: podApi,
 		SGPAPI: sgpAPI,
 	}
 
@@ -388,6 +389,7 @@ func main() {
 		Log:             ctrl.Log.WithName("introspect"),
 		BindAddress:     introspectBindAddr,
 		ResourceManager: resourceManager,
+		PodAPIWrapper:   podApi,
 	}).SetupWithManager(mgr, healthzHandler); err != nil {
 		setupLog.Error(err, "unable to create introspect API")
 		os.Exit(1)

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/pod/mock_podapiwrapper.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/pod/mock_podapiwrapper.go
@@ -108,6 +108,20 @@ func (mr *MockPodClientAPIWrapperMockRecorder) GetRunningPodsOnNode(arg0 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunningPodsOnNode", reflect.TypeOf((*MockPodClientAPIWrapper)(nil).GetRunningPodsOnNode), arg0)
 }
 
+// Introspect mocks base method.
+func (m *MockPodClientAPIWrapper) Introspect() interface{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Introspect")
+	ret0, _ := ret[0].(interface{})
+	return ret0
+}
+
+// Introspect indicates an expected call of Introspect.
+func (mr *MockPodClientAPIWrapperMockRecorder) Introspect() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Introspect", reflect.TypeOf((*MockPodClientAPIWrapper)(nil).Introspect))
+}
+
 // ListPods mocks base method.
 func (m *MockPodClientAPIWrapper) ListPods(arg0 string) (*v1.PodList, error) {
 	m.ctrl.T.Helper()

--- a/pkg/k8s/pod/client_wrapper.go
+++ b/pkg/k8s/pod/client_wrapper.go
@@ -69,7 +69,7 @@ var (
 )
 
 type IntrospectResponse struct {
-	PodDatastoreKeys []string
+	PodList []string
 }
 
 type PodClientAPIWrapper interface {
@@ -213,6 +213,6 @@ func (p *podClientAPIWrapper) GetPodFromAPIServer(ctx context.Context, namespace
 
 func (p *podClientAPIWrapper) Introspect() interface{} {
 	return IntrospectResponse{
-		PodDatastoreKeys: p.dataStore.ListKeys(),
+		PodList: p.dataStore.ListKeys(),
 	}
 }

--- a/pkg/k8s/pod/client_wrapper.go
+++ b/pkg/k8s/pod/client_wrapper.go
@@ -68,12 +68,17 @@ var (
 	)
 )
 
+type IntrospectResponse struct {
+	PodDatastoreKeys []string
+}
+
 type PodClientAPIWrapper interface {
 	GetPod(namespace string, name string) (*v1.Pod, error)
 	ListPods(nodeName string) (*v1.PodList, error)
 	AnnotatePod(podNamespace string, podName string, uid types.UID, key string, val string) error
 	GetPodFromAPIServer(ctx context.Context, namespace string, name string) (*v1.Pod, error)
 	GetRunningPodsOnNode(nodeName string) ([]v1.Pod, error)
+	Introspect() interface{}
 }
 
 type podClientAPIWrapper struct {
@@ -204,4 +209,10 @@ func (p *podClientAPIWrapper) GetPodFromAPIServer(ctx context.Context, namespace
 	}
 
 	return pod, err
+}
+
+func (p *podClientAPIWrapper) Introspect() interface{} {
+	return IntrospectResponse{
+		PodDatastoreKeys: p.dataStore.ListKeys(),
+	}
 }

--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -275,14 +275,14 @@ func (b *branchENIProvider) ReconcileNode(nodeName string) bool {
 		log.Info("no trunk ENI is pointing to the given node", "nodeName", nodeName)
 		return true
 	}
-	podList, err := b.apiWrapper.PodAPI.ListPods(nodeName)
+	podList, err := b.apiWrapper.PodAPI.GetRunningPodsOnNode(nodeName)
 	if err != nil {
 		// return true to set the node next cleanup asap since the LIST call may fail for other reasons
 		// we should assume that there are leaked resources need to be cleaned up
 		log.Error(err, "failed fo list pod")
 		return true
 	}
-	foundLeakedENI := trunkENI.Reconcile(podList.Items)
+	foundLeakedENI := trunkENI.Reconcile(podList)
 
 	log.Info("completed reconcile node cleanup on branch ENIs", "nodeName", nodeName)
 

--- a/pkg/provider/branch/provider_test.go
+++ b/pkg/provider/branch/provider_test.go
@@ -488,10 +488,10 @@ func TestBranchENIProvider_ReconcileNode_NoLeak(t *testing.T) {
 	fakeTrunk1 := mock_trunk.NewMockTrunkENI(ctrl)
 	provider.trunkENICache[NodeName] = fakeTrunk1
 
-	list := &v1.PodList{}
-	mockPodAPI.EXPECT().ListPods(NodeName).Return(list, nil)
+	list := []v1.Pod{}
+	mockPodAPI.EXPECT().GetRunningPodsOnNode(NodeName).Return(list, nil)
 
-	fakeTrunk1.EXPECT().Reconcile(list.Items).Return(false)
+	fakeTrunk1.EXPECT().Reconcile(list).Return(false)
 
 	result := provider.ReconcileNode(NodeName)
 	assert.False(t, result)
@@ -508,10 +508,10 @@ func TestBranchENIProvider_ReconcileNode_Leak(t *testing.T) {
 	fakeTrunk1 := mock_trunk.NewMockTrunkENI(ctrl)
 	provider.trunkENICache[NodeName] = fakeTrunk1
 
-	list := &v1.PodList{}
-	mockPodAPI.EXPECT().ListPods(NodeName).Return(list, nil)
+	list := []v1.Pod{}
+	mockPodAPI.EXPECT().GetRunningPodsOnNode(NodeName).Return(list, nil)
 
-	fakeTrunk1.EXPECT().Reconcile(list.Items).Return(true)
+	fakeTrunk1.EXPECT().Reconcile(list).Return(true)
 
 	result := provider.ReconcileNode(NodeName)
 	assert.True(t, result)

--- a/pkg/resource/introspect.go
+++ b/pkg/resource/introspect.go
@@ -17,19 +17,28 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"slices"
+	"strings"
 
 	rcHealthz "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/healthz"
 	podWrapper "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/k8s/pod"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 )
 
 const (
-	GetNodeResourcesPath      = "/node/"
-	GetAllResourcesPath       = "/resources/all"
-	GetResourcesSummaryPath   = "/resources/summary"
-	PodAPIWrapperResourcesKey = "podApiWrapperResources"
+	GetNodeResourcesPath    = "/node/"
+	GetAllResourcesPath     = "/resources/all"
+	GetResourcesSummaryPath = "/resources/summary"
+	// Use path "/datastore/all" to get all pods stored in the cache,
+	// "/datastore/listpods/<nodename>" to get list of all pods on a node (ie ListPods output)
+	// "datastore/listrunningpods/<nodename>" to get list of all running pods on a node (ie GetRunningPodsOnNode output)
+	GetDatastoreResourcePrefix = "/datastore/"
+	InvalidDSRequestMessage    = "Invalid request, valid requests for datastore are /datastore/all, /datastore/listpods/<nodename>, datastore/listrunningpods/<nodename>"
 )
 
 type IntrospectHandler struct {
@@ -39,7 +48,7 @@ type IntrospectHandler struct {
 	PodAPIWrapper   podWrapper.PodClientAPIWrapper
 }
 
-// StartENICleaner starts the ENI Cleaner routine that cleans up dangling ENIs created by the controller
+// Start the introspection API
 func (i *IntrospectHandler) Start(_ context.Context) error {
 	i.Log.Info("starting introspection API")
 
@@ -47,6 +56,7 @@ func (i *IntrospectHandler) Start(_ context.Context) error {
 	mux.HandleFunc(GetAllResourcesPath, i.ResourceHandler)
 	mux.HandleFunc(GetNodeResourcesPath, i.NodeResourceHandler)
 	mux.HandleFunc(GetResourcesSummaryPath, i.ResourceSummaryHandler)
+	mux.HandleFunc(GetDatastoreResourcePrefix, i.DatastoreResourceHandler)
 
 	// Should this be a fatal error?
 	err := http.ListenAndServe(i.BindAddress, mux) // #nosec G114
@@ -63,10 +73,6 @@ func (i *IntrospectHandler) ResourceHandler(w http.ResponseWriter, _ *http.Reque
 		data := provider.Introspect()
 		response[resourceName] = data
 	}
-
-	// Add pod datastore to introspect response
-	podApiWrapperResources := i.PodAPIWrapper.Introspect()
-	response[PodAPIWrapperResourcesKey] = podApiWrapperResources
 
 	jsonData, err := json.MarshalIndent(response, "", "\t")
 	if err != nil {
@@ -124,6 +130,60 @@ func (i *IntrospectHandler) ResourceSummaryHandler(w http.ResponseWriter, r *htt
 	w.Write(jsonData)
 }
 
+func (i *IntrospectHandler) DatastoreResourceHandler(w http.ResponseWriter, r *http.Request) {
+	response := make(map[string]interface{})
+
+	request := r.URL.Path[len(GetDatastoreResourcePrefix):]
+	request, nodeName, found := strings.Cut(request, "/")
+	if !found {
+		if request != "all" && !slices.Contains([]string{"listpods", "listrunningpods"}, request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(InvalidDSRequestMessage))
+			return
+		}
+	}
+	var err error
+	var isError bool
+	switch request {
+	case "listpods":
+		var podList *v1.PodList
+		if podList, err = i.PodAPIWrapper.ListPods(nodeName); err != nil {
+			isError = true
+			break
+		}
+		response[nodeName] = getPodNameSpaceName(podList.Items)
+	case "listrunningpods":
+		var pods []v1.Pod
+		if pods, err = i.PodAPIWrapper.GetRunningPodsOnNode(nodeName); err != nil {
+			isError = true
+			break
+		}
+		response[nodeName] = getPodNameSpaceName(pods)
+	case "all":
+		response["PodDatastore"] = i.PodAPIWrapper.Introspect()
+	default:
+		// will not execute, adding it for future cases
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(InvalidDSRequestMessage))
+		return
+	}
+	if isError {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	jsonData, err := json.MarshalIndent(response, "", "\t")
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
+	w.Header().Set("content-type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(jsonData)
+}
+
 func (i *IntrospectHandler) SetupWithManager(mgr ctrl.Manager, healthzHanlder *rcHealthz.HealthzHandler) error {
 	// add health check on subpath for introspect controller
 	healthzHanlder.AddControllersHealthCheckers(
@@ -131,4 +191,14 @@ func (i *IntrospectHandler) SetupWithManager(mgr ctrl.Manager, healthzHanlder *r
 	)
 
 	return mgr.Add(i)
+}
+
+func getPodNameSpaceName(podList []v1.Pod) interface{} {
+	var podNameSpaceName []string
+	for _, pod := range podList {
+		podNameSpaceName = append(podNameSpaceName, types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}.String())
+	}
+	return podWrapper.IntrospectResponse{
+		PodList: podNameSpaceName,
+	}
 }

--- a/pkg/resource/introspect_test.go
+++ b/pkg/resource/introspect_test.go
@@ -19,37 +19,49 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	mock_pod "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s/pod"
 	mock_provider "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/provider"
 	mock_resource "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/resource"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
-	resourceName = config.ResourceNamePodENI
-	nodeName     = "ip-192-168-1-2.us-west-2.compute.internal"
-	response     = "introspection-response"
+	resourceName              = config.ResourceNamePodENI
+	nodeName                  = "ip-192-168-1-2.us-west-2.compute.internal"
+	introspectionResponse     = "introspection-response"
+	mockPodIntrospectResponse = map[string]interface{}{
+		"PodDatastoreKeys": []interface{}{
+			types.NamespacedName{Namespace: "mock-namespace", Name: "mock-pod1"}.String(),
+			types.NamespacedName{Namespace: "mock-namespace", Name: "mock-pod2"}.String(),
+		},
+	}
 )
 
 type MockIntrospect struct {
-	mockManager  *mock_resource.MockResourceManager
-	mockProvider *mock_provider.MockResourceProvider
-	handler      IntrospectHandler
-	response     map[string]string
+	mockManager       *mock_resource.MockResourceManager
+	mockProvider      *mock_provider.MockResourceProvider
+	mockPodAPIWrapper *mock_pod.MockPodClientAPIWrapper
+	handler           IntrospectHandler
+	response          map[string]interface{}
 }
 
 func NewMockIntrospectHandler(ctrl *gomock.Controller) MockIntrospect {
 	mockManager := mock_resource.NewMockResourceManager(ctrl)
+	mockPodApiWrapper := mock_pod.NewMockPodClientAPIWrapper(ctrl)
 	return MockIntrospect{
-		mockManager:  mockManager,
-		mockProvider: mock_provider.NewMockResourceProvider(ctrl),
+		mockManager:       mockManager,
+		mockProvider:      mock_provider.NewMockResourceProvider(ctrl),
+		mockPodAPIWrapper: mockPodApiWrapper,
 		handler: IntrospectHandler{
 			ResourceManager: mockManager,
+			PodAPIWrapper:   mockPodApiWrapper,
 		},
-		response: map[string]string{resourceName: response},
+		response: map[string]interface{}{resourceName: introspectionResponse},
 	}
 }
 
@@ -66,7 +78,7 @@ func TestIntrospectHandler_NodeResourceHandler(t *testing.T) {
 	mock.mockManager.EXPECT().GetResourceProviders().
 		Return(map[string]provider.ResourceProvider{resourceName: mock.mockProvider})
 
-	mock.mockProvider.EXPECT().IntrospectNode(nodeName).Return(response)
+	mock.mockProvider.EXPECT().IntrospectNode(nodeName).Return(introspectionResponse)
 
 	mock.handler.NodeResourceHandler(rr, req)
 	VerifyResponse(t, rr, mock.response)
@@ -84,10 +96,15 @@ func TestIntrospectHandler_ResourceHandler(t *testing.T) {
 
 	mock.mockManager.EXPECT().GetResourceProviders().
 		Return(map[string]provider.ResourceProvider{resourceName: mock.mockProvider})
-	mock.mockProvider.EXPECT().Introspect().Return(response)
+	mock.mockProvider.EXPECT().Introspect().Return(introspectionResponse)
+
+	mock.mockPodAPIWrapper.EXPECT().Introspect().Return(mockPodIntrospectResponse)
 
 	mock.handler.ResourceHandler(rr, req)
-	VerifyResponse(t, rr, mock.response)
+	mockResourceHandlerResponse := make(map[string]interface{})
+	mockResourceHandlerResponse[config.ResourceNamePodENI] = introspectionResponse
+	mockResourceHandlerResponse[PodAPIWrapperResourcesKey] = mockPodIntrospectResponse
+	VerifyResponse(t, rr, mockResourceHandlerResponse)
 }
 
 func TestIntrospectHandler_SummaryHandler(t *testing.T) {
@@ -102,16 +119,16 @@ func TestIntrospectHandler_SummaryHandler(t *testing.T) {
 
 	mock.mockManager.EXPECT().GetResourceProviders().
 		Return(map[string]provider.ResourceProvider{resourceName: mock.mockProvider})
-	mock.mockProvider.EXPECT().IntrospectSummary().Return(response)
+	mock.mockProvider.EXPECT().IntrospectSummary().Return(introspectionResponse)
 
 	mock.handler.ResourceSummaryHandler(rr, req)
 	VerifyResponse(t, rr, mock.response)
 }
 
-func VerifyResponse(t *testing.T, rr *httptest.ResponseRecorder, response map[string]string) {
-	got := &map[string]string{}
-	err := json.Unmarshal(rr.Body.Bytes(), got)
+func VerifyResponse(t *testing.T, rr *httptest.ResponseRecorder, response map[string]interface{}) {
+	got := make(map[string]interface{})
+	err := json.Unmarshal(rr.Body.Bytes(), &got)
 	assert.NoError(t, err)
 	assert.Equal(t, rr.Code, http.StatusOK)
-	assert.Equal(t, response, *got)
+	assert.Equal(t, response, got)
 }

--- a/pkg/resource/introspect_test.go
+++ b/pkg/resource/introspect_test.go
@@ -72,16 +72,14 @@ var (
 			types.NamespacedName{Namespace: mockNS, Name: mockPod2}.String(),
 		},
 	}
-	mockListPodsResponse = map[string]interface{}{
-		mockNodeName: map[string]interface{}{
+	mockNodePodsResponse = map[string]interface{}{
+		"Pods": map[string]interface{}{
 			"PodList": []interface{}{
 				types.NamespacedName{Namespace: defaultNS, Name: mockPod1}.String(),
 				types.NamespacedName{Namespace: mockNS, Name: mockPod2}.String(),
 			},
 		},
-	}
-	mockGetRunningPodsOnNode = map[string]interface{}{
-		mockNodeName: map[string]interface{}{
+		"RunningPods": map[string]interface{}{
 			"PodList": []interface{}{
 				types.NamespacedName{Namespace: mockNS, Name: mockPod1}.String(),
 			},
@@ -185,21 +183,13 @@ func TestIntrospectHandler_DatastoreResourceHandler(t *testing.T) {
 			name: "TestListPods, verify response for list of pods on the node",
 			prepare: func(f *fields) {
 				f.mockPodAPIWrapper.EXPECT().ListPods(mockNodeName).Return(mockListPods, nil)
-			},
-			args: args{
-				request:    GetDatastoreResourcePrefix + "listpods/" + mockNodeName,
-				response:   mockListPodsResponse,
-				statusCode: http.StatusOK,
-			},
-		},
-		{
-			name: "TestGetRunningPodsOnNode, verify response for list of running pods on the node",
-			prepare: func(f *fields) {
 				f.mockPodAPIWrapper.EXPECT().GetRunningPodsOnNode(mockNodeName).Return(mockPods, nil)
 			},
 			args: args{
-				request:    GetDatastoreResourcePrefix + "listrunningpods/" + mockNodeName,
-				response:   mockGetRunningPodsOnNode,
+				request: GetDatastoreResourcePrefix + "node/" + mockNodeName,
+				response: map[string]interface{}{
+					mockNodeName: mockNodePodsResponse,
+				},
 				statusCode: http.StatusOK,
 			},
 		},


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
1. Adding handler for pod datastore operations to the introspect API
```
curl http://localhost:22775/datastore/all
{
	"PodDatastore": {
		"PodList": [
			"default/sgp-cronjob-28573380-9jmwf",
			"default/sgp-cronjob-28573380-jp8qj",
			"default/sgp-cronjob-28573380-crpdd",
			"default/hello-world-sgp-767766588-5fx78",
			"default/sgp-cronjob-28573200-4zdkm",
			"default/sgp-cronjob-28573200-h6wrj",
			"kube-system/kube-proxy-hgtjm",
...

sh-4.2$ curl http://localhost:22775/datastore/node/ip-xxx
{
	"ip-xxx": {
		"Pods": {
			"PodList": [
				"default/sgp-cronjob-28573980-w2v5h",
				"default/sgp-cronjob-28574040-z7hdf",
				"default/sgp-cronjob-28573920-zzrp8",
				"default/sgp-cronjob-28574040-mw8kg",
				"default/sgp-cronjob-28574040-r27fs",
				"default/sgp-cronjob-28574040-wdx54",
				"kube-system/kube-proxy-fwfhb",
				"default/sgp-cronjob-28573980-s2fbn",
				"default/sgp-cronjob-28574040-9klss",
				"default/sgp-cronjob-28574040-9mjdt",
				"default/sgp-cronjob-28573920-fzhhl",
				"default/sgp-cronjob-28573920-htd5k",
				"default/sgp-cronjob-28573980-msfln",
				"default/sgp-cronjob-28573980-rwsxj",
				"default/sgp-cronjob-28574040-qbq5j",
				"default/sgp-cronjob-28574040-smwdw",
				"default/sgp-cronjob-28573920-nplkt",
				"default/sgp-cronjob-28574040-dx9r9",
				"default/sgp-cronjob-28574040-rplhd",
				"default/sgp-cronjob-28573980-ktpcl",
				"default/sgp-cronjob-28573920-dkgfx",
				"default/sgp-cronjob-28573920-gt7cd",
				"default/sgp-cronjob-28574040-l7cqp",
				"default/sgp-cronjob-28573920-4z2dq",
				"default/sgp-cronjob-28573980-2wzpk",
				"default/sgp-cronjob-28574040-khzml",
				"default/sgp-cronjob-28573980-jcz6r",
				"default/sgp-cronjob-28574040-58jvz",
				"default/sgp-cronjob-28574040-dgn9x",
				"kube-system/aws-node-s2996",
				"default/sgp-cronjob-28574040-z78kl",
				"default/sgp-cronjob-28573920-mzxq2",
				"default/sgp-cronjob-28574040-2fld4",
				"default/sgp-cronjob-28574040-4vrhf",
				"default/sgp-cronjob-28574040-9mcqv",
				"default/sgp-cronjob-28574040-jbcdt",
				"default/sgp-cronjob-28574040-sp7rf",
				"default/sgp-cronjob-28574040-crrxd",
				"default/sgp-cronjob-28574040-gfj4v",
				"default/sgp-cronjob-28574040-nrhdg",
				"default/sgp-cronjob-28574040-wbftb",
				"default/sgp-cronjob-28574040-7kjg5",
				"default/sgp-cronjob-28573920-xfcq4",
				"default/sgp-cronjob-28573980-fds7l",
				"default/sgp-cronjob-28574040-2gbt6",
				"default/sgp-cronjob-28574040-6dkxv",
				"default/sgp-cronjob-28574040-hxsf9",
				"default/sgp-cronjob-28574040-npcdh",
				"default/sgp-cronjob-28574040-xc54l"
			]
		},
		"RunningPods": {
			"PodList": [
				"kube-system/kube-proxy-fwfhb",
				"default/sgp-cronjob-28574040-rplhd",
				"kube-system/aws-node-s2996",
				"default/sgp-cronjob-28574040-9mcqv"
			]
		}
	}

```
2. Added logs to debug the pod events received by the handler
```
{"level":"info","timestamp":"2024-04-23T19:00:00.291Z","logger":"controllers.Pod Reconciler.custom pod controller","msg":"processing item","objName":"sgp-cronjob-28564980-mvcbh","deltaType":"Updated"}
{"level":"info","timestamp":"2024-04-23T19:00:00.328Z","logger":"controllers.Pod Reconciler.custom pod controller","msg":"processing item","objName":"sgp-cronjob-28564980-cccxf","deltaType":"Added"}
{"level":"info","timestamp":"2024-04-29T11:15:05.384Z","logger":"controllers.Pod Reconciler.custom pod controller","msg":"processing item","objName":"sgp-cronjob-28573020-dbrcc","deltaType":"Deleted"}

{"level":"info","timestamp":"2024-04-29T15:14:16.420Z","logger":"controllers.Pod Reconciler.custom pod controller","msg":"deleting item","objName":"sgp-cronjob-28573200-ffvlk","namespace":"default"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
