### PR TITLE
skipping node cleaner if node id is not present

### DIFF
--- a/controllers/crds/cninode_controller_test.go
+++ b/controllers/crds/cninode_controller_test.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1alpha1"
+	mock_api "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/api"
 	mock_cleanup "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/api/cleanup"
 	mock_k8s "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s"
+	ec2API "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2/api"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2/api/cleanup"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -42,12 +45,12 @@ var (
 	}
 )
 
-func NewCNINodeMock(ctrl *gomock.Controller, mockObjects ...client.Object) CNINodeMock {
+func NewCNINodeMock(ctrl *gomock.Controller, mockObjects ...client.Object) *CNINodeMock {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
 	_ = v1alpha1.AddToScheme(scheme)
 	client := fakeClient.NewClientBuilder().WithScheme(scheme).WithObjects(mockObjects...).Build()
-	return CNINodeMock{
+	return &CNINodeMock{
 		Reconciler: CNINodeReconciler{
 			Client:      client,
 			scheme:      scheme,
@@ -67,6 +70,8 @@ func TestCNINodeReconcile(t *testing.T) {
 		mockResourceCleaner  *mock_cleanup.MockResourceCleaner
 		mockK8sApi           *mock_k8s.MockK8sWrapper
 		mockFinalizerManager *mock_k8s.MockFinalizerManager
+		mockEC2API           *mock_api.MockEC2APIHelper
+		mockCNINode          *CNINodeMock
 	}
 	tests := []struct {
 		name    string
@@ -92,18 +97,91 @@ func TestCNINodeReconcile(t *testing.T) {
 				assert.Equal(t, cniNode.Spec.Tags, map[string]string{config.VPCCNIClusterNameKey: mockClusterName})
 			},
 		},
+		{
+			name: "verify cleaner was not called if node id is not present given that node is being finalized",
+			args: args{
+				mockNode: nil,
+				mockCNINode: &v1alpha1.CNINode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: mockName,
+						Labels: map[string]string{
+							config.NodeLabelOS: config.OSLinux,
+						},
+						Finalizers:        []string{config.NodeTerminationFinalizer},
+						DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+					},
+				},
+			},
+			prepare: func(f *fields) {
+				f.mockCNINode.Reconciler.newResourceCleaner = func(nodeID string, eC2Wrapper ec2API.EC2Wrapper, vpcID string) cleanup.ResourceCleaner {
+					return f.mockResourceCleaner
+				}
+				f.mockResourceCleaner.EXPECT().DeleteLeakedResources().Times(0)
+
+				f.mockFinalizerManager.EXPECT().
+					RemoveFinalizers(gomock.Any(), gomock.Any(), config.NodeTerminationFinalizer).
+					Return(nil)
+			},
+			asserts: func(res reconcile.Result, err error, cniNode *v1alpha1.CNINode) {
+				assert.NoError(t, err)
+				assert.Equal(t, res, reconcile.Result{})
+			},
+		},
+		{
+			name: "verify cleaner was called if node id is not empty when node is being finalized",
+			args: args{
+				mockNode: nil,
+				mockCNINode: &v1alpha1.CNINode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: mockName,
+						Labels: map[string]string{
+							config.NodeLabelOS: config.OSLinux,
+						},
+						Finalizers:        []string{config.NodeTerminationFinalizer},
+						DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+					},
+					Spec: v1alpha1.CNINodeSpec{
+						Tags: map[string]string{
+							config.NetworkInterfaceNodeIDKey: "i-1234567890",
+						},
+					},
+				},
+			},
+			prepare: func(f *fields) {
+				f.mockCNINode.Reconciler.newResourceCleaner = func(nodeID string, eC2Wrapper ec2API.EC2Wrapper, vpcID string) cleanup.ResourceCleaner {
+					assert.Equal(t, "i-1234567890", nodeID)
+					return f.mockResourceCleaner
+				}
+				f.mockResourceCleaner.EXPECT().DeleteLeakedResources().Times(1).Return(nil)
+				f.mockFinalizerManager.EXPECT().
+					RemoveFinalizers(gomock.Any(), gomock.Any(), config.NodeTerminationFinalizer).
+					Return(nil)
+
+			},
+			asserts: func(res reconcile.Result, err error, cniNode *v1alpha1.CNINode) {
+				assert.NoError(t, err)
+				assert.Equal(t, res, reconcile.Result{})
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-
-			mock := NewCNINodeMock(ctrl, tt.args.mockNode, tt.args.mockCNINode)
+			objs := []client.Object{tt.args.mockCNINode}
+			if tt.args.mockNode != nil {
+				objs = append(objs, tt.args.mockNode)
+			}
+			mock := NewCNINodeMock(ctrl, objs...)
 			f := fields{
 				mockResourceCleaner:  mock_cleanup.NewMockResourceCleaner(ctrl),
 				mockK8sApi:           mock_k8s.NewMockK8sWrapper(ctrl),
 				mockFinalizerManager: mock_k8s.NewMockFinalizerManager(ctrl),
+				mockEC2API:           mock_api.NewMockEC2APIHelper(ctrl),
+				mockCNINode:          mock,
 			}
+			mock.Reconciler.finalizerManager = f.mockFinalizerManager
+			mock.Reconciler.k8sAPI = f.mockK8sApi
 			if tt.prepare != nil {
 				tt.prepare(&f)
 			}
@@ -118,5 +196,4 @@ func TestCNINodeReconcile(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	crdcontroller "github.com/aws/amazon-vpc-resource-controller-k8s/controllers/crds"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/api"
 	ec2API "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2/api"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2/api/cleanup"
 	eniCleaner "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2/api/cleanup"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/condition"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
@@ -438,6 +439,7 @@ func main() {
 			clusterName,
 			vpcID,
 			finalizerManager,
+			cleanup.NewNodeResourceCleaner,
 		).SetupWithManager(mgr, maxNodeConcurrentReconciles)); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "CNINode")
 			os.Exit(1)

--- a/pkg/aws/ec2/api/cleanup/node_cleanup.go
+++ b/pkg/aws/ec2/api/cleanup/node_cleanup.go
@@ -14,9 +14,11 @@
 package cleanup
 
 import (
+	ec2API "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2/api"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // NodeTerminationCleanerto handle resource cleanup at node termination
@@ -47,4 +49,17 @@ func (n *NodeTerminationCleaner) UpdateAvailableENIsIfNeeded(eniMap *map[string]
 // Updating node termination metrics does not make much sense as it will be updated on each node deletion and does not give us much info
 func (n *NodeTerminationCleaner) UpdateCleanupMetrics(vpcrcAvailableCount *int, vpccniAvailableCount *int, leakedENICount *int) {
 	return
+}
+
+func NewNodeResourceCleaner(nodeID string, eC2Wrapper ec2API.EC2Wrapper, vpcID string) ResourceCleaner {
+	cleaner := &NodeTerminationCleaner{
+		NodeID: nodeID,
+	}
+	cleaner.ENICleaner = &ENICleaner{
+		EC2Wrapper: eC2Wrapper,
+		Manager:    cleaner,
+		VpcId:      vpcID,
+		Log:        ctrl.Log.WithName("eniCleaner").WithName("node"),
+	}
+	return cleaner.ENICleaner
 }

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -127,7 +127,7 @@ var (
 	// CoolDownPeriod is the time to let kube-proxy propagates IP tables rules before assigning the resource back to new pod
 	CoolDownPeriod = time.Second * 30
 	// ENICleanUpInterval is the time interval between each dangling ENI clean up task
-	ENICleanUpInterval = time.Minute * 2
+	ENICleanUpInterval = time.Minute * 30
 )
 
 // ResourceConfig is the configuration for each resource type

--- a/pkg/provider/branch/trunk/trunk_test.go
+++ b/pkg/provider/branch/trunk/trunk_test.go
@@ -244,7 +244,7 @@ func getMockTrunk() trunkENI {
 		log:               log,
 		usedVlanIds:       make([]bool, MaxAllocatableVlanIds),
 		uidToBranchENIMap: map[string][]*ENIDetails{},
-		nodeNameTag: []awsEc2Types.Tag{
+		nodeIDTag: []awsEc2Types.Tag{
 			{
 				Key:   aws.String(config.NetworkInterfaceNodeIDKey),
 				Value: aws.String(FakeInstance.InstanceID()),
@@ -695,7 +695,7 @@ func TestTrunkENI_InitTrunk(t *testing.T) {
 				f.mockEC2APIHelper.EXPECT().GetInstanceNetworkInterface(&InstanceId).Return([]awsEc2Types.InstanceNetworkInterface{}, nil)
 				f.mockInstance.EXPECT().GetHighestUnusedDeviceIndex().Return(freeIndex, nil)
 				f.mockInstance.EXPECT().SubnetID().Return(SubnetId)
-				f.mockEC2APIHelper.EXPECT().CreateAndAttachNetworkInterface(&InstanceId, &SubnetId, SecurityGroups, f.trunkENI.nodeNameTag,
+				f.mockEC2APIHelper.EXPECT().CreateAndAttachNetworkInterface(&InstanceId, &SubnetId, SecurityGroups, f.trunkENI.nodeIDTag,
 					&freeIndex, &TrunkEniDescription, &InterfaceTypeTrunk, nil).Return(trunkInterface, nil)
 			},
 			// Pass nil to set the instance to fields.mockInstance in the function later
@@ -842,9 +842,9 @@ func TestTrunkENI_CreateAndAssociateBranchENIs(t *testing.T) {
 	mockInstance.EXPECT().SubnetV6CidrBlock().Return(SubnetV6CidrBlock).Times(2)
 
 	mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups,
-		append(vlan1Tag, trunkENI.nodeNameTag...), nil, nil).Return(BranchInterface1, nil)
+		append(vlan1Tag, trunkENI.nodeIDTag...), nil, nil).Return(BranchInterface1, nil)
 	mockEC2APIHelper.EXPECT().AssociateBranchToTrunk(&trunkId, &Branch1Id, VlanId1).Return(mockAssociationOutput1, nil)
-	mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups, append(vlan2Tag, trunkENI.nodeNameTag...),
+	mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups, append(vlan2Tag, trunkENI.nodeIDTag...),
 		nil, nil).Return(BranchInterface2, nil)
 	mockEC2APIHelper.EXPECT().AssociateBranchToTrunk(&trunkId, &Branch2Id, VlanId2).Return(mockAssociationOutput2, nil)
 
@@ -876,10 +876,10 @@ func TestTrunkENI_CreateAndAssociateBranchENIs_InstanceSecurityGroup(t *testing.
 	mockInstance.EXPECT().CurrentInstanceSecurityGroups().Return(InstanceSecurityGroup)
 
 	mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, InstanceSecurityGroup,
-		append(vlan1Tag, trunkENI.nodeNameTag...), nil, nil).Return(BranchInterface1, nil)
+		append(vlan1Tag, trunkENI.nodeIDTag...), nil, nil).Return(BranchInterface1, nil)
 	mockEC2APIHelper.EXPECT().AssociateBranchToTrunk(&trunkId, &Branch1Id, VlanId1).Return(mockAssociationOutput1, nil)
 	mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, InstanceSecurityGroup,
-		append(vlan2Tag, trunkENI.nodeNameTag...), nil, nil).Return(BranchInterface2, nil)
+		append(vlan2Tag, trunkENI.nodeIDTag...), nil, nil).Return(BranchInterface2, nil)
 	mockEC2APIHelper.EXPECT().AssociateBranchToTrunk(&trunkId, &Branch2Id, VlanId2).Return(mockAssociationOutput2, nil)
 
 	eniDetails, err := trunkENI.CreateAndAssociateBranchENIs(MockPod2, []string{}, 2)
@@ -910,10 +910,10 @@ func TestTrunkENI_CreateAndAssociateBranchENIs_ErrorAssociate(t *testing.T) {
 
 	gomock.InOrder(
 		mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups,
-			append(vlan1Tag, trunkENI.nodeNameTag...), nil, nil).Return(BranchInterface1, nil),
+			append(vlan1Tag, trunkENI.nodeIDTag...), nil, nil).Return(BranchInterface1, nil),
 		mockEC2APIHelper.EXPECT().AssociateBranchToTrunk(&trunkId, &Branch1Id, VlanId1).Return(mockAssociationOutput1, nil),
 		mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups,
-			append(vlan2Tag, trunkENI.nodeNameTag...), nil, nil).Return(BranchInterface2, nil),
+			append(vlan2Tag, trunkENI.nodeIDTag...), nil, nil).Return(BranchInterface2, nil),
 		mockEC2APIHelper.EXPECT().AssociateBranchToTrunk(&trunkId, &Branch2Id, VlanId2).Return(nil, MockError),
 	)
 
@@ -937,10 +937,10 @@ func TestTrunkENI_CreateAndAssociateBranchENIs_ErrorCreate(t *testing.T) {
 	mockInstance.EXPECT().SubnetV6CidrBlock().Return(SubnetV6CidrBlock).Times(1)
 
 	gomock.InOrder(
-		mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups, append(vlan1Tag, trunkENI.nodeNameTag...),
+		mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups, append(vlan1Tag, trunkENI.nodeIDTag...),
 			nil, nil).Return(BranchInterface1, nil),
 		mockEC2APIHelper.EXPECT().AssociateBranchToTrunk(&trunkId, &Branch1Id, VlanId1).Return(mockAssociationOutput1, nil),
-		mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups, append(vlan2Tag, trunkENI.nodeNameTag...),
+		mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups, append(vlan2Tag, trunkENI.nodeIDTag...),
 			nil, nil).Return(nil, MockError),
 	)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
skipping node cleaner if node-id tag not present in cninode is not present.

Test:
For node-id not present
1. made sure node-id not present in cninode.
2. detached the eni
3. deleted the node.
4. verified eni's were not deleted by node cleaner.

Also did same test with node-id and observed eni's were cleaned

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
