### PR TITLE
chore: update default vpc-cni version in test scripts

### DIFF
--- a/scripts/test/install-vpc-cni.sh
+++ b/scripts/test/install-vpc-cni.sh
@@ -5,7 +5,7 @@
 set -eo pipefail
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")" || exit 1; pwd)
-DEFAULT_VPC_CNI_VERSION="1.11"
+DEFAULT_VPC_CNI_VERSION="1.21"
 
 source "$SCRIPTS_DIR/lib/k8s.sh"
 source "$SCRIPTS_DIR/lib/common.sh"

--- a/scripts/test/test-with-eksctl.sh
+++ b/scripts/test/test-with-eksctl.sh
@@ -258,7 +258,7 @@ trap 'on_exit' EXIT
 kubectl cordon -l kubernetes.io/os=windows
 
 # Install the stable version of VPC CNI
-bash "$SCRIPTS_DIR/install-vpc-cni.sh" "1.11"
+bash "$SCRIPTS_DIR/install-vpc-cni.sh" "1.21"
 
 # Install Cert Manager which is used for generating the
 # certificates for the Webhooks


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Updating VPC CNI version that will be installed when running tests locally with `test-with-eksctl.sh`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
