### PR TITLE
keeping cluster tag filter of vpc-cni and vpc-rc

### DIFF
--- a/controllers/crds/cninode_controller.go
+++ b/controllers/crds/cninode_controller.go
@@ -128,13 +128,13 @@ func (r *CNINodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		shouldPatch := false
 		cniNodeCopy := cniNode.DeepCopy()
 		// Add cluster name tag if it does not exist
-		val, ok := cniNode.Spec.Tags[config.CNINodeClusterNameKey]
+		val, ok := cniNode.Spec.Tags[config.VPCCNIClusterNameKey]
 		if !ok || val != r.clusterName {
 			if len(cniNodeCopy.Spec.Tags) != 0 {
-				cniNodeCopy.Spec.Tags[config.CNINodeClusterNameKey] = r.clusterName
+				cniNodeCopy.Spec.Tags[config.VPCCNIClusterNameKey] = r.clusterName
 			} else {
 				cniNodeCopy.Spec.Tags = map[string]string{
-					config.CNINodeClusterNameKey: r.clusterName,
+					config.VPCCNIClusterNameKey: r.clusterName,
 				}
 			}
 			shouldPatch = true

--- a/controllers/crds/cninode_controller_test.go
+++ b/controllers/crds/cninode_controller_test.go
@@ -89,7 +89,7 @@ func TestCNINodeReconcile(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, res, reconcile.Result{})
 				assert.Equal(t, cniNode.Labels, map[string]string{config.NodeLabelOS: "linux"})
-				assert.Equal(t, cniNode.Spec.Tags, map[string]string{config.CNINodeClusterNameKey: mockClusterName})
+				assert.Equal(t, cniNode.Spec.Tags, map[string]string{config.VPCCNIClusterNameKey: mockClusterName})
 			},
 		},
 	}

--- a/pkg/aws/ec2/api/cleanup/eni_cleanup_test.go
+++ b/pkg/aws/ec2/api/cleanup/eni_cleanup_test.go
@@ -15,7 +15,6 @@ package cleanup
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -33,7 +32,7 @@ import (
 var (
 	mockClusterName       = "cluster-name"
 	mockNodeID            = "i-00000000000000001"
-	mockClusterNameTagKey = fmt.Sprintf(config.ClusterNameTagKeyFormat, mockClusterName)
+	mockClusterNameTagKey = config.CNINodeClusterNameKey
 
 	mockNetworkInterfaceId1 = "eni-000000000000000"
 	mockNetworkInterfaceId2 = "eni-000000000000001"
@@ -60,7 +59,7 @@ var (
 			},
 			{
 				Name:   aws.String("tag:" + mockClusterNameTagKey),
-				Values: []string{config.ClusterNameTagValue},
+				Values: []string{mockClusterName},
 			},
 		},
 	}

--- a/pkg/aws/ec2/api/helper.go
+++ b/pkg/aws/ec2/api/helper.go
@@ -69,8 +69,8 @@ func NewEC2APIHelper(ec2Wrapper EC2Wrapper, clusterName string) EC2APIHelper {
 	// Set the key and value of the cluster name tag which will be used to tag all the network interfaces created by
 	// the controller
 	clusterNameTag = ec2types.Tag{
-		Key:   aws.String(fmt.Sprintf(config.ClusterNameTagKeyFormat, clusterName)),
-		Value: aws.String(config.ClusterNameTagValue),
+		Key:   aws.String(config.CNINodeClusterNameKey),
+		Value: aws.String(clusterName),
 	}
 	return &ec2APIHelper{ec2Wrapper: ec2Wrapper}
 }

--- a/pkg/aws/ec2/api/helper.go
+++ b/pkg/aws/ec2/api/helper.go
@@ -69,8 +69,8 @@ func NewEC2APIHelper(ec2Wrapper EC2Wrapper, clusterName string) EC2APIHelper {
 	// Set the key and value of the cluster name tag which will be used to tag all the network interfaces created by
 	// the controller
 	clusterNameTag = ec2types.Tag{
-		Key:   aws.String(config.CNINodeClusterNameKey),
-		Value: aws.String(clusterName),
+		Key:   aws.String(fmt.Sprintf(config.VPCRCClusterNameTagKeyFormat, clusterName)),
+		Value: aws.String(config.VPCRCClusterNameTagValue),
 	}
 	return &ec2APIHelper{ec2Wrapper: ec2Wrapper}
 }

