### PR TITLE
Add IPv6 support for branch ENIs in dual-stack subnets

### DIFF
--- a/pkg/aws/ec2/api/helper.go
+++ b/pkg/aws/ec2/api/helper.go
@@ -136,15 +136,27 @@ func (h *ec2APIHelper) CreateNetworkInterface(description *string, subnetId *str
 	if ipResourceCount != nil {
 		secondaryPrivateIPCount := ipResourceCount.SecondaryIPv4Count
 		ipV4PrefixCount := ipResourceCount.IPv4PrefixCount
+		secondaryIPv6Count := ipResourceCount.SecondaryIPv6Count
+		ipV6PrefixCount := ipResourceCount.IPv6PrefixCount
 
 		if secondaryPrivateIPCount != 0 && ipV4PrefixCount != 0 {
 			return nil, fmt.Errorf("cannot specify both secondaryPrivateIPCount %v and ipV4PrefixCount %v", secondaryPrivateIPCount, ipV4PrefixCount)
+		}
+
+		if secondaryIPv6Count != 0 && ipV6PrefixCount != 0 {
+			return nil, fmt.Errorf("cannot specify both secondaryIPv6Count %v and ipV6PrefixCount %v", secondaryIPv6Count, ipV6PrefixCount)
 		}
 
 		if secondaryPrivateIPCount != 0 {
 			createInput.SecondaryPrivateIpAddressCount = aws.Int32(int32(secondaryPrivateIPCount))
 		} else if ipV4PrefixCount != 0 {
 			createInput.Ipv4PrefixCount = aws.Int32(int32(ipV4PrefixCount))
+		}
+
+		if secondaryIPv6Count != 0 {
+			createInput.Ipv6AddressCount = aws.Int32(int32(secondaryIPv6Count))
+		} else if ipV6PrefixCount != 0 {
+			createInput.Ipv6PrefixCount = aws.Int32(int32(ipV6PrefixCount))
 		}
 	}
 

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -103,6 +103,8 @@ const (
 type IPResourceCount struct {
 	SecondaryIPv4Count int
 	IPv4PrefixCount    int
+	SecondaryIPv6Count int
+	IPv6PrefixCount    int
 }
 
 // Events metadata

--- a/pkg/provider/branch/trunk/trunk.go
+++ b/pkg/provider/branch/trunk/trunk.go
@@ -428,9 +428,18 @@ func (t *trunkENI) CreateAndAssociateBranchENIs(pod *v1.Pod, securityGroups []st
 		}
 		// append the nodeName tag to add to branch ENIs
 		tags = append(tags, t.nodeIDTag...)
+
+		// Request IPv6 address for the branch ENI if the subnet has IPv6 enabled
+		var ipResourceCount *config.IPResourceCount
+		if t.instance.SubnetV6CidrBlock() != "" {
+			ipResourceCount = &config.IPResourceCount{
+				SecondaryIPv6Count: 1,
+			}
+		}
+
 		// Create Branch ENI
 		nwInterface, err = t.ec2ApiHelper.CreateNetworkInterface(&BranchEniDescription,
-			aws.String(t.instance.SubnetID()), securityGroups, tags, nil, nil)
+			aws.String(t.instance.SubnetID()), securityGroups, tags, ipResourceCount, nil)
 		if err != nil {
 			err = fmt.Errorf("creating network interface, %w", err)
 			t.freeVlanId(vlanID)

--- a/pkg/provider/branch/trunk/trunk_test.go
+++ b/pkg/provider/branch/trunk/trunk_test.go
@@ -95,6 +95,11 @@ var (
 	SecurityGroup2 = "sg-0000000000000"
 	SecurityGroups = []string{SecurityGroup1, SecurityGroup2}
 
+	// IP Resource Count for IPv6
+	IPv6ResourceCount = &config.IPResourceCount{
+		SecondaryIPv6Count: 1,
+	}
+
 	// Branch Interface 1
 	Branch1Id          = "eni-00000000000000000"
 	MacAddr1           = "FF:FF:FF:FF:FF:FF"
@@ -839,13 +844,13 @@ func TestTrunkENI_CreateAndAssociateBranchENIs(t *testing.T) {
 	mockInstance.EXPECT().Type().Return(InstanceType)
 	mockInstance.EXPECT().SubnetID().Return(SubnetId).Times(2)
 	mockInstance.EXPECT().SubnetCidrBlock().Return(SubnetCidrBlock).Times(2)
-	mockInstance.EXPECT().SubnetV6CidrBlock().Return(SubnetV6CidrBlock).Times(2)
+	mockInstance.EXPECT().SubnetV6CidrBlock().Return(SubnetV6CidrBlock).Times(4)
 
 	mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups,
-		append(vlan1Tag, trunkENI.nodeIDTag...), nil, nil).Return(BranchInterface1, nil)
+		append(vlan1Tag, trunkENI.nodeIDTag...), IPv6ResourceCount, nil).Return(BranchInterface1, nil)
 	mockEC2APIHelper.EXPECT().AssociateBranchToTrunk(&trunkId, &Branch1Id, VlanId1).Return(mockAssociationOutput1, nil)
 	mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups, append(vlan2Tag, trunkENI.nodeIDTag...),
-		nil, nil).Return(BranchInterface2, nil)
+		IPv6ResourceCount, nil).Return(BranchInterface2, nil)
 	mockEC2APIHelper.EXPECT().AssociateBranchToTrunk(&trunkId, &Branch2Id, VlanId2).Return(mockAssociationOutput2, nil)
 
 	eniDetails, err := trunkENI.CreateAndAssociateBranchENIs(MockPod2, SecurityGroups, 2)
