### PR TITLE
increasing timeout for few integration test

### DIFF
--- a/test/framework/utils/poll.go
+++ b/test/framework/utils/poll.go
@@ -22,7 +22,7 @@ const (
 	PollTimeout        = 30 * time.Second
 	// ResourceCreationTimeout is the number of seconds till the controller waits
 	// for the resource creation to complete
-	ResourceCreationTimeout = 120 * time.Second
+	ResourceCreationTimeout = 180 * time.Second
 	// Windows Container Images are much larger in size and pulling them the first
 	// time takes much longer, so have higher timeout for Windows Pod to be Ready
 	WindowsPodsCreationTimeout = 240 * time.Second

--- a/test/integration/scale/pod_scale_test.go
+++ b/test/integration/scale/pod_scale_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Security group per pod scale test", func() {
 				duration := time.Since(start)
 				verify.VerifyNetworkingOfAllPodUsingENI(namespace, sgpLabelKey, sgpLabelValue,
 					securityGroups)
-				Expect(duration.Minutes()).To(BeNumerically("<", 5.0))
+				Expect(duration.Minutes()).To(BeNumerically("<", 5.5))
 			})
 		})
 	})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For scale test 5 minutes is too tight of a deadline as node boot up takes varied amount of time. This is one my sample run where test failed because it took 0.0002 seconds more.
```
  [FAILED] Expected
      <float64>: 5.0002400429166665
  to be <
      <float64>: 5
  In [It] at: /home/yathakka/go/src/github.com/aws/amazon-vpc-resource-controller-k8s/test/integration/scale/pod_scale_test.go:84 @ 10/18/24 20:39:57.763
```
Same for resource creation timeout. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
