### PR TITLE
chore: migrate docker base images from AL2 to AL2023 (#647)

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest.2
+defaultBaseImage: public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest-al23

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 ARG BUILD_IMAGE
-ARG GORUNNER_VERSION=public.ecr.aws/eks-distro-build-tooling/go-runner:v0.18.0-go-1.26-latest.al2
+ARG GORUNNER_VERSION=public.ecr.aws/eks-distro-build-tooling/go-runner:v0.18.0-go-1.26-latest.al23
 ARG ARCH
 # Build the controller binary
 FROM $BUILD_IMAGE AS builder

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ MAKEFILE_PATH = $(dir $(realpath -s $(firstword $(MAKEFILE_LIST))))
 
 VERSION ?= $(GIT_VERSION)
 IMAGE ?= $(REPO):$(VERSION)
-BASE_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest.2
+BASE_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:latest-al23
 GOLANG_VERSION ?= $(shell cat .go-version)
 BUILD_IMAGE ?= public.ecr.aws/docker/library/golang:$(GOLANG_VERSION)
-GORUNNER_VERSION ?= public.ecr.aws/eks-distro-build-tooling/go-runner:v0.18.0-go-1.26-latest.al2
+GORUNNER_VERSION ?= public.ecr.aws/eks-distro-build-tooling/go-runner:v0.18.0-go-1.26-latest.al23
 GOARCH ?= amd64
 PLATFORM ?= linux/amd64
 USER_ROLE_ARN ?= arn:aws:iam::$(AWS_ACCOUNT):role/VPCResourceControllerRole


### PR DESCRIPTION
## Summary
Closes #647. Migrates docker base images from Amazon Linux 2 to Amazon Linux 2023 ahead of the AL2 EOL (2026-06-30).

## Files changed
- `Dockerfile` — `GORUNNER_VERSION` `go-1.26-latest.al2` → `go-1.26-latest.al23`
- `Makefile` — `BASE_IMAGE` `latest.2` → `latest-al23` and `GORUNNER_VERSION` to match
- `.ko.yaml` — `defaultBaseImage` `latest.2` → `latest-al23`

Tags verified against the public ECR registry (`latest-al23` and `v0.18.0-go-1.26-latest.al23` both exist).

## Notes
- No `yum`→`dnf` work needed — the Dockerfile uses the `eks-distro-minimal-base-nonroot` distroless image and just `COPY`s the prebuilt Go binary in.
- CI (`.github/workflows/presubmit.yaml`) uses `ubuntu-latest`, no AL2 base images.

## Prior attempts
PRs #648 and #650 attempted this earlier and were closed without merge or feedback. This PR uses the correct `latest-al23` tag format and picks up the matching `go-1.26-latest.al23` go-runner tag.
