### PR TITLE
Skipping health check on nodes if EC2 returns throttling errors

### DIFF
--- a/controllers/core/node_controller.go
+++ b/controllers/core/node_controller.go
@@ -168,6 +168,12 @@ func (r *NodeReconciler) Check() healthz.Checker {
 			return nil
 		}
 
+		if r.Manager.SkipHealthCheck() {
+			// node manager observes EC2 error on processing node, pausing reconciler check to avoid stressing the system
+			r.Log.Info("due to EC2 error, node controller skips node reconciler health check for now")
+			return nil
+		}
+
 		err := rcHealthz.PingWithTimeout(func(c chan<- error) {
 			// when the reconciler is ready, testing the reconciler with a fake node request
 			pingRequest := &ctrl.Request{

--- a/mocks/amazon-vcp-resource-controller-k8s/pkg/node/manager/mock_manager.go
+++ b/mocks/amazon-vcp-resource-controller-k8s/pkg/node/manager/mock_manager.go
@@ -102,6 +102,20 @@ func (mr *MockManagerMockRecorder) GetNode(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockManager)(nil).GetNode), arg0)
 }
 
+// SkipHealthCheck mocks base method.
+func (m *MockManager) SkipHealthCheck() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SkipHealthCheck")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SkipHealthCheck indicates an expected call of SkipHealthCheck.
+func (mr *MockManagerMockRecorder) SkipHealthCheck() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SkipHealthCheck", reflect.TypeOf((*MockManager)(nil).SkipHealthCheck))
+}
+
 // UpdateNode mocks base method.
 func (m *MockManager) UpdateNode(arg0 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
 	rcV1alpha1 "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1alpha1"
@@ -682,6 +683,38 @@ func Test_performAsyncOperation_fail(t *testing.T) {
 	_, err := mock.Manager.performAsyncOperation(job)
 	assert.NotContains(t, mock.Manager.dataStore, nodeName) // It should be cleared from cache
 	assert.NoError(t, err)
+}
+
+func Test_performAsyncOperation_fail_pausingHealthCheck(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := NewMock(ctrl, map[string]node.Node{nodeName: managedNode})
+
+	job := AsyncOperationJob{
+		node:     mock.MockNode,
+		nodeName: nodeName,
+		op:       Init,
+	}
+
+	mock.MockNode.EXPECT().InitResources(mock.MockResourceManager).Return(&node.ErrInitResources{
+		Err: errors.New("RequestLimitExceeded: Request limit exceeded.\n\tstatus code: 503, request id: 123-123-123-123-123"),
+	}).Times(2)
+	mock.MockK8sAPI.EXPECT().GetNode(nodeName).Return(v1Node, nil).Times(2)
+	mock.MockK8sAPI.EXPECT().BroadcastEvent(v1Node, utils.VersionNotice, fmt.Sprintf("The node is managed by VPC resource controller version %s", mock.Manager.controllerVersion), v1.EventTypeNormal).Times(2)
+
+	_, err := mock.Manager.performAsyncOperation(job)
+	time.Sleep(time.Millisecond * 100)
+	assert.True(t, mock.Manager.SkipHealthCheck())
+	assert.NotContains(t, mock.Manager.dataStore, nodeName) // It should be cleared from cache
+	assert.NoError(t, err)
+
+	time.Sleep(time.Second * 2)
+	_, err = mock.Manager.performAsyncOperation(job)
+	assert.NoError(t, err)
+	time.Sleep(time.Millisecond * 100)
+	assert.True(t, mock.Manager.SkipHealthCheck())
+	assert.True(t, time.Since(mock.Manager.stopHealthCheckAt) > time.Second*2 && time.Since(mock.Manager.stopHealthCheckAt) < time.Second*3)
 }
 
 // Test_isPodENICapacitySet test if the pod-eni capacity then true is returned

--- a/pkg/utils/errors.go
+++ b/pkg/utils/errors.go
@@ -23,6 +23,7 @@ var (
 	ErrInsufficientCidrBlocks     = errors.New("InsufficientCidrBlocks: The specified subnet does not have enough free cidr blocks to satisfy the request")
 	ErrMsgProviderAndPoolNotFound = "cannot find the instance provider and pool from the cache"
 	NotRetryErrors                = []string{InsufficientCidrBlocksReason}
+	PauseHealthCheckErrors        = []string{"RequestLimitExceeded"}
 )
 
 // ShouldRetryOnError returns true if the error is retryable, else returns false


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The controller shouldn't health check on resources when the upstream API returns some specific errors, such as EC2 throttling, since those errors are not recoverable by failing the controller.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
