### PR TITLE
Set controller user-agent to vpc-resource-controller/git-version

### DIFF
--- a/main.go
+++ b/main.go
@@ -204,6 +204,7 @@ func main() {
 	// Set the API Server QPS and Burst
 	kubeConfig.QPS = config.DefaultAPIServerQPS
 	kubeConfig.Burst = config.DefaultAPIServerBurst
+	kubeConfig.UserAgent = fmt.Sprintf("%s/%s", config.ControllerName, version.GitVersion)
 
 	setupLog.Info("starting the controller with leadership setting",
 		"leader mode enabled", enableLeaderElection,

--- a/main.go
+++ b/main.go
@@ -204,7 +204,7 @@ func main() {
 	// Set the API Server QPS and Burst
 	kubeConfig.QPS = config.DefaultAPIServerQPS
 	kubeConfig.Burst = config.DefaultAPIServerBurst
-	kubeConfig.UserAgent = fmt.Sprintf("%s/%s", config.ControllerName, version.GitVersion)
+	kubeConfig.UserAgent = fmt.Sprintf("%s/%s", ec2API.AppName, version.GitVersion)
 
 	setupLog.Info("starting the controller with leadership setting",
 		"leader mode enabled", enableLeaderElection,


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/amazon-vpc-resource-controller-k8s/issues/442

```
The cloudwatch EKS cluster logs for vpc-resource-controller actions shows the userAgent field as:
"userAgent": "controller/v0.0.0 (linux/amd64) kubernetes/$Format",
```
*Description of changes:*


The controller user agent is set in the kubeConfig / [client-go](https://github.com/kubernetes/client-go/blob/master/rest/config.go#L491-L505) in this controller's case.


And it can be customized by updating `.UserAgent` of the kubeconfig used in making the call.

## Testing.

1. Built the VPC RC Image with this change.
2. Deployed it to Beta Clusters
3. Verified it Audit Logs


```
fields @timestamp, @message, @logStream

| filter @logStream like /audit/

| filter requestURI like /cninodes/
```

![image](https://github.com/user-attachments/assets/49ee14ac-2881-4ee5-97f9-641ebed9f361)

After this change the userAgent will set to

```
        "@message": {
            "kind": "Event",
            "apiVersion": "audit.k8s.io/v1",
            "level": "Metadata",
            "auditID": "2e4b4b35-1aa0-4733-89c4-4xxx",
            "stage": "ResponseStarted",
            "requestURI": "/apis/vpcresources.k8s.aws/v1alpha1/cninodes?allowWatchBookmarks=true&resourceVersion=36132&timeoutSeconds=421&watch=true",
            "verb": "watch",
            "user": {
                "username": "eks:vpc-resource-controller",
                "groups": [
                    "system:authenticated"
                ]
            },
            "sourceIPs": [
                "10.0.97.217"
            ],
            "userAgent": "vpc-resource-controller/v1.5.0-11-gaabe5fd",
```
- there is no unit-test for the _main_ module for this controller at the moment; this will require some refactor.
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
