### PR TITLE
Add flags to configure controller parameters

### DIFF
--- a/controllers/core/configmap_controller.go
+++ b/controllers/core/configmap_controller.go
@@ -91,7 +91,7 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			)
 		}
 	} else {
-		r.Log.Error(err, "failed to retrieve branch ENI cool down period from amazon-vpc-cni configmap, will retain the current cooldown period", "cool down period", curCoolDownPeriod)
+		r.Log.Info("branch ENI cool down period not configured in amazon-vpc-cni configmap, will retain the current cooldown period", "cool down period", curCoolDownPeriod)
 	}
 
 	// Check if the Windows IPAM flag has changed

--- a/controllers/core/node_controller.go
+++ b/controllers/core/node_controller.go
@@ -57,8 +57,7 @@ var (
 // one routines to help high rate churn and larger nodes groups restarting
 // when the controller has to be restarted for various reasons.
 const (
-	MaxNodeConcurrentReconciles = 10
-	NodeTerminationFinalizer    = "networking.k8s.aws/resource-cleanup"
+	NodeTerminationFinalizer = "networking.k8s.aws/resource-cleanup"
 )
 
 // NodeReconciler reconciles a Node object
@@ -143,7 +142,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	return ctrl.Result{}, err
 }
 
-func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager, healthzHandler *rcHealthz.HealthzHandler) error {
+func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int, healthzHandler *rcHealthz.HealthzHandler) error {
 	// add health check on subpath for node controller
 	healthzHandler.AddControllersHealthCheckers(
 		map[string]healthz.Checker{"health-node-controller": r.Check()},
@@ -153,7 +152,7 @@ func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager, healthzHandler *rcHe
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Node{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: MaxNodeConcurrentReconciles}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Owns(&v1alpha1.CNINode{}).
 		Complete(r)
 }

--- a/controllers/core/pod_controller.go
+++ b/controllers/core/pod_controller.go
@@ -56,8 +56,7 @@ type PodReconciler struct {
 }
 
 var (
-	PodRequeueRequest          = ctrl.Result{Requeue: true, RequeueAfter: time.Second}
-	MaxPodConcurrentReconciles = 20
+	PodRequeueRequest = ctrl.Result{Requeue: true, RequeueAfter: time.Second}
 )
 
 // Reconcile handles create/update/delete event by delegating the request to the  handler
@@ -192,8 +191,8 @@ func getAggregateResources(pod *v1.Pod) map[string]int64 {
 // list of runnable. After Manager acquire the lease the pod controller runnable
 // will be started and the Pod events will be sent to Reconcile function
 func (r *PodReconciler) SetupWithManager(ctx context.Context, manager ctrl.Manager,
-	clientSet *kubernetes.Clientset, pageLimit int, syncPeriod time.Duration, healthzHandler *rcHealthz.HealthzHandler) error {
-	r.Log.Info("The pod controller is using MaxConcurrentReconciles", "Routines", MaxPodConcurrentReconciles)
+	clientSet *kubernetes.Clientset, pageLimit int, syncPeriod time.Duration, maxConcurrentReconciles int, healthzHandler *rcHealthz.HealthzHandler) error {
+	r.Log.Info("The pod controller is using MaxConcurrentReconciles", "Routines", maxConcurrentReconciles)
 
 	customChecker, err := custom.NewControllerManagedBy(ctx, manager).
 		WithLogger(r.Log.WithName("custom pod controller")).
@@ -205,7 +204,7 @@ func (r *PodReconciler) SetupWithManager(ctx context.Context, manager ctrl.Manag
 		}).Options(custom.Options{
 		PageLimit:               pageLimit,
 		ResyncPeriod:            syncPeriod,
-		MaxConcurrentReconciles: MaxPodConcurrentReconciles,
+		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).UsingConditions(r.Condition).Complete(r)
 
 	// add health check on subpath for pod and pod customized controllers

--- a/main.go
+++ b/main.go
@@ -155,8 +155,8 @@ func main() {
 	flag.IntVar(&nodeWorkerCount, "node-mgr-workers", 10, "The number of node workers")
 	flag.IntVar(&userClientQPS, "user-client-qps", 12, "The user client QPS rate")
 	flag.IntVar(&userClientBurst, "user-client-burst", 18, "The user client burst limit")
-	flag.IntVar(&instanceClientQPS, "instance-qps", 12, "The instance client QPS rate")
-	flag.IntVar(&instanceClientBurst, "instance-burst", 18, "The instance client burst limit")
+	flag.IntVar(&instanceClientQPS, "instance-client-qps", 12, "The instance client QPS rate")
+	flag.IntVar(&instanceClientBurst, "instance-client-burst", 18, "The instance client burst limit")
 	// API Server QPS & burst
 	// Use the same values as default client (https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/client/config/config.go#L85)
 	flag.IntVar(&apiServerQPS, "apiserver-qps", 20, "The API server client QPS rate")

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -43,23 +43,6 @@ const (
 	IPv4PDDefaultWarmIPTargetSize     = 1
 	IPv4PDDefaultMinIPTargetSize      = 3
 	IPv4PDDefaultWarmPrefixTargetSize = 0
-
-	// EC2 API QPS for user service client
-	// Tested: 15 + 20 limits
-	// Tested: 15 + 8 limits (not seeing significant degradation from 15+20)
-	// Tested: 12 + 8 limits (not seeing significant degradation from 15+8)
-	// Larger number seems not make latency better than 12+8
-	UserServiceClientQPS      = 12
-	UserServiceClientQPSBurst = 18
-
-	// EC2 API QPS for instance service client
-	InstanceServiceClientQPS   = 12
-	InstanceServiceClientBurst = 18
-
-	// API Server QPS
-	// Use the same values as default client (https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/client/config/config.go#L85)
-	DefaultAPIServerQPS   = 20
-	DefaultAPIServerBurst = 30
 )
 
 // LoadResourceConfig returns the Resource Configuration for all resources managed by the VPC Resource Controller. Currently


### PR DESCRIPTION
*Issue #, if available:*
#451 partly

*Description of changes:*
1. Add support to configure controller parameters via flags, flags added 
```
nodeWorkerCount: The number of node workers, default 10
userClientQPS: The EC2 user client QPS rate, default 12
userClientBurst: The EC2 user client burst limit, default 18
instanceClientQPS: The EC2 instance client QPS rate, default 12
instanceClientBurst: The instance client burst limit, default 18
apiServerQPS: The API server client QPS rate, default 20
apiServerBurst: The API server client burst limit, default 30
maxPodConcurrentReconciles: The maximum number of concurrent reconciles for pod controller, default 20
maxNodeConcurrentReconciles: The maximum number of concurrent reconciles for node controller, default 10
```

Customers can configure these values via controller flags eg [here](https://github.com/aws/amazon-vpc-resource-controller-k8s/blob/master/config/controller/controller.yaml) when running the controller on dataplane or non-EKS CP. Controller on EKS will use the defaults defined above. 
```
- --node-mgr-workers=xx
- --user-client-qps=xx
- --user-client-burst=xx
- --instance-client-qps=xx
- --instance-client-burst=xx
- --apiserver-qps=xx
- --apiserver-burst=xx
- --max-pod-reconcile=xx
- --max-node-reconcile=xx
``` 
Verified controller is able to run, SGPP tests passed:
```
Ran 18 of 22 Specs in 1190.175 seconds
SUCCESS! -- 18 Passed | 0 Failed | 0 Pending | 4 Skipped
PASS
```

2. Changed to `r.Log.Info("branch ENI cool down period not configured in amazon-vpc-cni configmap, will retain the current cooldown period", "cool down period", curCoolDownPeriod)` to avoid logging benign errors in the controller and make it easier to parse error logs. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
