### PR TITLE
Revert "use protobuf content type instead of json for k8s client (#468)"

### DIFF
--- a/main.go
+++ b/main.go
@@ -203,8 +203,6 @@ func main() {
 	kubeConfig.QPS = config.DefaultAPIServerQPS
 	kubeConfig.Burst = config.DefaultAPIServerBurst
 	kubeConfig.UserAgent = fmt.Sprintf("%s/%s", ec2API.AppName, version.GitVersion)
-	kubeConfig.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
-	kubeConfig.ContentType = "application/vnd.kubernetes.protobuf"
 
 	setupLog.Info("starting the controller with leadership setting",
 		"leader mode enabled", enableLeaderElection,


### PR DESCRIPTION
This reverts commit dd3564c30c5da8233d3ab5737ce331ee2fe0d10d.

*Issue #, if available:*

*Description of changes:*

Seeing errors, will fix these in a separate PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
