### PR TITLE
Add CNINode integration tests in canary

### DIFF
--- a/scripts/test/run-canary-test.sh
+++ b/scripts/test/run-canary-test.sh
@@ -115,6 +115,7 @@ function run_canary_tests() {
     echo "skipping Windows tests"
   fi
   (CGO_ENABLED=0 ginkgo --no-color --focus="CANARY" $EXTRA_GINKGO_FLAGS -v --timeout 5m $GINKGO_TEST_BUILD_DIR/webhook.test -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID)
+  (CGO_ENABLED=0 ginkgo --no-color --focus="CANARY" $EXTRA_GINKGO_FLAGS -v --timeout 10m $GINKGO_TEST_BUILD_DIR/cninode.test -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID)
 }
 
 echo "Starting the ginkgo test suite"

--- a/scripts/test/run-integration-tests.sh
+++ b/scripts/test/run-integration-tests.sh
@@ -47,6 +47,7 @@ function run_integration_tests(){
     echo "skipping Windows tests"
   fi
   (cd $INTEGRATION_TEST_DIR/webhook && CGO_ENABLED=0 ginkgo --skip=LOCAL $EXTRA_GINKGO_FLAGS -v -timeout=5m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID) || TEST_RESULT=fail
+  (cd $INTEGRATION_TEST_DIR/cninode && CGO_ENABLED=0 ginkgo --skip=LOCAL $EXTRA_GINKGO_FLAGS -v -timeout=10m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID) || TEST_RESULT=fail
 
   if [[ "$TEST_RESULT" == fail ]]; then
       exit 1

--- a/test/integration/cninode/cninode_test.go
+++ b/test/integration/cninode/cninode_test.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-var _ = Describe("CNINode test", func() {
+var _ = Describe("[CANARY]CNINode test", func() {
 	Describe("CNINode count verification on adding or removing node", func() {
 		var oldMinSize int64
 		var oldMaxSize int64


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Run CNINode integration tests as part of the canary and full integration tests. 
```
Running Suite: CNINode Test Suite - /repository/vpc-resource-controller/build
Will run 6 of 6 specs
PASSED [0.000 seconds]
Ran 6 of 6 Specs in 490.177 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 8m10.198094891s
Test Suite Passed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
