### PR TITLE
fix: use awshttp.BuildableClient to prevent panic in air-gapped regions

### DIFF
--- a/pkg/utils/httpClient.go
+++ b/pkg/utils/httpClient.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"time"
 
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"golang.org/x/time/rate"
 )
 
@@ -28,15 +29,17 @@ const (
 )
 
 // NewAWSSDKHTTPClient returns a new HTTP client with the default AWS SDK timeout.
-func NewAWSSDKHTTPClient() *http.Client {
-	return &http.Client{Timeout: defaultAWSSDKClientTimeout}
+// It returns *awshttp.BuildableClient (instead of *http.Client) so the SDK can
+// inject custom CA bundles via WithTransportOptions in air-gapped regions.
+func NewAWSSDKHTTPClient() *awshttp.BuildableClient {
+	return awshttp.NewBuildableClient().WithTimeout(defaultAWSSDKClientTimeout)
 }
 
 // NewRateLimitedClient returns a new HTTP client with rate limiter and the default AWS SDK timeout.
 // The timeout is applied after the rate limit wait, so queue time does not eat into the HTTP timeout.
 func NewRateLimitedClient(qps int, burst int) (*http.Client, error) {
 	if qps == 0 {
-		return NewAWSSDKHTTPClient(), nil
+		return &http.Client{Timeout: defaultAWSSDKClientTimeout}, nil
 	}
 	if burst < 1 {
 		return nil, fmt.Errorf("burst expected >0, got %d", burst)

--- a/pkg/utils/httpClient_test.go
+++ b/pkg/utils/httpClient_test.go
@@ -143,8 +143,8 @@ func testHandler(w http.ResponseWriter, req *http.Request) {
 
 func TestNewAWSSDKHTTPClient_SetsTimeout(t *testing.T) {
 	client := NewAWSSDKHTTPClient()
-	if client.Timeout != defaultAWSSDKClientTimeout {
-		t.Fatalf("expected timeout %v, got %v", defaultAWSSDKClientTimeout, client.Timeout)
+	if client.GetTimeout() != defaultAWSSDKClientTimeout {
+		t.Fatalf("expected timeout %v, got %v", defaultAWSSDKClientTimeout, client.GetTimeout())
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**Which issue does this PR fix?**:
Fixes panic in air-gapped regions introduced by #655

**What does this PR do / Why do we need it?**:
In air-gapped regions, the AWS SDK's `resolveCustomCABundle()` needs to inject custom CA certificates into the HTTP client's TLS transport via `WithTransportOptions()`. PR #655 introduced `NewAWSSDKHTTPClient()` which returns a plain `*http.Client`, but the SDK expects `*awshttp.BuildableClient` for CA bundle injection. This causes a panic:

```
panic: unable to add custom RootCAs HTTPClient, has no WithTransportOptions, *http.Client
```

`NewAWSSDKHTTPClient()` is used in `wrapper.go` via `config.WithHTTPClient()` in two places (`getInstanceConfig` and `getClientUsingAssumedRole`).

This PR changes `NewAWSSDKHTTPClient()` to return `*awshttp.BuildableClient` via `awshttp.NewBuildableClient().WithTimeout(...)`. `NewRateLimitedClient` (used for EC2 service clients, not `config.LoadDefaultConfig`) continues to return `*http.Client` since it doesn't go through the CA bundle resolution path.

**Testing done on this change**:
- All utils tests pass (`go test ./pkg/utils/... -v`)
- All affected packages compile (`go build ./pkg/utils/... ./pkg/aws/ec2/api/...`)

**Will this PR introduce any new dependencies?**: No
**Will this break upgrades or downgrades?**: No
**Does this change require updates to the VPC resource controller config?**: No
**Does this PR introduce any user-facing change?**: No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.