### PR TITLE
Add subnetID to CNINode status.trunkInterface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ verify:
 
 ## Run unit tests
 test: verify
-	go test -race ./pkg/... ./controllers/... ./webhooks/... -coverprofile cover.out
+	go test -race ./apis/... ./pkg/... ./controllers/... ./webhooks/... -coverprofile cover.out
 
 test-e2e:
 	KUBE_CONFIG_PATH=${KUBE_CONFIG_PATH} REGION=${AWS_REGION} CLUSTER_NAME=${CLUSTER_NAME} ./scripts/test/run-integration-tests.sh

--- a/apis/vpcresources/crds/vpcresources.k8s.aws_cninodes.yaml
+++ b/apis/vpcresources/crds/vpcresources.k8s.aws_cninodes.yaml
@@ -175,6 +175,16 @@ spec:
                   macAddress:
                     description: MacAddress is the MAC address of the trunk ENI.
                     type: string
+                  subnetID:
+                    description: |-
+                      SubnetID is the id of the EC2 subnet the trunk ENI resides in, which is
+                      also the subnet its branch ENIs are created in. Persisted with the trunk
+                      so a controller can create a branch ENI straight from the CNINode,
+                      without a DescribeNetworkInterfaces call on the pod path, and so the
+                      value survives a controller restart that drops in-memory node state.
+                    maxLength: 24
+                    pattern: ^subnet-([0-9a-f]{8}|[0-9a-f]{17})$
+                    type: string
                 required:
                 - id
                 type: object