@@ -872,14 +877,14 @@ func TestTrunkENI_CreateAndAssociateBranchENIs_InstanceSecurityGroup(t *testing.
 	mockInstance.EXPECT().Type().Return(InstanceType)
 	mockInstance.EXPECT().SubnetID().Return(SubnetId).Times(2)
 	mockInstance.EXPECT().SubnetCidrBlock().Return(SubnetCidrBlock).Times(2)
-	mockInstance.EXPECT().SubnetV6CidrBlock().Return(SubnetV6CidrBlock).Times(2)
+	mockInstance.EXPECT().SubnetV6CidrBlock().Return(SubnetV6CidrBlock).Times(4)
 	mockInstance.EXPECT().CurrentInstanceSecurityGroups().Return(InstanceSecurityGroup)
 
 	mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, InstanceSecurityGroup,
-		append(vlan1Tag, trunkENI.nodeIDTag...), nil, nil).Return(BranchInterface1, nil)
+		append(vlan1Tag, trunkENI.nodeIDTag...), IPv6ResourceCount, nil).Return(BranchInterface1, nil)
 	mockEC2APIHelper.EXPECT().AssociateBranchToTrunk(&trunkId, &Branch1Id, VlanId1).Return(mockAssociationOutput1, nil)
 	mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, InstanceSecurityGroup,
-		append(vlan2Tag, trunkENI.nodeIDTag...), nil, nil).Return(BranchInterface2, nil)
+		append(vlan2Tag, trunkENI.nodeIDTag...), IPv6ResourceCount, nil).Return(BranchInterface2, nil)
 	mockEC2APIHelper.EXPECT().AssociateBranchToTrunk(&trunkId, &Branch2Id, VlanId2).Return(mockAssociationOutput2, nil)
 
 	eniDetails, err := trunkENI.CreateAndAssociateBranchENIs(MockPod2, []string{}, 2)
@@ -906,14 +911,14 @@ func TestTrunkENI_CreateAndAssociateBranchENIs_ErrorAssociate(t *testing.T) {
 	mockInstance.EXPECT().Type().Return(InstanceType)
 	mockInstance.EXPECT().SubnetID().Return(SubnetId).Times(2)
 	mockInstance.EXPECT().SubnetCidrBlock().Return(SubnetCidrBlock).Times(2)
-	mockInstance.EXPECT().SubnetV6CidrBlock().Return(SubnetV6CidrBlock).Times(2)
+	mockInstance.EXPECT().SubnetV6CidrBlock().Return(SubnetV6CidrBlock).Times(4)
 
 	gomock.InOrder(
 		mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups,
-			append(vlan1Tag, trunkENI.nodeIDTag...), nil, nil).Return(BranchInterface1, nil),
+			append(vlan1Tag, trunkENI.nodeIDTag...), IPv6ResourceCount, nil).Return(BranchInterface1, nil),
 		mockEC2APIHelper.EXPECT().AssociateBranchToTrunk(&trunkId, &Branch1Id, VlanId1).Return(mockAssociationOutput1, nil),
 		mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups,
-			append(vlan2Tag, trunkENI.nodeIDTag...), nil, nil).Return(BranchInterface2, nil),
+			append(vlan2Tag, trunkENI.nodeIDTag...), IPv6ResourceCount, nil).Return(BranchInterface2, nil),
 		mockEC2APIHelper.EXPECT().AssociateBranchToTrunk(&trunkId, &Branch2Id, VlanId2).Return(nil, MockError),
 	)
 
