### PR TITLE
Passing page limit to cach config instead of override.

### DIFF
--- a/controllers/custom/builder.go
+++ b/controllers/custom/builder.go
@@ -113,15 +113,16 @@ func (b *Builder) Complete(reconciler Reconciler) (healthz.Checker, error) {
 		workqueue.DefaultControllerRateLimiter(), b.options.Name)
 
 	optimizedListWatch := newOptimizedListWatcher(b.ctx, b.clientSet.CoreV1().RESTClient(),
-		b.converter.Resource(), b.options.Namespace, b.options.PageLimit, b.converter)
+		b.converter.Resource(), b.options.Namespace, b.converter)
 
 	// Create the config for low level controller with the custom converter
 	// list and watch
 	config := &cache.Config{
-		Queue:            cache.NewDeltaFIFO(b.converter.Indexer, b.dataStore),
-		ListerWatcher:    optimizedListWatch,
-		ObjectType:       b.converter.ResourceType(),
-		FullResyncPeriod: b.options.ResyncPeriod,
+		Queue:             cache.NewDeltaFIFO(b.converter.Indexer, b.dataStore),
+		ListerWatcher:     optimizedListWatch,
+		WatchListPageSize: int64(b.options.PageLimit),
+		ObjectType:        b.converter.ResourceType(),
+		FullResyncPeriod:  b.options.ResyncPeriod,
 		Process: func(obj interface{}, _ bool) error {
 			// from oldest to newest
 			for _, d := range obj.(cache.Deltas) {

--- a/controllers/custom/builder.go
+++ b/controllers/custom/builder.go
@@ -113,7 +113,7 @@ func (b *Builder) Complete(reconciler Reconciler) (healthz.Checker, error) {
 		workqueue.DefaultControllerRateLimiter(), b.options.Name)
 
 	optimizedListWatch := newOptimizedListWatcher(b.ctx, b.clientSet.CoreV1().RESTClient(),
-		b.converter.Resource(), b.options.Namespace, b.converter)
+		b.converter.Resource(), b.options.Namespace, b.converter, b.log.WithName("listWatcher"))
 
 	// Create the config for low level controller with the custom converter
 	// list and watch

--- a/controllers/custom/custom_controller.go
+++ b/controllers/custom/custom_controller.go
@@ -178,23 +178,21 @@ func (c *CustomController) WaitForCacheSync(controller cache.Controller) {
 
 // newOptimizedListWatcher returns a list watcher with a custom list function that converts the
 // response for each page using the converter function and returns a general watcher
-func newOptimizedListWatcher(ctx context.Context, restClient cache.Getter, resource string, namespace string, limit int,
+func newOptimizedListWatcher(ctx context.Context, restClient cache.Getter, resource string, namespace string,
 	converter Converter) *cache.ListWatch {
 
 	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {
 		list, err := restClient.Get().
 			Namespace(namespace).
 			Resource(resource).
-			// This needs to be done because just setting the limit using option's
-			// Limit is being overridden and the response is returned without pagination.
 			VersionedParams(&metav1.ListOptions{
-				Limit:    int64(limit),
+				Limit:    options.Limit,
 				Continue: options.Continue,
 			}, metav1.ParameterCodec).
 			Do(ctx).
 			Get()
 		if err != nil {
-			return list, err
+			return nil, err
 		}
 		// Strip down the the list before passing the paginated response back to
 		// the pager function

--- a/controllers/custom/custom_controller.go
+++ b/controllers/custom/custom_controller.go
@@ -223,7 +223,7 @@ func newOptimizedListWatcher(ctx context.Context, restClient cache.Getter, resou
 			}
 			return nil, err
 		}
-		return watch,err
+		return watch, err
 	}
 	return &cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
 }


### PR DESCRIPTION
*Issue #, if available:*
solves #412 
*Description of changes:*
As described in issue #412, controller data store gets partially hydrated if it received error 410. This is because reflector calls customized listFunc with page limit set to 0 but code was overwriting page limit, resulting in partial list instead of full list. This PR passes page limit option to cache config struct and let reflector handle state of options.limit as it will change it to 0 if it faces resource expired error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
