### PR TITLE
use protobuf content type instead of json for k8s client

### DIFF
--- a/main.go
+++ b/main.go
@@ -205,6 +205,8 @@ func main() {
 	kubeConfig.QPS = config.DefaultAPIServerQPS
 	kubeConfig.Burst = config.DefaultAPIServerBurst
 	kubeConfig.UserAgent = fmt.Sprintf("%s/%s", ec2API.AppName, version.GitVersion)
+	kubeConfig.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	kubeConfig.ContentType = "application/vnd.kubernetes.protobuf"
 
 	setupLog.Info("starting the controller with leadership setting",
 		"leader mode enabled", enableLeaderElection,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This MR is a part of effort to elevate single eks cluster performance by migrating the EKS components to use protobuf instead of json.

Modify kubeconfig type to use content type application/vnd.kubernetes.protobuf instead of json for performance gain.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
