### PR TITLE
removing security group limit of 5 from crd

### DIFF
--- a/apis/vpcresources/v1beta1/securitygrouppolicy_types.go
+++ b/apis/vpcresources/v1beta1/securitygrouppolicy_types.go
@@ -30,7 +30,6 @@ type SecurityGroupPolicySpec struct {
 type GroupIds struct {
 	// Groups is the list of EC2 Security Groups Ids that need to be applied to the ENI of a Pod.
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=5
 	Groups []string `json:"groupIds,omitempty"`
 }
 

--- a/config/crd/bases/vpcresources.k8s.aws_cninodes.yaml
+++ b/config/crd/bases/vpcresources.k8s.aws_cninodes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: cninodes.vpcresources.k8s.aws
 spec:
   group: vpcresources.k8s.aws

--- a/config/crd/bases/vpcresources.k8s.aws_securitygrouppolicies.yaml
+++ b/config/crd/bases/vpcresources.k8s.aws_securitygrouppolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: securitygrouppolicies.vpcresources.k8s.aws
 spec:
   group: vpcresources.k8s.aws
@@ -105,7 +105,6 @@ spec:
                       need to be applied to the ENI of a Pod.
                     items:
                       type: string
-                    maxItems: 5
                     minItems: 1
                     type: array
                 type: object

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -15,16 +15,8 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - nodes
+  - serviceaccounts
   verbs:
   - get
   - list
@@ -39,10 +31,11 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - serviceaccounts
+  - pods
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - crd.k8s.amazonaws.com
@@ -80,21 +73,21 @@ metadata:
   namespace: kube-system
 rules:
 - apiGroups:
-  - apps
-  resourceNames:
-  - vpc-resource-controller
-  resources:
-  - deployments
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - ""
   resourceNames:
   - amazon-vpc-cni
   resources:
   - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resourceNames:
+  - vpc-resource-controller
+  resources:
+  - deployments
   verbs:
   - get
   - list

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -11,7 +11,7 @@ main() {
 
 tools() {
     go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230216140739-c98506dc3b8e
-    go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
+    go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.18.0
     go install github.com/google/ko@latest
 
     if ! echo "$PATH" | grep -q "${GOPATH:-undefined}/bin\|$HOME/go/bin"; then


### PR DESCRIPTION
*Issue #, if available:*
Removing the validation in security groups where we limit IDs by 5.
Regenerated CRD spec with newest controller-gen version. 
*Description of changes:*
We will open fail now if Cx quota for security group per network interface is less than what it matches to pod. 


Created SGP with 7 group ids, quota in my account was 5.

We failed to create pod 
```
 failed to allocate branch ENI to pod: creating network interface, operation error EC2: CreateNetworkInterface, https response error StatusCode: 400, RequestID: f3c2ff75-4ed5-433e-a797-c15a27804f8d, api error InvalidParameterValue: user 975050023620 exceeded limit 5 on the number of interface security group memberships
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