--- a/pkg/aws/ec2/api/helper_test.go
+++ b/pkg/aws/ec2/api/helper_test.go
@@ -83,8 +83,8 @@ var (
 	}
 
 	defaultClusterNameTag = ec2types.Tag{
-		Key:   aws.String(config.CNINodeClusterNameKey),
-		Value: aws.String(clusterName),
+		Key:   aws.String(fmt.Sprintf(config.VPCRCClusterNameTagKeyFormat, clusterName)),
+		Value: aws.String(config.VPCRCClusterNameTagValue),
 	}
 
 	createNetworkInterfaceInput = &ec2.CreateNetworkInterfaceInput{

--- a/pkg/aws/ec2/api/helper_test.go
+++ b/pkg/aws/ec2/api/helper_test.go
@@ -83,8 +83,8 @@ var (
 	}
 
 	defaultClusterNameTag = ec2types.Tag{
-		Key:   aws.String(fmt.Sprintf(config.ClusterNameTagKeyFormat, clusterName)),
-		Value: aws.String(config.ClusterNameTagValue),
+		Key:   aws.String(config.CNINodeClusterNameKey),
+		Value: aws.String(clusterName),
 	}
 
 	createNetworkInterfaceInput = &ec2.CreateNetworkInterfaceInput{

--- a/pkg/aws/ec2/api/wrapper.go
+++ b/pkg/aws/ec2/api/wrapper.go
@@ -761,6 +761,7 @@ func (e *ec2Wrapper) DescribeNetworkInterfacesPagesWithRetry(input *ec2.Describe
 				attemptInterfaces = append(attemptInterfaces, &ec2types.NetworkInterface{
 					NetworkInterfaceId: nwInterface.NetworkInterfaceId,
 					TagSet:             nwInterface.TagSet,
+					Attachment:         nwInterface.Attachment,
 				})
 			}
 

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -57,18 +57,16 @@ const (
 
 // EC2 Tags
 const (
-	ControllerTagPrefix = "vpcresources.k8s.aws/"
-	VLandIDTag          = ControllerTagPrefix + "vlan-id"
-	TrunkENIIDTag       = ControllerTagPrefix + "trunk-eni-id"
-
-	ClusterNameTagKeyFormat = "kubernetes.io/cluster/%s"
-	ClusterNameTagValue     = "owned"
-
+	ControllerTagPrefix                 = "vpcresources.k8s.aws/"
+	VLandIDTag                          = ControllerTagPrefix + "vlan-id"
+	TrunkENIIDTag                       = ControllerTagPrefix + "trunk-eni-id"
+	VPCRCClusterNameTagKeyFormat        = "kubernetes.io/cluster/%s"
+	VPCRCClusterNameTagValue            = "owned"
 	NetworkInterfaceOwnerTagKey         = "eks:eni:owner"
 	NetworkInterfaceOwnerTagValue       = "eks-vpc-resource-controller"
 	NetworkInterfaceOwnerVPCCNITagValue = "amazon-vpc-cni"
 	NetworkInterfaceNodeIDKey           = "node.k8s.amazonaws.com/instance_id"
-	CNINodeClusterNameKey               = "cluster.k8s.amazonaws.com/name"
+	VPCCNIClusterNameKey                = "cluster.k8s.amazonaws.com/name"
 )
 
 const (
@@ -129,7 +127,7 @@ var (
 	// CoolDownPeriod is the time to let kube-proxy propagates IP tables rules before assigning the resource back to new pod
 	CoolDownPeriod = time.Second * 30
 	// ENICleanUpInterval is the time interval between each dangling ENI clean up task
-	ENICleanUpInterval = time.Minute * 30
+	ENICleanUpInterval = time.Minute * 2
 )
 
 // ResourceConfig is the configuration for each resource type

--- a/pkg/k8s/wrapper.go
+++ b/pkg/k8s/wrapper.go
@@ -260,7 +260,7 @@ func (k *k8sWrapper) CreateCNINode(node *v1.Node, clusterName string) error {
 		},
 		Spec: rcv1alpha1.CNINodeSpec{
 			Tags: map[string]string{
-				fmt.Sprintf(config.CNINodeClusterNameKey): clusterName,
+				fmt.Sprintf(config.VPCCNIClusterNameKey): clusterName,
 			},
 		},
 	}

--- a/test/integration/cninode/cninode_test.go
+++ b/test/integration/cninode/cninode_test.go
@@ -190,7 +190,7 @@ func VerifyCNINodeFields(cniNode *v1alpha1.CNINode) {
 	// For maps, ContainElement searches through the map's values.
 	By("verifying cluster name tag is set")
 	Expect(cniNode.Spec.Tags).To(ContainElement(frameWork.Options.ClusterName))
-	Expect(config.CNINodeClusterNameKey).To(BeKeyOf(cniNode.Spec.Tags))
+	Expect(config.VPCCNIClusterNameKey).To(BeKeyOf(cniNode.Spec.Tags))
 
 	By("verifying node OS label is set")
 	Expect(cniNode.ObjectMeta.Labels).To(ContainElement(config.OSLinux))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We will keep two describe ENI calls for each cleanup, along with common filters we will add this filter for each call 
-  `"kubernetes.io/cluster/$Cluster_name":owned` 
-  `"cluster.k8s.amazonaws.com/name":$Cluster_name` 

Both are different cluster tags used by VPC-RC and VPC-CNI for the ENI it creates
  
  
  Testing Procedure:
  1. deployed master branch  vpc-cni on cluster
  2. Passed Cluster name to vpc-cni env variable
  3. Deployed workload
  4. Detached one of the ENI created by vpc-cni. 
  5. Confirmed from the logs of vpc-rc that it cleaned up that eni created by vpc-cni
  
  
  Also did the same test with trunk interface of node.  to check if VPC-RC cluster name are pushed 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
