### PR TITLE
QPS and busrt adjustment

### DIFF
--- a/controllers/core/pod_controller.go
+++ b/controllers/core/pod_controller.go
@@ -56,7 +56,7 @@ type PodReconciler struct {
 
 var (
 	PodRequeueRequest          = ctrl.Result{Requeue: true, RequeueAfter: time.Second}
-	MaxPodConcurrentReconciles = 10
+	MaxPodConcurrentReconciles = 20
 )
 
 // Reconcile handles create/update/delete event by delegating the request to the  handler

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -49,15 +49,16 @@ const (
 	// Tested: 12 + 8 limits (not seeing significant degradation from 15+8)
 	// Larger number seems not make latency better than 12+8
 	UserServiceClientQPS      = 12
-	UserServiceClientQPSBurst = 8
+	UserServiceClientQPSBurst = 18
 
 	// EC2 API QPS for instance service client
-	InstanceServiceClientQPS   = 5
-	InstanceServiceClientBurst = 7
+	InstanceServiceClientQPS   = 12
+	InstanceServiceClientBurst = 18
 
 	// API Server QPS
-	DefaultAPIServerQPS   = 10
-	DefaultAPIServerBurst = 15
+	// Use the same values as default client (https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/client/config/config.go#L85)
+	DefaultAPIServerQPS   = 20
+	DefaultAPIServerBurst = 30
 )
 
 // LoadResourceConfig returns the Resource Configuration for all resources managed by the VPC Resource Controller. Currently


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- The burst is incorrectly set and qps is capped to smaller number. 
- We should use the same rate limiting for related API calls.
- Update the kubernetes client qps and burst to be same as controller-runtime default values.
- Double the pod reconciler workers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
