### PR TITLE
Add Windows secondary IP mode configurable options for managing IP address allocation

### DIFF
--- a/docs/windows/secondary_ip_mode_config_options.md
+++ b/docs/windows/secondary_ip_mode_config_options.md
@@ -1,0 +1,63 @@
+# Configuration options when using secondary IP addresses Windows
+
+We provide multiple configuration options that allow you to fine-tune the IP address allocation behavior on Windows
+nodes using the secondary IP address mode. These configuration options can be set in the `amazon-vpc-cni` ConfigMap in
+the `kube-system` namespace.
+
+- `windows-warm-ip-target` → The total number of IP addresses that should be allocated to each Windows node in excess of
+  the current need at any given time. The excess IPs can be used by newly launched pods, which aids in faster pod
+  startup times since there is no wait time for additional IP addresses to be allocated. The VPC Resource Controller
+  will attempt to ensure that this excess desired threshold is always met.
+
+  Defaults to 3 if unspecified or invalid. Must be greater than or equal to 1.
+
+  For example, if no pods were running on a given Windows node, and if you set `windows-warm-ip-target` to 5, the VPC
+  Resource Controller will aim to ensure that each Windows node always has at least 5 IP addresses in excess, ready for
+  use, allocated to its ENI. If 2 pods are scheduled on the node, the controller will allocate 2 additional IP addresses
+  to the ENI, maintaining the 5 warm IP address target.
+
+- `windows-minimum-ip-target` → Defaults to 3 if unspecified or invalid. The minimum number of IP addresses, both in use
+  by running pods and available as warm IPs, that should be allocated to each Windows node at any given time. The
+  controller will attempt to ensure that this minimum threshold is always met.
+
+  Defaults to 3 if unspecified or invalid. Must be greater than or equal to 0.
+
+  For example, if no pods were running on a given Windows node, and if you set `windows-minimum-ip-target` to 10, the
+  VPC Resource Controller will aim to ensure that the total number of IP addresses on the Windows node should be at
+  least 10. Therefore, before pods are scheduled, there should be at least 10 IP addresses available. If 5 pods are
+  scheduled on a given node, they will consume 5 of the 10 available IPs. The VPC Resource Controller will keep 5 the
+  remaining available IPs available in addition to the 5 already in use to meet the target of 10.
+
+### Considerations while using the above configuration options
+
+- These configuration options only apply when the VPC Resource Controller is operating in the secondary IP mode. They do
+  not affect the prefix delegation mode. More explicitly, if `enable-windows-prefix-delegation` is set to false, or is
+  not specified, then the VPC Resource Controller operates in secondary IP mode.
+- Setting either `windows-warm-ip-target` or `windows-minimum-ip-target` to a negative value will result in the
+  respective default value being used.
+- If the values of `windows-warm-ip-target` or `windows-minimum-ip-target` are set such that the maximum node IP
+  capacity would be exceeded, the controller will limit the allocation to the maximum capacity possible.
+- The `warm-prefix-target` configuration option will be ignored when using the secondary IP mode, as it only applies to
+  the prefix delegation mode.
+- If `windows-warm-ip-target` is set to 0, the system will implicitly set `windows-warm-ip-target` to 1. This is
+  because on-demand IP allocation whereby an IP is allocated on the Windows node as the pods are scheduled is currently
+  not supported. Implicitly Setting `windows-warm-ip-target` to 1 ensures the minimum acceptable non-zero value is set
+  since the `windows-warm-ip-target` should always be at least 1.
+- The configuration options `warm-ip-target` and `minimum-ip-target` are deprecated in favor of the new
+  options `windows-warm-ip-target` and `windows-minimum-ip-target`.
+
+### Examples
+
+| `windows-warm-ip-target` | `windows-minimum-ip-target` | Running Pods | Total Allocated IPs | Warm IPs |
+|--------------------------|-----------------------------|--------------|---------------------|----------|
+| 1                        | 0                           | 0            | 1                   | 1        |
+| 1                        | 0                           | 5            | 6                   | 1        |
+| 5                        | 0                           | 0            | 5                   | 5        |
+| 1                        | 1                           | 0            | 1                   | 1        |
+| 1                        | 1                           | 1            | 2                   | 1        |
+| 1                        | 3                           | 3            | 4                   | 1        |
+| 1                        | 3                           | 5            | 6                   | 1        |
+| 5                        | 10                          | 0            | 10                  | 10       |
+| 10                       | 10                          | 0            | 10                  | 10       |
+| 10                       | 10                          | 10           | 20                  | 10       |
+| 15                       | 10                          | 10           | 25                  | 15       |

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -97,7 +97,7 @@ func ParseWinIPTargetConfigs(log logr.Logger, vpcCniConfigMap *v1.ConfigMap) (wa
 	if vpcCniConfigMap.Data == nil {
 		warmIPTarget = IPv4DefaultWinWarmIPTarget
 		minIPTarget = IPv4DefaultWinMinIPTarget
-		log.V(1).Info(
+		log.Info(
 			"No ConfigMap data found, falling back to using default values",
 			"minIPTarget", minIPTarget,
 			"warmIPTarget", warmIPTarget,
@@ -126,46 +126,36 @@ func ParseWinIPTargetConfigs(log logr.Logger, vpcCniConfigMap *v1.ConfigMap) (wa
 
 	// If warm IP target config value is not found, or there is an error parsing it, the value will be set to zero
 	if foundWarmIP {
-		warmIPTargetInt, err := strconv.Atoi(warmIPTargetStr)
+		warmIPTarget, err = strconv.Atoi(warmIPTargetStr)
 		if err != nil {
 			log.Info("Could not parse warm ip target, defaulting to zero", "warm ip target", warmIPTargetStr)
-			warmIPTarget = 0
-		} else {
-			warmIPTarget = warmIPTargetInt
-
+		} else if !isPDEnabled && warmIPTarget == 0 {
 			// Handle secondary IP mode scenario where WarmIPTarget is explicitly configured to zero
 			// In such a case there must always be 1 warm IP to ensure that the warmpool is never empty
-			if !isPDEnabled && warmIPTarget == 0 {
-				log.V(1).Info("Explicitly setting WarmIPTarget zero value not supported in secondary IP mode, will override with 1")
-				warmIPTarget = 1
-			}
+			log.Info("Explicitly setting WarmIPTarget zero value not supported in secondary IP mode, will override with 1")
+			warmIPTarget = 1
 		}
 	} else {
-		log.V(1).Info("could not find warm ip target in ConfigMap, defaulting to zero")
+		log.Info("could not find warm ip target in ConfigMap, defaulting to zero")
 		warmIPTarget = 0
 	}
 
 	// If min IP target config value is not found, or there is an error parsing it, the value will be set to zero
 	if foundMinIP {
-		minIPTargetInt, err := strconv.Atoi(minIPTargetStr)
+		minIPTarget, err = strconv.Atoi(minIPTargetStr)
 		if err != nil {
 			log.Info("Could not parse minimum ip target, defaulting to zero", "minimum ip target", minIPTargetStr)
-			minIPTarget = 0
-		} else {
-			minIPTarget = minIPTargetInt
 		}
 	} else {
-		log.V(1).Info("could not find minimum ip target in ConfigMap, defaulting to zero")
+		log.Info("could not find minimum ip target in ConfigMap, defaulting to zero")
 		minIPTarget = 0
 	}
 
 	warmPrefixTarget = 0
 	if isPDEnabled && foundWarmPrefix {
-		warmPrefixTargetInt, err := strconv.Atoi(warmPrefixTargetStr)
+		warmPrefixTarget, err = strconv.Atoi(warmPrefixTargetStr)
 		if err != nil {
 			log.Info("Could not parse warm prefix target, defaulting to zero", "warm prefix target", warmPrefixTargetStr)
-		} else {
-			warmPrefixTarget = warmPrefixTargetInt
 		}
 	}
 
@@ -178,7 +168,7 @@ func ParseWinIPTargetConfigs(log logr.Logger, vpcCniConfigMap *v1.ConfigMap) (wa
 			minIPTarget = IPv4DefaultWinMinIPTarget
 			warmIPTarget = IPv4DefaultWinWarmIPTarget
 		}
-		log.V(1).Info(
+		log.Info(
 			"Encountered zero values for warm-ip-target, min-ip-target and warm-prefix-target in ConfigMap data, falling back to using default values since on demand IP allocation is not supported",
 			"minIPTarget", minIPTarget,
 			"warmIPTarget", warmIPTarget,

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -28,13 +28,14 @@ const (
 	// Default Configuration for Pod ENI resource type
 	PodENIDefaultWorker = 30
 
-	// Default Configuration for IPv4 resource type
-	IPv4DefaultWorker  = 2
-	IPv4DefaultWPSize  = 3
-	IPv4DefaultMaxDev  = 1
-	IPv4DefaultResSize = 0
+	// Default Windows Configuration for IPv4 resource type
+	IPv4DefaultWinWorkerCount  = 2
+	IPv4DefaultWinWarmIPTarget = 3
+	IPv4DefaultWinMinIPTarget  = 3
+	IPv4DefaultWinMaxDev       = 0
+	IPv4DefaultWinResSize      = 0
 
-	// Default Configuration for IPv4 prefix resource type
+	// Default Windows Configuration for IPv4 prefix resource type
 	IPv4PDDefaultWorker               = 2
 	IPv4PDDefaultWPSize               = 1
 	IPv4PDDefaultMaxDev               = 0
@@ -70,26 +71,44 @@ func LoadResourceConfig() map[string]ResourceConfig {
 func LoadResourceConfigFromConfigMap(log logr.Logger, vpcCniConfigMap *v1.ConfigMap) map[string]ResourceConfig {
 	resourceConfig := getDefaultResourceConfig()
 
-	warmIPTarget, minIPTarget, warmPrefixTarget := ParseWinPDTargets(log, vpcCniConfigMap)
+	warmIPTarget, minIPTarget, warmPrefixTarget, isPDEnabled := ParseWinIPTargetConfigs(log, vpcCniConfigMap)
 
 	// If no PD configuration is set in configMap or none is valid, return default resource config
 	if warmIPTarget == 0 && minIPTarget == 0 && warmPrefixTarget == 0 {
 		return resourceConfig
 	}
 
-	resourceConfig[ResourceNameIPAddressFromPrefix].WarmPoolConfig.WarmIPTarget = warmIPTarget
-	resourceConfig[ResourceNameIPAddressFromPrefix].WarmPoolConfig.MinIPTarget = minIPTarget
-	resourceConfig[ResourceNameIPAddressFromPrefix].WarmPoolConfig.WarmPrefixTarget = warmPrefixTarget
+	if isPDEnabled {
+		resourceConfig[ResourceNameIPAddressFromPrefix].WarmPoolConfig.WarmIPTarget = warmIPTarget
+		resourceConfig[ResourceNameIPAddressFromPrefix].WarmPoolConfig.MinIPTarget = minIPTarget
+		resourceConfig[ResourceNameIPAddressFromPrefix].WarmPoolConfig.WarmPrefixTarget = warmPrefixTarget
+	} else {
+		resourceConfig[ResourceNameIPAddress].WarmPoolConfig.WarmIPTarget = warmIPTarget
+		resourceConfig[ResourceNameIPAddress].WarmPoolConfig.MinIPTarget = minIPTarget
+	}
 
 	return resourceConfig
 }
 
-// ParseWinPDTargets parses config map for Windows prefix delegation configurations set by users
-func ParseWinPDTargets(log logr.Logger, vpcCniConfigMap *v1.ConfigMap) (warmIPTarget int, minIPTarget int, warmPrefixTarget int) {
-	warmIPTarget, minIPTarget, warmPrefixTarget = 0, 0, 0
-
+// ParseWinIPTargetConfigs parses Windows IP target configuration parameters in the amazon-vpc-cni ConfigMap
+// If all three config parameter values (warm-ip-target, min-ip-target, warm-prefix-target) are 0 or unset, or config map does not exist,
+// then default values for warm-ip-target and min-ip-target will be set.
+func ParseWinIPTargetConfigs(log logr.Logger, vpcCniConfigMap *v1.ConfigMap) (warmIPTarget int, minIPTarget int, warmPrefixTarget int, isPDEnabled bool) {
 	if vpcCniConfigMap.Data == nil {
-		return warmIPTarget, minIPTarget, warmPrefixTarget
+		warmIPTarget = IPv4DefaultWinWarmIPTarget
+		minIPTarget = IPv4DefaultWinMinIPTarget
+		log.V(1).Info(
+			"No ConfigMap data found, falling back to using default values",
+			"minIPTarget", minIPTarget,
+			"warmIPTarget", warmIPTarget,
+		)
+		return warmIPTarget, minIPTarget, 0, false
+	}
+
+	isPDEnabled, err := strconv.ParseBool(vpcCniConfigMap.Data[EnableWindowsPrefixDelegationKey])
+	if err != nil {
+		log.Info("Could not parse prefix delegation flag from ConfigMap, falling back to using secondary IP mode")
+		isPDEnabled = false
 	}
 
 	warmIPTargetStr, foundWarmIP := vpcCniConfigMap.Data[WarmIPTarget]
@@ -105,36 +124,70 @@ func ParseWinPDTargets(log logr.Logger, vpcCniConfigMap *v1.ConfigMap) (warmIPTa
 		warmPrefixTargetStr, foundWarmPrefix = vpcCniConfigMap.Data[WinWarmPrefixTarget]
 	}
 
-	// If no configuration is found, return 0
-	if !foundWarmIP && !foundMinIP && !foundWarmPrefix {
-		return warmIPTarget, minIPTarget, warmPrefixTarget
-	}
-
+	// If warm IP target config value is not found, or there is an error parsing it, the value will be set to zero
 	if foundWarmIP {
 		warmIPTargetInt, err := strconv.Atoi(warmIPTargetStr)
 		if err != nil {
-			log.Error(err, "failed to parse warm ip target", "warm ip target", warmIPTargetStr)
+			log.Info("Could not parse warm ip target, defaulting to zero", "warm ip target", warmIPTargetStr)
+			warmIPTarget = 0
 		} else {
 			warmIPTarget = warmIPTargetInt
+
+			// Handle secondary IP mode scenario where WarmIPTarget is explicitly configured to zero
+			// In such a case there must always be 1 warm IP to ensure that the warmpool is never empty
+			if !isPDEnabled && warmIPTarget == 0 {
+				log.V(1).Info("Explicitly setting WarmIPTarget zero value not supported in secondary IP mode, will override with 1")
+				warmIPTarget = 1
+			}
 		}
+	} else {
+		log.V(1).Info("could not find warm ip target in ConfigMap, defaulting to zero")
+		warmIPTarget = 0
 	}
+
+	// If min IP target config value is not found, or there is an error parsing it, the value will be set to zero
 	if foundMinIP {
 		minIPTargetInt, err := strconv.Atoi(minIPTargetStr)
 		if err != nil {
-			log.Error(err, "failed to parse minimum ip target", "minimum ip target", minIPTargetStr)
+			log.Info("Could not parse minimum ip target, defaulting to zero", "minimum ip target", minIPTargetStr)
+			minIPTarget = 0
 		} else {
 			minIPTarget = minIPTargetInt
 		}
+	} else {
+		log.V(1).Info("could not find minimum ip target in ConfigMap, defaulting to zero")
+		minIPTarget = 0
 	}
-	if foundWarmPrefix {
+
+	warmPrefixTarget = 0
+	if isPDEnabled && foundWarmPrefix {
 		warmPrefixTargetInt, err := strconv.Atoi(warmPrefixTargetStr)
 		if err != nil {
-			log.Error(err, "failed to parse warm prefix target", "warm prefix target", warmPrefixTargetStr)
+			log.Info("Could not parse warm prefix target, defaulting to zero", "warm prefix target", warmPrefixTargetStr)
 		} else {
 			warmPrefixTarget = warmPrefixTargetInt
 		}
 	}
-	return warmIPTarget, minIPTarget, warmPrefixTarget
+
+	if warmIPTarget == 0 && minIPTarget == 0 {
+		if isPDEnabled && warmPrefixTarget == 0 {
+			minIPTarget = IPv4PDDefaultMinIPTargetSize
+			warmIPTarget = IPv4PDDefaultWarmIPTargetSize
+			warmPrefixTarget = IPv4PDDefaultWarmPrefixTargetSize
+		} else if !isPDEnabled {
+			minIPTarget = IPv4DefaultWinMinIPTarget
+			warmIPTarget = IPv4DefaultWinWarmIPTarget
+		}
+		log.V(1).Info(
+			"Encountered zero values for warm-ip-target, min-ip-target and warm-prefix-target in ConfigMap data, falling back to using default values since on demand IP allocation is not supported",
+			"minIPTarget", minIPTarget,
+			"warmIPTarget", warmIPTarget,
+			"warmPrefixTarget", warmPrefixTarget,
+			"isPDEnabled", isPDEnabled,
+		)
+	}
+
+	return warmIPTarget, minIPTarget, warmPrefixTarget, isPDEnabled
 }
 
 // getDefaultResourceConfig returns the default Resource Configuration.
@@ -153,13 +206,15 @@ func getDefaultResourceConfig() map[string]ResourceConfig {
 
 	// Create default configuration for IPv4 Resource
 	ipV4WarmPoolConfig := WarmPoolConfig{
-		DesiredSize:  IPv4DefaultWPSize,
-		MaxDeviation: IPv4DefaultMaxDev,
-		ReservedSize: IPv4DefaultResSize,
+		DesiredSize:  IPv4DefaultWinWarmIPTarget,
+		WarmIPTarget: IPv4DefaultWinWarmIPTarget,
+		MinIPTarget:  IPv4DefaultWinMinIPTarget,
+		MaxDeviation: IPv4DefaultWinMaxDev,
+		ReservedSize: IPv4DefaultWinResSize,
 	}
 	ipV4Config := ResourceConfig{
 		Name:           ResourceNameIPAddress,
-		WorkerCount:    IPv4DefaultWorker,
+		WorkerCount:    IPv4DefaultWinWorkerCount,
 		SupportedOS:    map[string]bool{OSWindows: true, OSLinux: false},
 		WarmPoolConfig: &ipV4WarmPoolConfig,
 	}

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -155,6 +155,7 @@ type ResourceConfig struct {
 
 // WarmPoolConfig is the configuration of Warm Pool of a resource
 type WarmPoolConfig struct {
+	// TODO: Deprecate DesiredSize in favour of using WarmIPTarget since historically they served the same purpose
 	// Number of resources to keep in warm pool per node; for prefix IP pool, this is used to check if pool is active
 	DesiredSize int
 	// Number of resources not to use in the warm pool

--- a/pkg/pool/utils.go
+++ b/pkg/pool/utils.go
@@ -1,0 +1,39 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package pool
+
+import (
+	"github.com/go-logr/logr"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/api"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+)
+
+// GetWinWarmPoolConfig retrieves Windows warmpool configuration from ConfigMap, falls back to using default values on failure
+func GetWinWarmPoolConfig(log logr.Logger, w api.Wrapper, isPDEnabled bool) *config.WarmPoolConfig {
+	var resourceConfig map[string]config.ResourceConfig
+	vpcCniConfigMap, err := w.K8sAPI.GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace)
+	if err == nil {
+		resourceConfig = config.LoadResourceConfigFromConfigMap(log, vpcCniConfigMap)
+	} else {
+		log.Error(err, "failed to read from config map, will use default resource config")
+		resourceConfig = config.LoadResourceConfig()
+	}
+
+	if isPDEnabled {
+		return resourceConfig[config.ResourceNameIPAddressFromPrefix].WarmPoolConfig
+	} else {
+		return resourceConfig[config.ResourceNameIPAddress].WarmPoolConfig
+	}
+}

--- a/pkg/pool/utils_test.go
+++ b/pkg/pool/utils_test.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package provider
+package pool
 
 import (
 	"fmt"

--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/api"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/vpc"
@@ -33,7 +35,6 @@ import (
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/branch/trunk"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/utils"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/worker"
-	"github.com/google/uuid"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/go-logr/logr"

--- a/pkg/provider/ip/provider.go
+++ b/pkg/provider/ip/provider.go
@@ -153,9 +153,11 @@ func (p *ipv4Provider) InitResource(instance ec2.EC2Instance) error {
 	// Expected node capacity based on instance type in secondary IP mode
 	nodeCapacity := getCapacity(instance.Type(), instance.Os())
 
+	isPDEnabled := p.conditions.IsWindowsPrefixDelegationEnabled()
+	p.config = provider.GetWinWarmPoolConfig(p.log, p.apiWrapper, isPDEnabled)
+
 	// Set warm pool config to empty config if PD is enabled
 	secondaryIPWPConfig := p.config
-	isPDEnabled := p.conditions.IsWindowsPrefixDelegationEnabled()
 	if isPDEnabled {
 		secondaryIPWPConfig = &config.WarmPoolConfig{}
 	} else {
@@ -238,6 +240,8 @@ func (p *ipv4Provider) UpdateResourceCapacity(instance ec2.EC2Instance) error {
 	}
 
 	resourceProviderAndPool.isPrevPDEnabled = false
+
+	p.config = provider.GetWinWarmPoolConfig(p.log, p.apiWrapper, isCurrPDEnabled && isNitroInstance)
 
 	// Set the secondary IP provider pool state to active
 	job := resourceProviderAndPool.resourcePool.SetToActive(p.config)

--- a/pkg/provider/ip/provider.go
+++ b/pkg/provider/ip/provider.go
@@ -154,7 +154,7 @@ func (p *ipv4Provider) InitResource(instance ec2.EC2Instance) error {
 	nodeCapacity := getCapacity(instance.Type(), instance.Os())
 
 	isPDEnabled := p.conditions.IsWindowsPrefixDelegationEnabled()
-	p.config = provider.GetWinWarmPoolConfig(p.log, p.apiWrapper, isPDEnabled)
+	p.config = pool.GetWinWarmPoolConfig(p.log, p.apiWrapper, isPDEnabled)
 
 	// Set warm pool config to empty config if PD is enabled
 	secondaryIPWPConfig := p.config
@@ -241,7 +241,7 @@ func (p *ipv4Provider) UpdateResourceCapacity(instance ec2.EC2Instance) error {
 
 	resourceProviderAndPool.isPrevPDEnabled = false
 
-	p.config = provider.GetWinWarmPoolConfig(p.log, p.apiWrapper, isCurrPDEnabled && isNitroInstance)
+	p.config = pool.GetWinWarmPoolConfig(p.log, p.apiWrapper, isCurrPDEnabled && isNitroInstance)
 
 	// Set the secondary IP provider pool state to active
 	job := resourceProviderAndPool.resourcePool.SetToActive(p.config)

--- a/pkg/provider/prefix/provider.go
+++ b/pkg/provider/prefix/provider.go
@@ -156,7 +156,7 @@ func (p *ipv4PrefixProvider) InitResource(instance ec2.EC2Instance) error {
 	nodeCapacity := getCapacity(instance.Type(), instance.Os()) * pool.NumIPv4AddrPerPrefix
 
 	isPDEnabled := p.conditions.IsWindowsPrefixDelegationEnabled()
-	p.config = provider.GetWinWarmPoolConfig(p.log, p.apiWrapper, isPDEnabled)
+	p.config = pool.GetWinWarmPoolConfig(p.log, p.apiWrapper, isPDEnabled)
 
 	// Set warm pool config to empty if PD is not enabled
 	prefixIPWPConfig := p.config
@@ -234,7 +234,7 @@ func (p *ipv4PrefixProvider) UpdateResourceCapacity(instance ec2.EC2Instance) er
 
 	resourceProviderAndPool.isPrevPDEnabled = true
 
-	warmPoolConfig := provider.GetWinWarmPoolConfig(p.log, p.apiWrapper, isCurrPDEnabled)
+	warmPoolConfig := pool.GetWinWarmPoolConfig(p.log, p.apiWrapper, isCurrPDEnabled)
 
 	// Set the secondary IP provider pool state to active
 	job := resourceProviderAndPool.resourcePool.SetToActive(warmPoolConfig)

--- a/pkg/provider/prefix/provider.go
+++ b/pkg/provider/prefix/provider.go
@@ -155,11 +155,11 @@ func (p *ipv4PrefixProvider) InitResource(instance ec2.EC2Instance) error {
 	// Expected node capacity based on instance type in PD mode
 	nodeCapacity := getCapacity(instance.Type(), instance.Os()) * pool.NumIPv4AddrPerPrefix
 
-	p.config = p.getPDWarmPoolConfig()
+	isPDEnabled := p.conditions.IsWindowsPrefixDelegationEnabled()
+	p.config = provider.GetWinWarmPoolConfig(p.log, p.apiWrapper, isPDEnabled)
 
 	// Set warm pool config to empty if PD is not enabled
 	prefixIPWPConfig := p.config
-	isPDEnabled := p.conditions.IsWindowsPrefixDelegationEnabled()
 	if !isPDEnabled {
 		prefixIPWPConfig = &config.WarmPoolConfig{}
 	} else {
@@ -234,7 +234,7 @@ func (p *ipv4PrefixProvider) UpdateResourceCapacity(instance ec2.EC2Instance) er
 
 	resourceProviderAndPool.isPrevPDEnabled = true
 
-	warmPoolConfig := p.getPDWarmPoolConfig()
+	warmPoolConfig := provider.GetWinWarmPoolConfig(p.log, p.apiWrapper, isCurrPDEnabled)
 
 	// Set the secondary IP provider pool state to active
 	job := resourceProviderAndPool.resourcePool.SetToActive(warmPoolConfig)
@@ -506,19 +506,6 @@ func getCapacity(instanceType string, instanceOs string) int {
 	}
 
 	return capacity
-}
-
-// Retrieve dynamic configuration for prefix delegation from config map, else use default warm pool config
-func (p *ipv4PrefixProvider) getPDWarmPoolConfig() *config.WarmPoolConfig {
-	var resourceConfig map[string]config.ResourceConfig
-	vpcCniConfigMap, err := p.apiWrapper.K8sAPI.GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace)
-	if err == nil {
-		resourceConfig = config.LoadResourceConfigFromConfigMap(p.log, vpcCniConfigMap)
-	} else {
-		p.log.Error(err, "failed to read from config map, will use default resource config")
-		resourceConfig = config.LoadResourceConfig()
-	}
-	return resourceConfig[config.ResourceNameIPAddressFromPrefix].WarmPoolConfig
 }
 
 func (p *ipv4PrefixProvider) check() healthz.Checker {

--- a/pkg/provider/prefix/provider_test.go
+++ b/pkg/provider/prefix/provider_test.go
@@ -19,6 +19,8 @@ import (
 	"strconv"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	mock_ec2 "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2"
 	mock_condition "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/condition"
 	mock_k8s "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s"
@@ -31,7 +33,6 @@ import (
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/ip/eni"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/utils"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/worker"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -541,24 +542,6 @@ func TestIpv4PrefixProvider_Introspect(t *testing.T) {
 func getMockIPv4PrefixProvider() ipv4PrefixProvider {
 	return ipv4PrefixProvider{instanceProviderAndPool: map[string]*ResourceProviderAndPool{},
 		log: zap.New(zap.UseDevMode(true)).WithName("prefix provider")}
-}
-
-func TestGetPDWarmPoolConfig(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockK8sWrapper := mock_k8s.NewMockK8sWrapper(ctrl)
-	mockConditions := mock_condition.NewMockConditions(ctrl)
-	prefixProvider := ipv4PrefixProvider{apiWrapper: api.Wrapper{K8sAPI: mockK8sWrapper},
-		instanceProviderAndPool: map[string]*ResourceProviderAndPool{},
-		log:                     zap.New(zap.UseDevMode(true)).WithName("prefix provider"), conditions: mockConditions}
-
-	for _, c := range []*v1.ConfigMap{vpcCNIConfig, vpcCNIConfigWindows} {
-		mockK8sWrapper.EXPECT().GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace).Return(c, nil)
-
-		config := prefixProvider.getPDWarmPoolConfig()
-		assert.Equal(t, pdWarmPoolConfig, config)
-	}
 }
 
 // TestIsInstanceSupported tests that if the instance type is nitro, return true

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -14,10 +14,14 @@
 package provider
 
 import (
-	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2"
-	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/pool"
+	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/api"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/pool"
 )
 
 // ResourceProvider is the provider interface that each resource managed by the controller has to implement
@@ -45,4 +49,22 @@ type ResourceProvider interface {
 	// IntrospectSummary allows introspection of resources summary per node
 	IntrospectSummary() interface{}
 	ReconcileNode(nodeName string) bool
+}
+
+// GetWinWarmPoolConfig retrieves Windows warmpool configuration from ConfigMap, falls back to using default values on failure
+func GetWinWarmPoolConfig(log logr.Logger, w api.Wrapper, isPDEnabled bool) *config.WarmPoolConfig {
+	var resourceConfig map[string]config.ResourceConfig
+	vpcCniConfigMap, err := w.K8sAPI.GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace)
+	if err == nil {
+		resourceConfig = config.LoadResourceConfigFromConfigMap(log, vpcCniConfigMap)
+	} else {
+		log.Error(err, "failed to read from config map, will use default resource config")
+		resourceConfig = config.LoadResourceConfig()
+	}
+
+	if isPDEnabled {
+		return resourceConfig[config.ResourceNameIPAddressFromPrefix].WarmPoolConfig
+	} else {
+		return resourceConfig[config.ResourceNameIPAddress].WarmPoolConfig
+	}
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -14,13 +14,10 @@
 package provider
 
 import (
-	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
-	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/api"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2"
-	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/pool"
 )
 
@@ -49,22 +46,4 @@ type ResourceProvider interface {
 	// IntrospectSummary allows introspection of resources summary per node
 	IntrospectSummary() interface{}
 	ReconcileNode(nodeName string) bool
-}
-
-// GetWinWarmPoolConfig retrieves Windows warmpool configuration from ConfigMap, falls back to using default values on failure
-func GetWinWarmPoolConfig(log logr.Logger, w api.Wrapper, isPDEnabled bool) *config.WarmPoolConfig {
-	var resourceConfig map[string]config.ResourceConfig
-	vpcCniConfigMap, err := w.K8sAPI.GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace)
-	if err == nil {
-		resourceConfig = config.LoadResourceConfigFromConfigMap(log, vpcCniConfigMap)
-	} else {
-		log.Error(err, "failed to read from config map, will use default resource config")
-		resourceConfig = config.LoadResourceConfig()
-	}
-
-	if isPDEnabled {
-		return resourceConfig[config.ResourceNameIPAddressFromPrefix].WarmPoolConfig
-	} else {
-		return resourceConfig[config.ResourceNameIPAddress].WarmPoolConfig
-	}
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,0 +1,112 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package provider
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	mock_k8s "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/api"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+)
+
+func TestGetWinWarmPoolConfig_PDDisabledAndAPICallSuccess_ReturnsConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	log := zap.New(zap.UseDevMode(true)).WithName("provider test")
+
+	configMapToReturn := &v1.ConfigMap{
+		Data: map[string]string{
+			config.EnableWindowsIPAMKey:             "true",
+			config.EnableWindowsPrefixDelegationKey: "true",
+			config.WinWarmIPTarget:                  strconv.Itoa(config.IPv4DefaultWinWarmIPTarget),
+			config.WinMinimumIPTarget:               strconv.Itoa(config.IPv4DefaultWinMinIPTarget),
+		},
+	}
+	expectedWarmPoolConfig := &config.WarmPoolConfig{
+		WarmIPTarget: config.IPv4DefaultWinWarmIPTarget,
+		MinIPTarget:  config.IPv4DefaultWinMinIPTarget,
+		DesiredSize:  config.IPv4DefaultWinWarmIPTarget,
+	}
+
+	mockK8sWrapper := mock_k8s.NewMockK8sWrapper(ctrl)
+	mockK8sWrapper.EXPECT().GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace).Return(configMapToReturn, nil)
+	apiWrapperMock := api.Wrapper{K8sAPI: mockK8sWrapper}
+
+	actualWarmPoolConfig := GetWinWarmPoolConfig(log, apiWrapperMock, false)
+	assert.Equal(t, expectedWarmPoolConfig, actualWarmPoolConfig)
+}
+
+func TestGetWinWarmPoolConfig_PDEnabledAndAPICallSuccess_ReturnsConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	log := zap.New(zap.UseDevMode(true)).WithName("provider test")
+
+	configMapToReturn := &v1.ConfigMap{
+		Data: map[string]string{
+			config.EnableWindowsIPAMKey:             "true",
+			config.EnableWindowsPrefixDelegationKey: "true",
+			config.WinWarmIPTarget:                  strconv.Itoa(config.IPv4PDDefaultWarmIPTargetSize),
+			config.WinWarmPrefixTarget:              strconv.Itoa(config.IPv4PDDefaultWarmPrefixTargetSize),
+			config.WinMinimumIPTarget:               strconv.Itoa(config.IPv4PDDefaultMinIPTargetSize),
+		},
+	}
+	expectedWarmPoolConfig := &config.WarmPoolConfig{
+		WarmIPTarget:     config.IPv4PDDefaultWarmIPTargetSize,
+		WarmPrefixTarget: config.IPv4PDDefaultWarmPrefixTargetSize,
+		MinIPTarget:      config.IPv4PDDefaultMinIPTargetSize,
+		DesiredSize:      config.IPv4PDDefaultWarmIPTargetSize,
+	}
+
+	mockK8sWrapper := mock_k8s.NewMockK8sWrapper(ctrl)
+	mockK8sWrapper.EXPECT().GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace).Return(configMapToReturn, nil)
+	apiWrapperMock := api.Wrapper{K8sAPI: mockK8sWrapper}
+
+	actualWarmPoolConfig := GetWinWarmPoolConfig(log, apiWrapperMock, true)
+	assert.Equal(t, expectedWarmPoolConfig, actualWarmPoolConfig)
+}
+
+func TestGetWinWarmPoolConfig_PDDisabledAndAPICallFailure_ReturnsDefaultConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	log := zap.New(zap.UseDevMode(true)).WithName("provider test")
+
+	var configMapToReturn *v1.ConfigMap = nil
+	errorToReturn := fmt.Errorf("Some error occurred while fetching config map")
+	expectedWarmPoolConfig := &config.WarmPoolConfig{
+		WarmIPTarget: config.IPv4DefaultWinWarmIPTarget,
+		MinIPTarget:  config.IPv4DefaultWinMinIPTarget,
+		DesiredSize:  config.IPv4DefaultWinWarmIPTarget,
+	}
+
+	mockK8sWrapper := mock_k8s.NewMockK8sWrapper(ctrl)
+	mockK8sWrapper.EXPECT().GetConfigMap(
+		config.VpcCniConfigMapName,
+		config.KubeSystemNamespace,
+	).Return(
+		configMapToReturn,
+		errorToReturn,
+	)
+	apiWrapperMock := api.Wrapper{K8sAPI: mockK8sWrapper}
+
+	actualWarmPoolConfig := GetWinWarmPoolConfig(log, apiWrapperMock, false)
+	assert.Equal(t, expectedWarmPoolConfig, actualWarmPoolConfig)
+}

--- a/scripts/test/run-integration-tests.sh
+++ b/scripts/test/run-integration-tests.sh
@@ -42,7 +42,7 @@ function run_integration_tests(){
   TEST_RESULT=success
   (cd $INTEGRATION_TEST_DIR/perpodsg && CGO_ENABLED=0 ginkgo --skip=LOCAL $EXTRA_GINKGO_FLAGS -v -timeout=35m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID) || TEST_RESULT=fail
   if [[ -z "${SKIP_WINDOWS_TEST}" ]]; then
-    (cd $INTEGRATION_TEST_DIR/windows && CGO_ENABLED=0 ginkgo --skip=LOCAL $EXTRA_GINKGO_FLAGS -v -timeout=120m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID) || TEST_RESULT=fail
+    (cd $INTEGRATION_TEST_DIR/windows && CGO_ENABLED=0 ginkgo --skip=LOCAL $EXTRA_GINKGO_FLAGS -v -timeout=150m -- -cluster-kubeconfig=$KUBE_CONFIG_PATH -cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id $VPC_ID) || TEST_RESULT=fail
   else
     echo "skipping Windows tests"
   fi

--- a/test/README.md
+++ b/test/README.md
@@ -63,7 +63,7 @@ The Integration test suite provides the following focuses.
    echo "Running Security Group for Pods Integration Tests"
    (cd perpodsg && CGO_ENABLED=0 GOOS=$OS ginkgo -v --timeout 40m -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID)
    echo "Running Windows Integration Tests"
-   (cd windows && CGO_ENABLED=0 GOOS=$OS ginkgo -v --timeout 40m -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID)
+   (cd windows && CGO_ENABLED=0 GOOS=$OS ginkgo -v --timeout 150m -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID)
    ```
 
 #### Running Integration tests on Controller running on EKS Control Plane


### PR DESCRIPTION
> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

## Issue 
Resolves https://github.com/aws/amazon-vpc-resource-controller-k8s/issues/428

### Description of changes
This change introduces changes to provide configurable options for managing IP address allocation on Windows nodes when using secondary IP mode. The VPC Resource Controller will now allow configuring of the `windows-minimum-ip-target` and `windows-warm-ip-target` parameters in the `amazon-vpc-cni` ConfigMap. These parameters will control the minimum number of IP addresses to be allocated on each Windows node, and the number of 'warm' IP addresses to be pre-allocated respectively. The VPC RC will always ensure that based on the configurations, there will always be enough warm IPs to satisfy the configurations. 

Previously, the VPC Resource Controller utilized a fixed and hardcoded number of 3 warm secondary IP addresses on each Windows node. This approach, while beneficial for enabling faster pod startup times, wasn't ideal for the following example scenarios. 

1. _When there is a need to configure fewer warm IPs to improve IP address utilization in the subnet._ The fixed warm IP target could lead to inefficient IP address utilization, particularly in subnets with limited IPv4 address space.
2. _When there is a need to configure a higher target for warm IPs to ensure faster pod startup times._ The fixed warm IP target may not provide enough pre-allocated IP addresses to meet the requirements for faster pod launches in a case where a warmpool target greater than 3 is desired.
3. _When there is a need to configure a minimum IP target after the node is set up._ The lack of a configurable minimum IP target could result in insufficient IP addresses being allocated to the node, potentially impacting pod startup times in cases where high availability is desired.

### Scope
- This change only affects Windows nodes when `enable-windows-ipam` is set to `true`
- This change only affects Windows modes when running in the Secondary IP mode, in contrast to running in prefix delegation mode

### Notes for reviewers
- A warmpool target of 1 is enforced even if a zero value is set because the current code design workflow relies on the warmpool always being populated with at least 1 warm IP. In future, a follow up change can be applied to make it both minimum IP and warm IP targets configurable to zero such that zero IPs are kept warm for use cases where no warm IPs are desired.

Todo 
- [x] Integration tests will be added later to further validate the proposed changes. To start with unit tests have been added and manual e2e tests have been performed. After reaching consensus on the core design and implementation of the initial changes, I can follow up with integration tests either in this PR or a different one.
- [x] Documentation will be updated to reflect the new configuration options and their intended usage once the core design and default behavior have been finalized and agreed upon. This will ensure that the documentation accurately represents the final implementation.

### Integration Test Output
Output as of Tue Jul 23 11:52AM PDT
```
[tzifudzi:~/GolandProjects/amazon-vpc-resource-controller-k8s/test/integration/windows] feature/secondary-ip-configs(+11/-15,1)+* 3h0m40s 130 ± ginkgo --skip=Stress -v --timeout 180m -- --cluster-kubeconfig='/Users/tzifudzi/.kube/config' --cluster-name=$CLUSTER_NAME --aws-region=$AWS_REGION --aws-vpc-id=$VPC_ID --ginkgo.skip="stress"
Running Suite: Windows Integration Test Suite - /Users/tzifudzi/GolandProjects/amazon-vpc-resource-controller-k8s/test/integration/windows
...
Ran 34 of 40 Specs in 6833.774 seconds
SUCCESS! -- 34 Passed | 0 Failed | 0 Pending | 6 Skipped
PASS
...
```

Integration test runs
- July 22 [integration-test-output.txt](https://github.com/user-attachments/files/16353208/integration-test-output.txt)
- Aug 29 [output.txt](https://github.com/user-attachments/files/16808386/output.txt)