### PR TITLE
Fix CNINodes integration test for internal testbed 

### DIFF
--- a/test/integration/cninode/cninode_test.go
+++ b/test/integration/cninode/cninode_test.go
@@ -44,6 +44,11 @@ var _ = Describe("[CANARY]CNINode test", func() {
 			Expect(err).ToNot(HaveOccurred())
 			oldMinSize = *asg[0].MinSize
 			oldMaxSize = *asg[0].MaxSize
+
+			// Keep atleast one instance running in the cluster when restoring the values in AfterEach
+			if oldMinSize == 0 {
+				oldMinSize = 1
+			}
 		})
 		AfterEach(func() {
 			By("restoring ASG minSize & maxSize after test")


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This ensures there is always a node running in the cluster while running the cni nodes integration suite

<img width="233" alt="image" src="https://github.com/aws/amazon-vpc-resource-controller-k8s/assets/23660509/e8145d56-524d-44e1-90bf-657d0c99884b">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