--- a/apis/vpcresources/crds_test.go
+++ b/apis/vpcresources/crds_test.go
@@ -15,6 +15,7 @@ package vpcresources
 
 import (
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,6 +43,45 @@ func TestCRDsUnmarshal(t *testing.T) {
 	assert.Contains(t, specProps, "managedBy")
 	require.Len(t, version.SelectableFields, 1)
 	assert.Equal(t, ".spec.managedBy", version.SelectableFields[0].JSONPath)
+}
+
+// TestTrunkInterfaceSubnetIDSchema pins the trunk subnetID contract: a
+// controller reads this field instead of calling EC2 DescribeNetworkInterfaces
+// to learn where to create branch ENIs, so both the property name and the
+// server-side validation are part of the API surface consumers depend on.
+func TestTrunkInterfaceSubnetIDSchema(t *testing.T) {
+	require.Len(t, CNINodeCRD.Spec.Versions, 1)
+	trunk := CNINodeCRD.Spec.Versions[0].Schema.OpenAPIV3Schema.
+		Properties["status"].Properties["trunkInterface"]
+
+	subnetID, ok := trunk.Properties["subnetID"]
+	require.True(t, ok, "status.trunkInterface.subnetID must be in the schema")
+	assert.Equal(t, "string", subnetID.Type)
+	assert.Equal(t, `^subnet-([0-9a-f]{8}|[0-9a-f]{17})$`, subnetID.Pattern)
+	require.NotNil(t, subnetID.MaxLength)
+	assert.EqualValues(t, 24, *subnetID.MaxLength)
+
+	// Optional: only the trunk's own id is required, so existing objects and
+	// controllers that never set a subnet stay valid.
+	assert.NotContains(t, trunk.Required, "subnetID")
+	assert.Equal(t, []string{"id"}, trunk.Required)
+
+	// Exercise the pattern the API server will enforce, so a typo in it cannot
+	// silently reject real subnet ids. EC2 issues both the legacy 8-hex and
+	// the current 17-hex forms.
+	re, err := regexp.Compile(subnetID.Pattern)
+	require.NoError(t, err)
+	for _, valid := range []string{"subnet-1a2b3c4d", "subnet-0123456789abcdef0", "subnet-00000000"} {
+		assert.True(t, re.MatchString(valid), "%q must be accepted", valid)
+	}
+	for _, invalid := range []string{
+		"", "subnet-", "subnet-1a2b3c4", "subnet-1a2b3c4de", // wrong hex length
+		"subnet-0123456789ABCDEF0",     // uppercase hex
+		"eni-1a2b3c4d", "vpc-1a2b3c4d", // wrong resource type
+		"subnet-1a2b3c4d ", " subnet-1a2b3c4d", // surrounding whitespace
+	} {
+		assert.False(t, re.MatchString(invalid), "%q must be rejected", invalid)
+	}
 }
 
 // TestEmbeddedCRDsMatchGenerated fails if the embedded copies drift from the

--- a/apis/vpcresources/v1alpha1/cninode_types.go
+++ b/apis/vpcresources/v1alpha1/cninode_types.go
@@ -86,6 +86,15 @@ type TrunkInterface struct {
 	// DeviceIndex is the attachment device index of the trunk ENI on the instance.
 	// +optional
 	DeviceIndex int32 `json:"deviceIndex,omitempty"`
+	// SubnetID is the id of the EC2 subnet the trunk ENI resides in, which is
+	// also the subnet its branch ENIs are created in. Persisted with the trunk
+	// so a controller can create a branch ENI straight from the CNINode,
+	// without a DescribeNetworkInterfaces call on the pod path, and so the
+	// value survives a controller restart that drops in-memory node state.
+	// +optional
+	// +kubebuilder:validation:MaxLength=24
+	// +kubebuilder:validation:Pattern=`^subnet-([0-9a-f]{8}|[0-9a-f]{17})$`
+	SubnetID string `json:"subnetID,omitempty"`
 	// Branches are the branch ENIs associated with this trunk ENI.
 	// Listed as a map keyed by id so distinct field managers can own
 	// individual entries under Server-Side Apply without conflicting.

--- a/apis/vpcresources/v1alpha1/cninode_types_test.go
+++ b/apis/vpcresources/v1alpha1/cninode_types_test.go
@@ -1,0 +1,61 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTrunkInterfaceSubnetIDWireFormat pins the serialized field name and the
+// omitempty behaviour. Node-side components read this off the CNINode by its
+// wire name, so renaming it is a breaking change, and emitting an empty
+// subnetID would fail the CRD's pattern validation on objects that legitimately
+// have no subnet recorded.
+func TestTrunkInterfaceSubnetIDWireFormat(t *testing.T) {
+	withSubnet, err := json.Marshal(TrunkInterface{ID: "eni-1a2b3c4d", SubnetID: "subnet-0123456789abcdef0"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"id":"eni-1a2b3c4d","subnetID":"subnet-0123456789abcdef0"}`, string(withSubnet))
+
+	// Unset must be omitted entirely, not serialized as "".
+	withoutSubnet, err := json.Marshal(TrunkInterface{ID: "eni-1a2b3c4d"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"id":"eni-1a2b3c4d"}`, string(withoutSubnet))
+
+	var round TrunkInterface
+	require.NoError(t, json.Unmarshal(withSubnet, &round))
+	assert.Equal(t, "subnet-0123456789abcdef0", round.SubnetID)
+}
+
+// TestTrunkInterfaceDeepCopyCarriesSubnetID guards against the generated
+// deepcopy dropping the field, which would silently lose it on any controller
+// that mutates a cached CNINode copy.
+func TestTrunkInterfaceDeepCopyCarriesSubnetID(t *testing.T) {
+	original := &TrunkInterface{
+		ID:       "eni-1a2b3c4d",
+		SubnetID: "subnet-0123456789abcdef0",
+		Branches: []BranchInterface{{ID: "eni-9f8e7d6c", VlanID: 1}},
+	}
+
+	copied := original.DeepCopy()
+	assert.Equal(t, original, copied)
+	assert.Equal(t, "subnet-0123456789abcdef0", copied.SubnetID)
+
+	// Mutating the copy must not touch the original (independent memory).
+	copied.SubnetID = "subnet-1a2b3c4d"
+	assert.Equal(t, "subnet-0123456789abcdef0", original.SubnetID)
+}

--- a/config/crd/bases/vpcresources.k8s.aws_cninodes.yaml
+++ b/config/crd/bases/vpcresources.k8s.aws_cninodes.yaml
@@ -175,6 +175,16 @@ spec:
                   macAddress:
                     description: MacAddress is the MAC address of the trunk ENI.
                     type: string
+                  subnetID:
+                    description: |-
+                      SubnetID is the id of the EC2 subnet the trunk ENI resides in, which is
+                      also the subnet its branch ENIs are created in. Persisted with the trunk
+                      so a controller can create a branch ENI straight from the CNINode,
+                      without a DescribeNetworkInterfaces call on the pod path, and so the
+                      value survives a controller restart that drops in-memory node state.
+                    maxLength: 24
+                    pattern: ^subnet-([0-9a-f]{8}|[0-9a-f]{17})$
+                    type: string
                 required:
                 - id
                 type: object


### PR DESCRIPTION
A controller that creates branch ENIs needs the subnet the trunk ENI lives in — branch ENIs are created in the trunk's subnet. Today that means an EC2 DescribeNetworkInterfaces call on the trunk to recover a value the controller already knew when it created the trunk, and the call sits on the pod path. It is also lost across a controller restart, since it is only held in memory.

Persist it with the trunk instead. status.trunkInterface.subnetID is optional, so pre-existing objects and controllers that never set it stay valid; when set, the API server validates the EC2 subnet id form (8- or 17-hex, maxLength 24). No subnet id is added to BranchInterface: branches are always created in the trunk's subnet, and BranchInterface already carries subnetCIDR.

Tests: schema contract for the new property (type, pattern, maxLength, optionality) plus accept/reject cases exercised against the shipped pattern; wire-format (field name, omitempty) and deepcopy round-trip on the Go type. ./apis/... added to the make test target so these — and the pre-existing crds_test.go, which no target ran — execute in CI.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
