### PR TITLE
update branch ENI operation metrics & dev guide

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -8,8 +8,12 @@ make toolchain # Install required to develop the project
 
 ## Testing a code change
 
-Deploy your changes to a local development cluster and run the tests against it. You will need to allowlist your account
-for ENI trunking before the deployment.
+Deploy your changes to a local development cluster and run the tests against it. You will need to allowlist your account for ENI trunking before the deployment.
+
+If you are testing on EKS beta cluster, set
+```sh
+BETA_CLUSTER=true
+```
 
 ```sh
 make apply-dependencies # install the cert manager and certificate

--- a/config/controller/controller.yaml
+++ b/config/controller/controller.yaml
@@ -33,6 +33,8 @@ spec:
           - --role-arn=USER_ROLE_ARN
           - --leader-elect
           - --metrics-bind-address=:8443
+          - --introspect-bind-addr=:22775
+          - --vpc-id=VPC_ID
         image: controller:latest
         name: controller
         resources:

--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -45,26 +45,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-var (
-	branchProviderOperationsErrCount = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "branch_provider_operations_err_count",
-			Help: "The number of errors encountered for branch provider operations",
-		},
-		[]string{"operation"},
-	)
-
-	branchProviderOperationLatency = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Name: "branch_provider_operation_latency",
-			Help: "Branch Provider operations latency in ms",
-		},
-		[]string{"operation", "resource_count"},
-	)
-
-	operationCreateBranchENI            = "create_branch_eni"
-	operationCreateBranchENIAndAnnotate = "create_and_annotate_branch_eni"
-	operationInitTrunk                  = "init_trunk"
+const (
+	operationCreateBranchENI   = "create_branch_eni"
+	operationAnnotateBranchENI = "annotate_branch_eni"
+	operationInitTrunk         = "init_trunk"
+	resourceCountLabel         = "resource_count"
+	operationLabel             = "branch_provider_operation"
 
 	ReasonSecurityGroupRequested    = "SecurityGroupRequested"
 	ReasonResourceAllocated         = "ResourceAllocated"
@@ -72,6 +58,25 @@ var (
 	ReasonBranchENIAnnotationFailed = "BranchENIAnnotationFailed"
 
 	ReasonTrunkENICreationFailed = "TrunkENICreationFailed"
+)
+
+var (
+	branchProviderOperationsErrCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "branch_provider_operations_err_count",
+			Help: "The number of errors encountered for branch provider operations",
+		},
+		[]string{operationLabel},
+	)
+
+	branchProviderOperationLatency = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name:       "branch_provider_operation_latency",
+			Help:       "Branch Provider operations latency in ms",
+			Objectives: map[float64]float64{0: 0, 0.5: 0.05, 0.9: 0.01, 0.99: 0.001, 1: 0},
+		},
+		[]string{operationLabel, resourceCountLabel},
+	)
 
 	deleteQueueRequeueRequest = ctrl.Result{RequeueAfter: time.Second * 30, Requeue: true}
 
@@ -80,9 +85,7 @@ var (
 	NodeDeleteRequeueRequestDelay = time.Minute * 1
 
 	prometheusRegistered = false
-)
 
-var (
 	ErrTrunkExistInCache = fmt.Errorf("trunk eni already exist in cache")
 	ErrTrunkNotInCache   = fmt.Errorf("trunk eni not present in cache")
 )
@@ -172,7 +175,7 @@ func (b *branchENIProvider) InitResource(instance ec2.EC2Instance) error {
 
 		utils.SendNodeEventWithNodeName(b.apiWrapper.K8sAPI, nodeName, utils.NodeTrunkFailedInitializationReason, "The node failed initializing trunk interface", v1.EventTypeNormal, b.log)
 		branchProviderOperationsErrCount.WithLabelValues("init").Inc()
-		return fmt.Errorf("initalizing trunk, %w", err)
+		return fmt.Errorf("initializing trunk, %w", err)
 	}
 	branchProviderOperationLatency.WithLabelValues(operationInitTrunk, "1").Observe(timeSinceMs(start))
 
@@ -379,6 +382,7 @@ func (b *branchENIProvider) CreateAndAnnotateResources(podNamespace string, podN
 		return ctrl.Result{}, err
 	}
 
+	start = time.Now()
 	// Annotate the pod with the created resources
 	err = b.apiWrapper.PodAPI.AnnotatePod(pod.Namespace, pod.Name, pod.UID,
 		config.ResourceNamePodENI, string(jsonBytes))
@@ -395,7 +399,7 @@ func (b *branchENIProvider) CreateAndAnnotateResources(podNamespace string, podN
 	b.apiWrapper.K8sAPI.BroadcastEvent(pod, ReasonResourceAllocated,
 		fmt.Sprintf("Allocated %s to the pod", string(jsonBytes)), v1.EventTypeNormal)
 
-	branchProviderOperationLatency.WithLabelValues(operationCreateBranchENIAndAnnotate, strconv.Itoa(resourceCount)).
+	branchProviderOperationLatency.WithLabelValues(operationAnnotateBranchENI, strconv.Itoa(resourceCount)).
 		Observe(timeSinceMs(start))
 
 	log.Info("created and annotated branch interface/s successfully", "branches", branchENIs)

--- a/scripts/test/lib/config.sh
+++ b/scripts/test/lib/config.sh
@@ -14,7 +14,7 @@ function add_suffix() {
 
 # IAM Role Name for Linux Node Role where VPC Resource Controller Runs. It should
 # have the Trunk Association Policy
-TRUNK_ASSOC_POLICY_NAME=$(add_suffix "AssociateTrunkInterfcePolicy")
+TRUNK_ASSOC_POLICY_NAME=$(add_suffix "AssociateTrunkInterfacePolicy")
 INSTANCE_ROLE_NAME=$(add_suffix "LinuxNodeRole")
 
 # IAM Role and it's Policy Names which have the permission to manage Trunk/Branch


### PR DESCRIPTION
*Description of changes:*
Updated the metrics to measure branch ENI operations- create branch ENI, annotate pod, and initialize trunk. The summary metric also measures 0.5, 0.9, 0.99 quantiles (50th, 90th, and 99th percentiles), and quantile 0(min value) & 1(max value). 

*Test*
Running scale tests to deploy 1K pods repeatedly:
```
# HELP branch_provider_operation_latency Branch Provider operations latency in ms
# TYPE branch_provider_operation_latency summary
branch_provider_operation_latency{branch_provider_operation="annotate_branch_eni",resource_count="1",quantile="0"} 9
branch_provider_operation_latency{branch_provider_operation="annotate_branch_eni",resource_count="1",quantile="0.5"} 15
branch_provider_operation_latency{branch_provider_operation="annotate_branch_eni",resource_count="1",quantile="0.9"} 35
branch_provider_operation_latency{branch_provider_operation="annotate_branch_eni",resource_count="1",quantile="0.99"} 84
branch_provider_operation_latency{branch_provider_operation="annotate_branch_eni",resource_count="1",quantile="1"} 110
branch_provider_operation_latency_sum{branch_provider_operation="annotate_branch_eni",resource_count="1"} 32414
branch_provider_operation_latency_count{branch_provider_operation="annotate_branch_eni",resource_count="1"} 1612
branch_provider_operation_latency{branch_provider_operation="create_branch_eni",resource_count="1",quantile="0"} 817
branch_provider_operation_latency{branch_provider_operation="create_branch_eni",resource_count="1",quantile="0.5"} 4928
branch_provider_operation_latency{branch_provider_operation="create_branch_eni",resource_count="1",quantile="0.9"} 5453
branch_provider_operation_latency{branch_provider_operation="create_branch_eni",resource_count="1",quantile="0.99"} 5854
branch_provider_operation_latency{branch_provider_operation="create_branch_eni",resource_count="1",quantile="1"} 15032
branch_provider_operation_latency_sum{branch_provider_operation="create_branch_eni",resource_count="1"} 7.565694e+06
branch_provider_operation_latency_count{branch_provider_operation="create_branch_eni",resource_count="1"} 1613
branch_provider_operation_latency{branch_provider_operation="init_trunk",resource_count="1",quantile="0"} 3112
branch_provider_operation_latency{branch_provider_operation="init_trunk",resource_count="1",quantile="0.5"} 3186
branch_provider_operation_latency{branch_provider_operation="init_trunk",resource_count="1",quantile="0.9"} 15665
branch_provider_operation_latency{branch_provider_operation="init_trunk",resource_count="1",quantile="0.99"} 15869
branch_provider_operation_latency{branch_provider_operation="init_trunk",resource_count="1",quantile="1"} 15869
branch_provider_operation_latency_sum{branch_provider_operation="init_trunk",resource_count="1"} 276597
branch_provider_operation_latency_count{branch_provider_operation="init_trunk",resource_count="1"} 30
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
