### PR TITLE
Skipping health check on nodes if EC2 returns throttling errors

### DIFF
--- a/controllers/core/node_controller.go
+++ b/controllers/core/node_controller.go
@@ -168,6 +168,12 @@ func (r *NodeReconciler) Check() healthz.Checker {
 			return nil
 		}
 
+		if r.Manager.SkipHealthCheck() {
+			// node manager observes EC2 error on processing node, pausing reconciler check to avoid stressing the system
+			r.Log.Info("due to EC2 error, node controller skips node reconciler health check for now")
+			return nil
+		}
+
 		err := rcHealthz.PingWithTimeout(func(c chan<- error) {
 			// when the reconciler is ready, testing the reconciler with a fake node request
 			pingRequest := &ctrl.Request{

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/node/manager/mock_manager.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/node/manager/mock_manager.go
@@ -102,6 +102,20 @@ func (mr *MockManagerMockRecorder) GetNode(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockManager)(nil).GetNode), arg0)
 }
 
+// SkipHealthCheck mocks base method.
+func (m *MockManager) SkipHealthCheck() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SkipHealthCheck")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SkipHealthCheck indicates an expected call of SkipHealthCheck.
+func (mr *MockManagerMockRecorder) SkipHealthCheck() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SkipHealthCheck", reflect.TypeOf((*MockManager)(nil).SkipHealthCheck))
+}
+
 // UpdateNode mocks base method.
 func (m *MockManager) UpdateNode(arg0 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -57,6 +57,7 @@ type manager struct {
 	worker            asyncWorker.Worker
 	conditions        condition.Conditions
 	controllerVersion string
+	stopHealthCheckAt time.Time
 }
 
 // Manager to perform operation on list of managed/un-managed node
@@ -66,6 +67,7 @@ type Manager interface {
 	UpdateNode(nodeName string) error
 	DeleteNode(nodeName string) error
 	CheckNodeForLeakedENIs(nodeName string)
+	SkipHealthCheck() bool
 }
 
 // AsyncOperation is operation on a node after the lock has been released.
@@ -95,6 +97,8 @@ type AsyncOperationJob struct {
 	node     node.Node
 	nodeName string
 }
+
+const pausingHealthCheckDuration = 30 * time.Minute
 
 // NewNodeManager returns a new node manager
 func NewNodeManager(logger logr.Logger, resourceManager resource.ResourceManager,
@@ -425,6 +429,10 @@ func (m *manager) performAsyncOperation(job interface{}) (ctrl.Result, error) {
 		utils.SendNodeEventWithNodeName(m.wrapper.K8sAPI, asyncJob.nodeName, utils.VersionNotice, fmt.Sprintf("The node is managed by VPC resource controller version %s", m.controllerVersion), v1.EventTypeNormal, m.Log)
 		err = asyncJob.node.InitResources(m.resourceManager)
 		if err != nil {
+			if pauseHealthCheckOnError(err) {
+				m.setStopHealthCheck()
+				log.Info("node manager sets a pause on health check due to observing a EC2 error", "error", err.Error())
+			}
 			log.Error(err, "removing the node from cache as it failed to initialize")
 			m.removeNodeSafe(asyncJob.nodeName)
 			// if initializing node failed, we want to make this visible although the manager will retry
@@ -565,12 +573,36 @@ func (m *manager) check() healthz.Checker {
 			randomName := uuid.New().String()
 			_, found := m.GetNode(randomName)
 			m.Log.V(1).Info("health check tested ping GetNode to check on datastore cache in node manager successfully", "TesedNodeName", randomName, "NodeFound", found)
-			var ping interface{}
-			m.worker.SubmitJob(ping)
-			m.Log.V(1).Info("health check tested ping SubmitJob with a nil job to check on worker queue in node manager successfully")
+			if m.SkipHealthCheck() {
+				m.Log.Info("due to EC2 error, node manager skips node worker queue health check for now")
+			} else {
+				var ping interface{}
+				m.worker.SubmitJob(ping)
+				m.Log.V(1).Info("health check tested ping SubmitJob with a nil job to check on worker queue in node manager successfully")
+			}
 			c <- nil
 		}, m.Log)
 
 		return err
 	}
+}
+
+func (m *manager) SkipHealthCheck() bool {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	return time.Since(m.stopHealthCheckAt) < pausingHealthCheckDuration
+}
+
+func (m *manager) setStopHealthCheck() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.stopHealthCheckAt = time.Now()
+}
+
+func pauseHealthCheckOnError(err error) bool {
+	return lo.ContainsBy(utils.PauseHealthCheckErrors, func(e string) bool {
+		return strings.Contains(err.Error(), e)
+	})
 }

--- a/pkg/utils/errors.go
+++ b/pkg/utils/errors.go
@@ -23,6 +23,7 @@ var (
 	ErrInsufficientCidrBlocks     = errors.New("InsufficientCidrBlocks: The specified subnet does not have enough free cidr blocks to satisfy the request")
 	ErrMsgProviderAndPoolNotFound = "cannot find the instance provider and pool from the cache"
 	NotRetryErrors                = []string{InsufficientCidrBlocksReason}
+	PauseHealthCheckErrors        = []string{"RequestLimitExceeded"}
 )
 
 // ShouldRetryOnError returns true if the error is retryable, else returns false


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update key dependencies including apimachinery, client-go, and controller-runtime versions.

The changes have been tested locally and passed integration tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