@@ -934,19 +939,44 @@ func TestTrunkENI_CreateAndAssociateBranchENIs_ErrorCreate(t *testing.T) {
 	mockInstance.EXPECT().Type().Return(InstanceType)
 	mockInstance.EXPECT().SubnetID().Return(SubnetId).Times(2)
 	mockInstance.EXPECT().SubnetCidrBlock().Return(SubnetCidrBlock).Times(1)
-	mockInstance.EXPECT().SubnetV6CidrBlock().Return(SubnetV6CidrBlock).Times(1)
+	mockInstance.EXPECT().SubnetV6CidrBlock().Return(SubnetV6CidrBlock).Times(3)
 
 	gomock.InOrder(
 		mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups, append(vlan1Tag, trunkENI.nodeIDTag...),
-			nil, nil).Return(BranchInterface1, nil),
+			IPv6ResourceCount, nil).Return(BranchInterface1, nil),
 		mockEC2APIHelper.EXPECT().AssociateBranchToTrunk(&trunkId, &Branch1Id, VlanId1).Return(mockAssociationOutput1, nil),
 		mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups, append(vlan2Tag, trunkENI.nodeIDTag...),
-			nil, nil).Return(nil, MockError),
+			IPv6ResourceCount, nil).Return(nil, MockError),
 	)
 
 	_, err := trunkENI.CreateAndAssociateBranchENIs(MockPod2, SecurityGroups, 2)
 	assert.Error(t, MockError, err)
 	assert.Equal(t, []*ENIDetails{EniDetails1}, trunkENI.deleteQueue)
+}
+
+// TestTrunkENI_CreateAndAssociateBranchENIs_NoIPv6Subnet tests that IPv6 is NOT requested when subnet has no IPv6 CIDR
+func TestTrunkENI_CreateAndAssociateBranchENIs_NoIPv6Subnet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, mockEC2APIHelper, mockInstance := getMockHelperInstanceAndTrunkObject(ctrl)
+	trunkENI.trunkENIId = trunkId
+
+	mockInstance.EXPECT().Type().Return(InstanceType)
+	mockInstance.EXPECT().SubnetID().Return(SubnetId).Times(1)
+	mockInstance.EXPECT().SubnetCidrBlock().Return(SubnetCidrBlock).Times(1)
+	mockInstance.EXPECT().SubnetV6CidrBlock().Return("").Times(2) // Empty string = no IPv6
+
+	// Expect nil for ipResourceCount when no IPv6 subnet
+	mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups,
+		append(vlan1Tag, trunkENI.nodeIDTag...), nil, nil).Return(BranchInterface1, nil)
+	mockEC2APIHelper.EXPECT().AssociateBranchToTrunk(&trunkId, &Branch1Id, VlanId1).Return(mockAssociationOutput1, nil)
+
+	eniDetails, err := trunkENI.CreateAndAssociateBranchENIs(MockPod2, SecurityGroups, 1)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(eniDetails))
+	assert.True(t, trunkENI.usedVlanIds[VlanId1])
 }
 
 func TestTrunkENI_Introspect(t *testing.T) {


### PR DESCRIPTION
Branch ENIs were not receiving IPv6 addresses when deployed in dual-stack subnets (subnets with both IPv4 and IPv6 CIDR blocks). The controller checks if the subnet has an IPv6 CIDR block but did not request IPv6 addresses in the CreateNetworkInterface API call, resulting in IPv4-only ENIs even when IPv6 was available.

AWS automatically assigns one primary IPv4 address when creating ENIs in dual-stack subnets, but IPv6 addresses must be explicitly requested via the Ipv6AddressCount or Ipv6PrefixCount parameters.

The fix adds SecondaryIPv6Count and IPv6PrefixCount fields to the IPResourceCount struct and updates CreateNetworkInterface to pass these to the EC2 API when non-zero. The trunk ENI provider now requests one IPv6 address when creating branch ENIs in subnets that have an IPv6 CIDR block.

This enables pods using branch ENIs to communicate over IPv6 in dual-stack environments. The controller provisions IP addresses that match the subnet's capabilities, allowing the pod/kubelet/CNI layer to decide which IP family to use.

Test coverage was added to verify IPv6 parameters are handled correctly in the EC2 helper and that branch ENIs request IPv6 only when the subnet has an IPv6 CIDR block. Tests also verify that IPv6 is NOT requested in IPv4-only subnets.

Closes: https://github.com/aws/amazon-vpc-resource-controller-k8s/issues/635

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
