### PR TITLE
add timeout to AWS SDK clients

### DIFF
--- a/pkg/aws/ec2/api/wrapper.go
+++ b/pkg/aws/ec2/api/wrapper.go
@@ -481,9 +481,12 @@ func NewEC2Wrapper(roleARN, clusterName, region string, instanceClientQPS, insta
 
 func (e *ec2Wrapper) getInstanceConfig() (*aws.Config, error) {
 	// Create a new config
-	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithAPIOptions([]func(stack *smithymiddleware.Stack) error{
-		awsmiddleware.AddUserAgentKeyValue(AppName, version.GitVersion),
-	}))
+	cfg, err := config.LoadDefaultConfig(context.TODO(),
+		config.WithHTTPClient(utils.NewAWSSDKHTTPClient()),
+		config.WithAPIOptions([]func(stack *smithymiddleware.Stack) error{
+			awsmiddleware.AddUserAgentKeyValue(AppName, version.GitVersion),
+		}),
+	)
 	if err != nil {
 		return &cfg, fmt.Errorf("failed to load AWS config: %w", err)
 	}
@@ -520,6 +523,7 @@ func (e *ec2Wrapper) getInstanceServiceClient(qps int, burst int, cfg aws.Config
 func (e *ec2Wrapper) getClientUsingAssumedRole(instanceRegion, roleARN, clusterName, region string, qps, burst int) (*ec2.Client, error) {
 	cfg, err := config.LoadDefaultConfig(context.TODO(),
 		config.WithRegion(instanceRegion),
+		config.WithHTTPClient(utils.NewAWSSDKHTTPClient()),
 		config.WithRetryer(func() aws.Retryer {
 			return retry.NewStandard(func(o *retry.StandardOptions) {
 				o.MaxAttempts = MaxRetries

--- a/pkg/utils/httpClient.go
+++ b/pkg/utils/httpClient.go
@@ -14,36 +14,53 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"golang.org/x/time/rate"
 )
 
-// NewRateLimitedClient returns a new HTTP client with rate limiter.
+const (
+	// defaultAWSSDKClientTimeout is the timeout for individual HTTP requests made by AWS SDK clients.
+	defaultAWSSDKClientTimeout = 30 * time.Second
+)
+
+// NewAWSSDKHTTPClient returns a new HTTP client with the default AWS SDK timeout.
+func NewAWSSDKHTTPClient() *http.Client {
+	return &http.Client{Timeout: defaultAWSSDKClientTimeout}
+}
+
+// NewRateLimitedClient returns a new HTTP client with rate limiter and the default AWS SDK timeout.
+// The timeout is applied after the rate limit wait, so queue time does not eat into the HTTP timeout.
 func NewRateLimitedClient(qps int, burst int) (*http.Client, error) {
 	if qps == 0 {
-		return http.DefaultClient, nil
+		return NewAWSSDKHTTPClient(), nil
 	}
 	if burst < 1 {
 		return nil, fmt.Errorf("burst expected >0, got %d", burst)
 	}
 	return &http.Client{
 		Transport: &rateLimitedRoundTripper{
-			rt: http.DefaultTransport,
-			rl: rate.NewLimiter(rate.Limit(qps), burst),
+			rt:      http.DefaultTransport,
+			rl:      rate.NewLimiter(rate.Limit(qps), burst),
+			timeout: defaultAWSSDKClientTimeout,
 		},
 	}, nil
 }
 
 type rateLimitedRoundTripper struct {
-	rt http.RoundTripper
-	rl *rate.Limiter
+	rt      http.RoundTripper
+	rl      *rate.Limiter
+	timeout time.Duration
 }
 
 func (rr *rateLimitedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err := rr.rl.Wait(req.Context()); err != nil {
 		return nil, err
 	}
-	return rr.rt.RoundTrip(req)
+	ctx, cancel := context.WithTimeout(req.Context(), rr.timeout)
+	defer cancel()
+	return rr.rt.RoundTrip(req.WithContext(ctx))
 }

--- a/pkg/utils/httpClient_test.go
+++ b/pkg/utils/httpClient_test.go
@@ -140,3 +140,37 @@ func testHandler(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "Method Not Allowed", 405)
 	}
 }
+
+func TestNewAWSSDKHTTPClient_SetsTimeout(t *testing.T) {
+	client := NewAWSSDKHTTPClient()
+	if client.Timeout != defaultAWSSDKClientTimeout {
+		t.Fatalf("expected timeout %v, got %v", defaultAWSSDKClientTimeout, client.Timeout)
+	}
+}
+
+func TestNewRateLimitedClient_SetsTimeout(t *testing.T) {
+	// With qps=0, should return client with timeout (not http.DefaultClient)
+	cli, err := NewRateLimitedClient(0, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cli == http.DefaultClient {
+		t.Fatal("expected a new client, got http.DefaultClient")
+	}
+	if cli.Timeout != defaultAWSSDKClientTimeout {
+		t.Fatalf("expected timeout %v, got %v", defaultAWSSDKClientTimeout, cli.Timeout)
+	}
+
+	// With qps>0, timeout is on the transport, not the client
+	cli, err = NewRateLimitedClient(10, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rt, ok := cli.Transport.(*rateLimitedRoundTripper)
+	if !ok {
+		t.Fatal("expected rateLimitedRoundTripper transport")
+	}
+	if rt.timeout != defaultAWSSDKClientTimeout {
+		t.Fatalf("expected transport timeout %v, got %v", defaultAWSSDKClientTimeout, rt.timeout)
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
AWS SDK v2 defaults to no HTTP request timeout, which means API calls can hang indefinitely if AWS is unresponsive. Set a 10-second timeout on all SDK clients by configuring their clients.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
