### PR TITLE
Fix orphan branch-ENI / VLAN lifecycle under high churn

### DIFF
--- a/pkg/provider/branch/provider.go
+++ b/pkg/provider/branch/provider.go
@@ -34,7 +34,6 @@ import (
 	rcHealthz "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/healthz"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/pool"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider"
-	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/branch/cooldown"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/branch/trunk"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/utils"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/worker"
@@ -139,6 +138,14 @@ var (
 	// NodeDeleteRequeueRequestDelay represents the time after which the resources belonging to a node will be cleaned
 	// up after receiving the actual node delete event.
 	NodeDeleteRequeueRequestDelay = time.Minute * 1
+
+	// capacityRetryRequeueDelay bounds the requeue interval when pod branch ENI allocation fails
+	// because the trunk is at capacity (trunk.ErrCurrentlyAtMaxCapacity). M1 (design doc section
+	// 2.2) frees a trunk slot within one delete-queue processing pass instead of waiting a full
+	// cooldown period, so requeuing after a full cooldown (as before) would now be the dominant
+	// source of retry latency for a pod waiting on capacity (design doc E6). Kept short but bounded
+	// to avoid a hot loop while a slot is still genuinely full.
+	capacityRetryRequeueDelay = time.Second * 10
 
 	prometheusRegistered = false
 
@@ -715,7 +722,7 @@ func (b *branchENIProvider) CreateAndAnnotateResources(podNamespace string, podN
 	branchENIs, err := trunkENI.CreateAndAssociateBranchENIs(pod, securityGroups, resourceCount)
 	if err != nil {
 		if err == trunk.ErrCurrentlyAtMaxCapacity {
-			return ctrl.Result{RequeueAfter: cooldown.GetCoolDown().GetCoolDownPeriod(), Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: capacityRetryRequeueDelay, Requeue: true}, nil
 		}
 		b.apiWrapper.K8sAPI.BroadcastEvent(pod, ReasonBranchAllocationFailed,
 			fmt.Sprintf("failed to allocate branch ENI to pod: %v", err), v1.EventTypeWarning)

--- a/pkg/provider/branch/trunk/trunk.go
+++ b/pkg/provider/branch/trunk/trunk.go
@@ -56,6 +56,15 @@ const (
 	// maxShadowRecordsPerTrunk bounds the per-trunk recently-released record list (FIFO evict)
 	// so the shadow instrumentation cannot grow memory unboundedly at high pod churn.
 	maxShadowRecordsPerTrunk = 32
+
+	// errorDrivenReclaimWindow is the minimum interval between two error-driven orphan reclaim
+	// describes on the SAME trunk (M3, design doc section 2.4). The reclaim runs on the branch-ENI
+	// addition FAILURE path, so it must be bounded: without this window a persistent EC2 error plus
+	// pod-reconcile retries would turn every failure into a DescribeNetworkInterfaces call. One
+	// describe per trunk per window is enough because a reclaim that found nothing will not find
+	// anything on an immediate retry either, and a reclaim that did find orphans has already
+	// enqueued them.
+	errorDrivenReclaimWindow = 30 * time.Second
 )
 
 var (
@@ -164,7 +173,75 @@ var (
 		[]string{"sg_match"},
 	)
 
+	// branchENIDeleteQueueDedupCount counts delete-queue enqueue attempts skipped because an
+	// entry with the same ENI ID was already queued (M5 G2, design doc section 2.6). A duplicate
+	// entry would later run deleteENI twice and double-free the ENI's VLAN - releasing a VLAN
+	// that may meanwhile belong to a NEW pod's branch ENI (hazard H-B). A non-zero rate here
+	// means the dedup guard is absorbing real high-churn races.
+	branchENIDeleteQueueDedupCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "branch_eni_delete_queue_dedup_total",
+			Help: "The number of delete queue enqueue attempts skipped because the branch ENI is already in the delete queue",
+		},
+	)
+
+	// branchENIVlanReuseCooldownBlockedCount counts assignVlanId calls that skipped at least one
+	// otherwise-free VLAN because it was still inside its M1 reuse cooldown window (design doc
+	// section 2.2). This is the signal that would justify lowering reuseCooldown below its current
+	// floor (design doc section 5.4) once it shows a sustained non-trivial rate.
+	branchENIVlanReuseCooldownBlockedCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "branch_eni_vlan_reuse_cooldown_blocked_total",
+			Help: "The number of VLAN allocation attempts that skipped an otherwise-free VLAN still inside its M1 reuse cooldown window",
+		},
+	)
+
+	// branchENIErrorDrivenReclaimCount counts error-driven orphan reclaim attempts (M3, design doc
+	// section 2.4) - the reactive correctness floor that runs when a branch ENI could not be added to
+	// the trunk. result="reclaimed" means the describe ran and found at least one orphan (the wedge
+	// was real and is now broken), "clean" means it ran and found none (EC2 agreed with the ledger,
+	// so the failure was something else), "skipped_window" means another reclaim ran on this trunk
+	// within errorDrivenReclaimWindow, and "describe_error" means the reclaim describe itself failed.
+	// The error_class label is BEST-EFFORT observability only and never gates the reclaim.
+	branchENIErrorDrivenReclaimCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "branch_eni_error_driven_reclaim_total",
+			Help: "The number of error-driven orphan reclaim attempts triggered by a failed branch ENI addition, by outcome and best-effort error class",
+		},
+		[]string{"result", "error_class"},
+	)
+
+	// branchENIErrorDrivenOrphanCount counts orphan branch ENIs discovered specifically by the
+	// error-driven reclaim path (M3). Deliberately separate from branch_ledger_verify_orphans_total
+	// (the proactive gate, M2) and branch_eni_orphan_reclaimed_total (the slow sweep, M4) so the
+	// three discovery sources stay separable in Grafana: a non-zero rate here means orphans are
+	// actually wedging live allocations, which is a stronger signal than the sweep finding them idle.
+	branchENIErrorDrivenOrphanCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "branch_eni_error_driven_orphans_total",
+			Help: "The number of orphan branch ENIs discovered by the error-driven reclaim path after a failed branch ENI addition",
+		},
+	)
+
 	prometheusRegistered = false
+)
+
+// branchENIErrorDrivenReclaimCount result label values.
+const (
+	reclaimResultReclaimed     = "reclaimed"
+	reclaimResultClean         = "clean"
+	reclaimResultSkippedWindow = "skipped_window"
+	reclaimResultDescribeError = "describe_error"
+)
+
+// branchENIErrorDrivenReclaimCount error_class label values. BEST-EFFORT classification of the
+// EC2 failure, used for observability only - it never decides whether the reclaim runs. AWS does
+// not document per-API error codes for AssociateTrunkInterface, so an unrecognized error is
+// reported as "other" rather than being treated as ineligible (see reclaimErrorClass).
+const (
+	reclaimErrorClassCapacity  = "capacity"
+	reclaimErrorClassVlanInUse = "vlan_in_use"
+	reclaimErrorClassOther     = "other"
 )
 
 // orphanReuseShadowHitCount sg_match label values.
@@ -177,6 +254,20 @@ const (
 const (
 	ledgerVerifyResultVerified = "verified"
 	ledgerVerifyResultError    = "error"
+)
+
+// eniPhase is the lifecycle phase of an entry in trunkENI.inFlightENIs: an ENI the controller
+// is actively operating on, which exists (attached or not) in EC2 while temporarily outside
+// both the pod-owned ledger and the delete queue.
+type eniPhase string
+
+const (
+	// eniPhaseCreating: CreateNetworkInterface returned, addBranchToCache has not run yet
+	// (M5 G1, design doc section 2.6 - hazard H-A window).
+	eniPhaseCreating eniPhase = "creating"
+	// eniPhaseDeleting: popped from the delete queue, its EC2 disassociate/delete call is in
+	// flight (the pop window, design doc section 4.1 H-C).
+	eniPhaseDeleting eniPhase = "deleting"
 )
 
 type TrunkENI interface {
@@ -220,6 +311,9 @@ type trunkENI struct {
 	usedVlanIds []bool
 	// branchENIs is the list of BranchENIs associated with the trunk
 	uidToBranchENIMap map[string][]*ENIDetails
+	// eniToPodUID retains ownership after an ENI leaves uidToBranchENIMap so asynchronous VLAN
+	// lifecycle logs can still identify the pod. It is controller-local and never serialized.
+	eniToPodUID map[string]string
 	// deleteQueue is the queue of ENIs that are being cooled down before being deleted
 	deleteQueue []*ENIDetails
 	// nodeName tag is the tag added to trunk and branch ENIs created on the node
@@ -240,6 +334,44 @@ type trunkENI struct {
 	// AssociateTrunkInterface. CreateAndAssociateBranchENIs therefore verifies the ledger from
 	// EC2 (verifyBranchLedger) before the first allocation on a hydrated trunk.
 	branchLedgerVerified bool
+	// inFlightENIs is the set of branch ENI IDs the controller is actively operating on: they
+	// exist in EC2 while temporarily outside both uidToBranchENIMap and the delete queue, so
+	// the ledger-verify gate, the orphan reclaim sweep, and the error-driven reclaim must never
+	// classify them as orphans. Two phases share one set because the classification rule is
+	// identical; the phase only attributes logs/metrics:
+	//   - creating (M5 G1, design doc section 2.6): added right after CreateNetworkInterface
+	//     returns, removed on EVERY exit for that ENI - success (addBranchToCache) or failure
+	//     (PushENIsToFrontOfDeleteQueue). Without it an in-flight create in the
+	//     Associate-to-cache window could be deleted from under a live pod (hazard H-A).
+	//   - deleting (the pop window, design doc section 4.1 H-C): added when the ENI is popped
+	//     from the delete queue, removed when its processing pass ends - delete success or
+	//     forgotten (DeleteCooledDownENIs), or re-queue (PushENIsToFrontOfDeleteQueue, which
+	//     clears the marker before its dedup check so the pipeline's own re-push always
+	//     passes). Without it a concurrent describe during the in-flight EC2 disassociate/
+	//     delete call would re-enqueue the ENI as a duplicate orphan.
+	// Only needs to live within a single controller lifetime: on restart an in-flight ENI
+	// becomes a true orphan and is reconciled by the gate/sweep like any other (the same
+	// argument as section 4.2 H-A). Guarded by lock.
+	inFlightENIs map[string]eniPhase
+	// lastErrorDrivenReclaim is when the error-driven orphan reclaim (M3, design doc section 2.4)
+	// last ran a describe for this trunk. It bounds that failure-path reclaim to at most one
+	// describe per errorDrivenReclaimWindow so a persistent EC2 error cannot turn pod-reconcile
+	// retries into a describe storm. Guarded by lock.
+	lastErrorDrivenReclaim time.Time
+	// vlanOwner maps an assigned VLAN ID to the branch ENI ID that currently owns it (M5 G3,
+	// design doc section 2.6). Set wherever a VLAN is assigned or marked with a known ENI ID;
+	// cleared by freeVlanId. freeVlanId refuses to free a VLAN owned by a different ENI, so a
+	// duplicate delete cannot release a VLAN that meanwhile belongs to a NEW pod's branch ENI
+	// (hazard H-B defense in depth). An absent/empty owner preserves legacy free behavior.
+	// Reserved VLAN 0 never gets an owner and is never freed. Guarded by lock.
+	vlanOwner map[int]string
+	// vlanReleasedAt records, for a VLAN ID that has been released by the M1 immediate-disassociate
+	// step (design doc section 2.2), the time its ENI entered the delete queue
+	// (ENIDetails.deletionTimeStamp - NOT the time disassociation itself completed, so the VLAN
+	// reuse cooldown reproduces today's cooldown timing exactly regardless of how long
+	// disassociation took to succeed). assignVlanId refuses to hand out a free VLAN still inside
+	// this window; the entry is cleared once the VLAN is reassigned. Guarded by lock.
+	vlanReleasedAt map[int]time.Time
 }
 
 // shadowReleaseRecord is one recently-released branch ENI observed by the Phase-2 shadow reuse
@@ -346,6 +478,15 @@ type ENIDetails struct {
 	// plugin); consumed by the Phase-2 shadow reuse instrumentation on pod release. Empty for
 	// ENIs rebuilt from annotations or discovered via EC2 describe (SGs unknown there).
 	securityGroups []string
+	// slotReleased records whether this ENI's trunk slot has been positively observed as released
+	// (M1, design doc section 2.2): set once DisassociateTrunkInterface succeeds (or EC2 reports
+	// the association already gone), or as a fallback once the ENI is confirmed deleted (covers a
+	// sweep-discovered orphan with no known AssociationID, or a disassociate that never
+	// succeeded). Never inferred from AssociationID=="" - a sweep-discovered orphan has no known
+	// AssociationID but is still attached in EC2, so canCreateMore must keep counting it as
+	// occupying a slot until release is positively observed (over-counting is safe, under-counting
+	// is not).
+	slotReleased bool
 }
 
 type IntrospectResponse struct {
@@ -374,6 +515,10 @@ func NewTrunkENI(logger logr.Logger, instance ec2.EC2Instance, helper api.EC2API
 		ec2ApiHelper:      helper,
 		instance:          instance,
 		uidToBranchENIMap: make(map[string][]*ENIDetails),
+		eniToPodUID:       make(map[string]string),
+		inFlightENIs:      make(map[string]eniPhase),
+		vlanOwner:         make(map[int]string),
+		vlanReleasedAt:    make(map[int]time.Time),
 		nodeIDTag: []ec2types.Tag{
 			{
 				Key:   aws.String(config.NetworkInterfaceNodeIDKey),
@@ -394,6 +539,10 @@ func PrometheusRegister() {
 		metrics.Registry.MustRegister(branchLedgerVerifyCount)
 		metrics.Registry.MustRegister(branchLedgerVerifyOrphanCount)
 		metrics.Registry.MustRegister(orphanReuseShadowHitCount)
+		metrics.Registry.MustRegister(branchENIDeleteQueueDedupCount)
+		metrics.Registry.MustRegister(branchENIVlanReuseCooldownBlockedCount)
+		metrics.Registry.MustRegister(branchENIErrorDrivenReclaimCount)
+		metrics.Registry.MustRegister(branchENIErrorDrivenOrphanCount)
 
 		prometheusRegistered = true
 	}
@@ -413,6 +562,7 @@ func (t *trunkENI) InitTrunkFromStatus(status *rcv1alpha1.TrunkInterface, podLis
 
 	t.trunkENIId = status.ID
 	t.uidToBranchENIMap = make(map[string][]*ENIDetails)
+	t.eniToPodUID = make(map[string]string)
 	t.deleteQueue = nil
 	// The hydrated ledger only knows pod-owned branch ENIs; it has not been checked against the
 	// trunk's actual branch ENIs in EC2. Leave it unverified so the first allocation runs
@@ -427,7 +577,8 @@ func (t *trunkENI) InitTrunkFromStatus(status *rcv1alpha1.TrunkInterface, podLis
 		}
 
 		for _, eni := range eniListFromPod {
-			if err := t.markVlanAssignedLocked(eni.VlanID); err != nil {
+			t.eniToPodUID[eni.ID] = string(pod.UID)
+			if err := t.markVlanAssignedWithOwnerLocked(eni.VlanID, eni.ID); err != nil {
 				return fmt.Errorf("invalid VLAN ID in pod annotation for pod %s/%s: %w",
 					pod.Namespace, pod.Name, err)
 			}
@@ -443,12 +594,10 @@ func (t *trunkENI) InitTrunkFromStatus(status *rcv1alpha1.TrunkInterface, podLis
 func (t *trunkENI) ReconcileUnassignedBranchENIs() (bool, error) {
 	t.lock.RLock()
 	trunkENIID := t.trunkENIId
-	assignedBranchENIs := make(map[string]struct{})
-	for _, branchENIs := range t.uidToBranchENIMap {
-		for _, eni := range branchENIs {
-			assignedBranchENIs[eni.ID] = struct{}{}
-		}
-	}
+	// M5 G1+G2 (design doc section 2.6): the "known" set is ledger UNION delete queue UNION
+	// pending creates. An ENI awaiting deletion is being processed, not an orphan (hazard H-B),
+	// and an ENI still being created must never be deleted from under a live pod (hazard H-A).
+	knownBranchENIs := t.knownBranchENIsLocked()
 	t.lock.RUnlock()
 
 	if trunkENIID == "" {
@@ -466,13 +615,146 @@ func (t *trunkENI) ReconcileUnassignedBranchENIs() (bool, error) {
 			continue
 		}
 		branchENIID := *branchInterface.NetworkInterfaceId
-		if _, assigned := assignedBranchENIs[branchENIID]; assigned {
+		if _, known := knownBranchENIs[branchENIID]; known {
 			continue
 		}
 		unassignedBranchInterfaces[branchENIID] = branchInterface
 	}
 
 	return t.pushUnassignedBranchInterfacesToDeleteQueue(unassignedBranchInterfaces), nil
+}
+
+// reclaimErrorClass classifies a failed branch-ENI addition for METRIC LABELLING ONLY.
+//
+// It deliberately does NOT gate the reclaim. AWS does not document per-API error codes for
+// AssociateTrunkInterface, so any hard-coded allowlist of codes would be unverifiable and, worse,
+// would fail SILENTLY: a renamed or previously unseen code would mean the reclaim never runs and the
+// node stays wedged forever (design doc hazard E4) - the exact bug M3 exists to fix. Missing a
+// trigger is unbounded damage; an extra describe is one cheap read, already bounded by
+// errorDrivenReclaimWindow. So every addition failure is eligible and this function only records
+// what the error looked like.
+func reclaimErrorClass(err error) string {
+	if err == nil {
+		return reclaimErrorClassOther
+	}
+	msg := strings.ToLower(err.Error())
+	// API request throttling also says "limit exceeded" but is a rate problem, not a trunk-capacity
+	// problem. Classify it as "other" so the capacity label stays meaningful; it is still eligible
+	// for reclaim (this function never gates).
+	if strings.Contains(msg, "requestlimitexceeded") || strings.Contains(msg, "throttl") {
+		return reclaimErrorClassOther
+	}
+	switch {
+	case strings.Contains(msg, "capacity"), strings.Contains(msg, "limitexceeded"),
+		strings.Contains(msg, "limit exceeded"):
+		return reclaimErrorClassCapacity
+	case strings.Contains(msg, "vlan"), strings.Contains(msg, "duplicate"),
+		strings.Contains(msg, "already in use"), strings.Contains(msg, "alreadyexists"):
+		return reclaimErrorClassVlanInUse
+	default:
+		return reclaimErrorClassOther
+	}
+}
+
+// reclaimOrphansAfterAddFailure is the M3 reactive correctness floor (design doc section 2.4).
+//
+// When a branch ENI could not be added to the trunk, EC2 and the in-memory ledger may disagree: an
+// orphan (a restart leftover, a delete-retry "forgotten" ENI, or a create/associate partial) can be
+// attached in EC2 occupying a real branch slot or VLAN while the ledger believes that resource is
+// free. canCreateMore only counts the ledger, so without this path the node retries forever -
+// creating and deleting a fresh ENI each time while the orphan keeps the slot (hazard E4).
+//
+// This runs ONE describe, classifies orphans through the shared M5 known set (ledger UNION delete
+// queue UNION pending creates, so an in-flight create or an ENI already awaiting deletion is never
+// reclaimed - hazards H-A/H-B), and enqueues what it finds through the existing dedup-aware delete
+// path. It never blocks the allocation: the caller still returns its original error so the pod
+// reconcile retries against the reclaimed capacity.
+//
+// It does NOT replace the proactive gate (M2, verifyBranchLedger). Per the captain's A-tier decision
+// recorded in design doc section 2.4, both are kept: the gate avoids hitting this failure path at
+// all, while this path guarantees recovery whenever an orphan actually wedges a live allocation.
+//
+// Locking mirrors verifyBranchLedger: the EC2 describe runs unlocked, ledger mutation takes the lock.
+func (t *trunkENI) reclaimOrphansAfterAddFailure(cause error) {
+	errClass := reclaimErrorClass(cause)
+
+	t.lock.Lock()
+	if !t.lastErrorDrivenReclaim.IsZero() && time.Since(t.lastErrorDrivenReclaim) < errorDrivenReclaimWindow {
+		t.lock.Unlock()
+		branchENIErrorDrivenReclaimCount.WithLabelValues(reclaimResultSkippedWindow, errClass).Inc()
+		return
+	}
+	// Stamp BEFORE the describe so concurrent failures on this trunk collapse onto one call.
+	t.lastErrorDrivenReclaim = time.Now()
+	trunkENIID := t.trunkENIId
+	t.lock.Unlock()
+
+	if trunkENIID == "" {
+		branchENIErrorDrivenReclaimCount.WithLabelValues(reclaimResultDescribeError, errClass).Inc()
+		t.log.Error(fmt.Errorf("missing trunk ENI ID"), "skipping error-driven orphan reclaim")
+		return
+	}
+
+	branchInterfaces, err := t.ec2ApiHelper.GetBranchNetworkInterface(&trunkENIID, aws.String(t.instance.SubnetID()))
+	if err != nil {
+		// Never mask the original allocation failure: log and return so the caller's error stands.
+		trunkENIOperationsErrCount.WithLabelValues("error_driven_reclaim_describe").Inc()
+		branchENIErrorDrivenReclaimCount.WithLabelValues(reclaimResultDescribeError, errClass).Inc()
+		t.log.Error(err, "error-driven orphan reclaim describe failed", "trunk", trunkENIID)
+		return
+	}
+
+	t.lock.Lock()
+	knownBranchENIs := t.knownBranchENIsLocked()
+	unassignedBranchInterfaces := make(map[string]*ec2types.NetworkInterface)
+	for _, branchInterface := range branchInterfaces {
+		if branchInterface.NetworkInterfaceId == nil {
+			continue
+		}
+		branchENIID := *branchInterface.NetworkInterfaceId
+		if _, known := knownBranchENIs[branchENIID]; known {
+			continue
+		}
+		unassignedBranchInterfaces[branchENIID] = branchInterface
+	}
+	t.lock.Unlock()
+
+	if len(unassignedBranchInterfaces) == 0 {
+		branchENIErrorDrivenReclaimCount.WithLabelValues(reclaimResultClean, errClass).Inc()
+		t.log.Info("error-driven orphan reclaim found no orphans; EC2 agrees with the ledger",
+			"trunk", trunkENIID, "attachedBranchENIs", len(branchInterfaces))
+		return
+	}
+
+	// Takes its own lock; enqueues through the shared dedup-aware path so an ENI already queued is
+	// not duplicated and its VLAN is re-marked idempotently.
+	t.pushUnassignedBranchInterfacesToDeleteQueue(unassignedBranchInterfaces)
+
+	branchENIErrorDrivenOrphanCount.Add(float64(len(unassignedBranchInterfaces)))
+	branchENIErrorDrivenReclaimCount.WithLabelValues(reclaimResultReclaimed, errClass).Inc()
+	t.log.Info("error-driven orphan reclaim enqueued orphans after a failed branch ENI addition",
+		"trunk", trunkENIID, "orphans", len(unassignedBranchInterfaces),
+		"attachedBranchENIs", len(branchInterfaces), "cause", cause)
+}
+
+// knownBranchENIsLocked builds the set of branch ENI IDs the controller knows about: the
+// pod-owned ledger UNION the delete queue UNION the in-flight set (creating: M5 G1; deleting:
+// the pop window - design doc sections 2.6 and 4.1 H-C). Only an attached branch ENI OUTSIDE
+// this set is an orphan. Caller must hold the trunk lock (read or write).
+func (t *trunkENI) knownBranchENIsLocked() map[string]struct{} {
+	knownBranchENIs := make(map[string]struct{})
+	for _, branchENIs := range t.uidToBranchENIMap {
+		for _, eni := range branchENIs {
+			knownBranchENIs[eni.ID] = struct{}{}
+		}
+	}
+	for _, eni := range t.deleteQueue {
+		knownBranchENIs[eni.ID] = struct{}{}
+	}
+	for eniID := range t.inFlightENIs {
+		knownBranchENIs[eniID] = struct{}{}
+	}
+	return knownBranchENIs
 }
 
 func (t *trunkENI) CNINodeStatus() *rcv1alpha1.TrunkInterface {
@@ -597,6 +879,7 @@ func (t *trunkENI) InitTrunk(instance ec2.EC2Instance, podList []v1.Pod) error {
 		}
 		var branchENIs []*ENIDetails
 		for _, eni := range eniListFromPod {
+			t.rememberPodUID(eni.ID, string(pod.UID))
 			_, isPresent := associatedBranchInterfaces[eni.ID]
 			if !isPresent {
 				t.log.Error(fmt.Errorf("eni allocated to pod not found in ec2"), "eni not found", "eni", eni)
@@ -604,7 +887,7 @@ func (t *trunkENI) InitTrunk(instance ec2.EC2Instance, podList []v1.Pod) error {
 				continue
 			}
 			// Mark the Vlan ID from the pod's annotation
-			t.markVlanAssigned(eni.VlanID)
+			t.markVlanAssignedWithOwner(eni.VlanID, eni.ID)
 
 			branchENIs = append(branchENIs, eni)
 			delete(associatedBranchInterfaces, eni.ID)
@@ -667,16 +950,14 @@ func (t *trunkENI) verifyBranchLedger() error {
 	}
 	// Under the lock: mark EVERY attached branch ENI's VLAN as used (same tag parsing and
 	// reserved-VLAN-0 fallback as the orphan delete-queue path) and partition the ENIs into
-	// pod-owned and orphaned. Marking must complete before branchLedgerVerified flips so no
+	// known and orphaned. Marking must complete before branchLedgerVerified flips so no
 	// concurrent allocation can grab a VLAN that is occupied in EC2. Owned ENIs' VLANs were
 	// already marked by hydrate from the pod annotation; markVlanAssignedLocked is idempotent,
 	// so re-marking from the tag is harmless and covers annotation/tag divergence.
-	assignedBranchENIs := make(map[string]struct{})
-	for _, branchENIs := range t.uidToBranchENIMap {
-		for _, eni := range branchENIs {
-			assignedBranchENIs[eni.ID] = struct{}{}
-		}
-	}
+	// M5 G1+G2 (design doc section 2.6): the "known" set is ledger UNION delete queue UNION
+	// pending creates - an ENI awaiting deletion (hazard H-B) or still being created (hazard
+	// H-A) must never be classified as an orphan here.
+	knownBranchENIs := t.knownBranchENIsLocked()
 	unassignedBranchInterfaces := make(map[string]*ec2types.NetworkInterface)
 	for _, branchInterface := range branchInterfaces {
 		if branchInterface.NetworkInterfaceId == nil {
@@ -691,10 +972,10 @@ func (t *trunkENI) verifyBranchLedger() error {
 				"interface", branchENIID, "error", err)
 			vlanId = 0
 		}
-		if err := t.markVlanAssignedLocked(vlanId); err != nil {
+		if err := t.markVlanAssignedWithOwnerLocked(vlanId, branchENIID); err != nil {
 			t.log.Error(err, "failed to mark vlan id at ledger verification", "interface", branchENIID)
 		}
-		if _, assigned := assignedBranchENIs[branchENIID]; !assigned {
+		if _, known := knownBranchENIs[branchENIID]; !known {
 			unassignedBranchInterfaces[branchENIID] = branchInterface
 		}
 	}
@@ -788,10 +1069,13 @@ func (t *trunkENI) CreateAndAssociateBranchENIs(pod *v1.Pod, securityGroups []st
 
 	for i := 0; i < eniCount; i++ {
 		// Assign VLAN
-		vlanID, err = t.assignVlanId()
+		vlanID, err = t.assignVlanId(string(pod.UID))
 		if err != nil {
 			err = fmt.Errorf("assigning vlad id, %w", err)
 			trunkENIOperationsErrCount.WithLabelValues("assign_vlan_id").Inc()
+			// M3 (design doc section 2.4): the ledger has no free VLAN. Orphaned branch ENIs hold
+			// VLANs the ledger marks used, so reclaiming them is what eventually frees one.
+			t.reclaimOrphansAfterAddFailure(err)
 			break
 		}
 
@@ -813,12 +1097,24 @@ func (t *trunkENI) CreateAndAssociateBranchENIs(pod *v1.Pod, securityGroups []st
 			aws.String(t.instance.SubnetID()), securityGroups, tags, nil, nil, connectionTrackingSpec)
 		if err != nil {
 			err = fmt.Errorf("creating network interface, %w", err)
-			t.freeVlanId(vlanID)
+			// The ENI was never created, so the VLAN has no owner yet (legacy ownerless free).
+			t.freeVlanId(vlanID, "", string(pod.UID))
 			branchENIOperationsFailureCount.WithLabelValues("creating_branch_eni_failed").Inc()
 			break
 		} else {
 			branchENIOperationsSuccessCount.WithLabelValues("created_branch_eni_succeeded").Inc()
 		}
+
+		t.log.Info("assigned VLAN ID to branch ENI",
+			"vlanID", vlanID, "eniID", *nwInterface.NetworkInterfaceId, "podUID", string(pod.UID))
+
+		// M5 G1 (design doc section 2.6): the ENI now exists in EC2 but is not yet in
+		// uidToBranchENIMap. Record it as in-flight (phase=creating) so the ledger-verify gate
+		// and the orphan reclaim sweep never classify it as an orphan (hazard H-A). Removed on
+		// every exit for this ENI: success via addBranchToCache, failure via
+		// PushENIsToFrontOfDeleteQueue. The ENI ID is known now, so also record it as the owner
+		// of its VLAN (M5 G3).
+		t.addInFlightCreate(*nwInterface.NetworkInterfaceId, vlanID, string(pod.UID))
 
 		// Branch ENI can have an IPv4 address, IPv6 address, or both
 		var v4Addr, v6Addr string
@@ -842,6 +1138,12 @@ func (t *trunkENI) CreateAndAssociateBranchENIs(pod *v1.Pod, securityGroups []st
 		if err != nil {
 			err = fmt.Errorf("associating branch to trunk, %w", err)
 			trunkENIOperationsErrCount.WithLabelValues("associate_branch").Inc()
+			// M3 (design doc section 2.4): the branch could not be added to the trunk, so EC2 and
+			// the ledger disagree - an orphan may be holding the slot or this VLAN. Reclaim it so
+			// the pod's retry has capacity, instead of looping create/delete forever (hazard E4).
+			// This ENI is still in the in-flight set here, so the shared known set keeps the
+			// reclaim from enqueueing the ENI we are about to hand to the delete queue ourselves.
+			t.reclaimOrphansAfterAddFailure(err)
 			break
 		}
 		newENI.AssociationID = *associationOutput.InterfaceAssociation.AssociationId
@@ -849,7 +1151,10 @@ func (t *trunkENI) CreateAndAssociateBranchENIs(pod *v1.Pod, securityGroups []st
 
 	if err != nil {
 		log.Error(err, "failed to create ENI, moving the ENI to delete list")
-		// Moving to delete list, because it has all the retrying logic in case of failure
+		// Moving to delete list, because it has all the retrying logic in case of failure.
+		// nil pod: this pod was never added to uidToBranchENIMap (addBranchToCache runs only on
+		// full success), so there is no cache entry to remove; ownership for the lifecycle logs
+		// was already recorded per-ENI by addInFlightCreate above.
 		t.PushENIsToFrontOfDeleteQueue(nil, newENIs)
 		return nil, err
 	}
@@ -877,6 +1182,7 @@ func (t *trunkENI) PushBranchENIsToCoolDownQueue(UID string) {
 	}
 
 	for _, eni := range branchENIs {
+		t.rememberPodUIDLocked(eni.ID, UID)
 		eni.deletionTimeStamp = time.Now()
 		t.deleteQueue = append(t.deleteQueue, eni)
 		// Phase-2 shadow instrumentation: this ENI is exactly what a reuse pool would hold.
@@ -890,7 +1196,19 @@ func (t *trunkENI) PushBranchENIsToCoolDownQueue(UID string) {
 }
 
 func (t *trunkENI) DeleteCooledDownENIs() {
+	// M1 (design doc section 2.2): a not-yet-cooled-down ENI is set aside here instead of being
+	// requeued (and immediately re-popped) inline, so every entry in the queue still gets its
+	// immediate-disassociate step this pass - not just the front one - regardless of delete
+	// cooldown. All set-aside entries are pushed back once the pass finishes draining the queue.
+	var notYetCooledDown []*ENIDetails
+
 	for eni, hasENI := t.popENIFromDeleteQueue(); hasENI; eni, hasENI = t.popENIFromDeleteQueue() {
+		// Disassociate as soon as the ENI is processed, with NO cooldown wait, so the trunk slot
+		// (and, subject to the VLAN reuse cooldown, the VLAN) is freed immediately instead of being
+		// held hostage for the full cooldown period. DeleteNetworkInterface timing below is
+		// deliberately left unchanged.
+		t.disassociateIfNeeded(eni)
+
 		if eni.deletionTimeStamp.IsZero() ||
 			time.Now().After(eni.deletionTimeStamp.Add(cooldown.GetCoolDown().GetCoolDownPeriod())) {
 			err := t.deleteENI(eni)
@@ -902,38 +1220,83 @@ func (t *trunkENI) DeleteCooledDownENIs() {
 					// orphan PRODUCER that a later orphan reclaim sweep will rediscover. Count it so
 					// orphan production is observable alongside branch_eni_orphan_reclaimed_total.
 					branchENIDeleteForgottenCount.WithLabelValues("max_delete_retries_exceeded").Inc()
-					// TODO: free vlan id?
+					// Deliberately dropped from the in-flight set too: from here on the sweep
+					// SHOULD rediscover it as an orphan - that is its recovery path.
+					t.removeInFlight(eni)
 					continue
 				}
 				t.log.Error(err, "failed to delete eni, will retry", "eni", eni)
 				t.PushENIsToFrontOfDeleteQueue(nil, []*ENIDetails{eni})
 				continue
 			}
+			t.removeInFlight(eni)
 			t.log.V(1).Info("deleted eni successfully", "eni", eni, "deletion time", time.Now(),
 				"pushed to queue time", eni.deletionTimeStamp)
 		} else {
-			// Since the current item is not cooled down so the items added after it would not be cooled down either
-			t.PushENIsToFrontOfDeleteQueue(nil, []*ENIDetails{eni})
-			return
+			notYetCooledDown = append(notYetCooledDown, eni)
 		}
+	}
+
+	if len(notYetCooledDown) > 0 {
+		t.PushENIsToFrontOfDeleteQueue(nil, notYetCooledDown)
 	}
 }
 
-// deleteENIs deletes the provided ENIs and frees up the Vlan assigned to then
-func (t *trunkENI) deleteENI(eniDetail *ENIDetails) (err error) {
-	// Disassociate branch ENI from trunk if association ID exists and delete branch network interface
-	if eniDetail.AssociationID != "" {
-		err = t.ec2ApiHelper.DisassociateTrunkInterface(&eniDetail.AssociationID)
-		if err != nil {
-			trunkENIOperationsErrCount.WithLabelValues("disassociate_trunk_error").Inc()
-			if !strings.Contains(err.Error(), ec2Errors.NotFoundAssociationID) {
-				t.log.Error(err, "failed to disassociate branch ENI from trunk, will try to delete the branch ENI")
-				// Not returning error here, fallback to force branch ENI deletion
-			} else {
-				t.log.Info("AssociationID not found when disassociating branch from trunk ENI, it is already disassociated so delete the branch ENI")
-			}
-		}
+// disassociateIfNeeded is the M1 immediate-disassociate step (design doc section 2.2): called on
+// every processing pass through the delete queue, independent of the delete cooldown gate below it.
+// On success (or EC2 reporting the association already gone) it releases the trunk slot and starts
+// the VLAN reuse cooldown right away, instead of waiting for DeleteNetworkInterface to also
+// complete. A real failure is left for the next pass to retry; the slot stays counted as occupied
+// until release is positively observed (requirement R3/canCreateMore conservatism). An ENI with no
+// known AssociationID (a sweep-discovered orphan, see pushUnassignedBranchInterfacesToDeleteQueue)
+// has nothing for us to disassociate - its slot is released as a fallback at successful delete
+// instead (see deleteENI).
+func (t *trunkENI) disassociateIfNeeded(eni *ENIDetails) {
+	if eni.slotReleased || eni.AssociationID == "" {
+		return
 	}
+
+	err := t.ec2ApiHelper.DisassociateTrunkInterface(&eni.AssociationID)
+	if err != nil {
+		trunkENIOperationsErrCount.WithLabelValues("disassociate_trunk_error").Inc()
+		if !strings.Contains(err.Error(), ec2Errors.NotFoundAssociationID) {
+			branchENIOperationsFailureCount.WithLabelValues("immediate_disassociate_failed").Inc()
+			t.log.Error(err, "failed to immediately disassociate branch ENI from trunk, will retry", "eni", eni.ID)
+			return
+		}
+		t.log.Info("AssociationID not found when disassociating branch from trunk ENI, it is already disassociated", "eni", eni.ID)
+	}
+
+	branchENIOperationsSuccessCount.WithLabelValues("immediate_disassociate_succeeded").Inc()
+	t.log.Info("immediately disassociated branch ENI from trunk",
+		"vlanID", eni.VlanID, "eniID", eni.ID, "podUID", t.podUIDForENI(eni.ID))
+	t.releaseSlot(eni)
+}
+
+// releaseSlot marks eni's trunk slot as positively released (M1, design doc section 2.2) and, for a
+// real VLAN, frees it subject to the VLAN reuse cooldown starting from eni.deletionTimeStamp - not
+// from now - so the cooldown reproduces today's cooldown timing exactly regardless of how long
+// release itself took (see assignVlanId). Idempotent: a no-op if the VLAN is not currently owned by
+// this ENI (already freed by a previous call, M5 G3).
+func (t *trunkENI) releaseSlot(eni *ENIDetails) {
+	eni.slotReleased = true
+	if eni.VlanID == 0 {
+		return
+	}
+
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if !t.freeVlanIdLocked(eni.VlanID, eni.ID, "") {
+		return
+	}
+	t.vlanReleasedAt[eni.VlanID] = eni.deletionTimeStamp
+}
+
+// deleteENIs deletes the provided ENIs. Disassociation is handled separately and earlier by
+// disassociateIfNeeded (M1, design doc section 2.2); this only calls DeleteNetworkInterface, whose
+// timing stays gated behind the existing cooldown check in DeleteCooledDownENIs.
+func (t *trunkENI) deleteENI(eniDetail *ENIDetails) (err error) {
 	err = t.ec2ApiHelper.DeleteNetworkInterface(&eniDetail.ID)
 	if err != nil {
 		branchENIOperationsFailureCount.WithLabelValues("delete_branch_error").Inc()
@@ -950,9 +1313,12 @@ func (t *trunkENI) deleteENI(eniDetail *ENIDetails) (err error) {
 
 	t.log.Info("deleted eni", "eni details", eniDetail)
 
-	// Free vlan id used by the branch ENI
-	if eniDetail.VlanID != 0 {
-		t.freeVlanId(eniDetail.VlanID)
+	// Fallback release (M1, design doc section 2.2): the ENI is now confirmed gone from EC2, so its
+	// slot and VLAN are definitely free even if disassociateIfNeeded never positively observed a
+	// release - covers a sweep-discovered orphan with no known AssociationID, and a disassociate
+	// that kept failing right up until delete itself succeeded. A no-op if already released.
+	if !eniDetail.slotReleased {
+		t.releaseSlot(eniDetail)
 	}
 
 	return nil
@@ -983,20 +1349,79 @@ func (t *trunkENI) pushENIToDeleteQueue(eni *ENIDetails) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
+	t.pushENIToDeleteQueueLocked(eni)
+}
+
+// pushENIToDeleteQueueLocked appends an ENI to the delete queue. M5 G2 (design doc section 2.6):
+// an ENI ID already present in the queue is skipped (logged and counted) - a duplicate entry
+// would later run deleteENI twice and double-free the ENI's VLAN (hazard H-B). Caller must hold
+// the trunk lock. Returns whether the ENI was actually queued.
+func (t *trunkENI) pushENIToDeleteQueueLocked(eni *ENIDetails) bool {
+	if t.isENIInDeleteQueueLocked(eni.ID) {
+		branchENIDeleteQueueDedupCount.Inc()
+		t.log.Info("skipping delete queue push, eni is already in the delete queue", "eni", eni.ID)
+		return false
+	}
+
 	t.deleteQueue = append(t.deleteQueue, eni)
 	// Phase-2 shadow instrumentation: an orphan entering the delete queue is a reuse candidate
 	// too. Its security groups are unknown from the describe (empty), so it can only ever count
 	// as an sg_match="mismatch" availability - a real pool would describe or modify before reuse.
 	t.recordShadowReleaseLocked(eni.securityGroups)
+	return true
+}
+
+// isENIInDeleteQueueLocked returns whether an ENI with the given ID is already in the delete
+// queue. Caller must hold the trunk lock (read or write).
+func (t *trunkENI) isENIInDeleteQueueLocked(eniID string) bool {
+	for _, queued := range t.deleteQueue {
+		if queued.ID == eniID {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *trunkENI) pushUnassignedBranchInterfacesToDeleteQueue(branchInterfaces map[string]*ec2types.NetworkInterface) bool {
 	foundUnassignedBranchENI := false
+
+	// One lock for the whole batch so the G1/G2 checks and the enqueue are atomic: a create or a
+	// concurrent enqueue cannot slip in between the classification and the queue insert.
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
 	for _, branchInterface := range branchInterfaces {
 		if branchInterface.NetworkInterfaceId == nil {
 			continue
 		}
 		branchENIID := *branchInterface.NetworkInterfaceId
+
+		// M5 G1 + pop window (design doc sections 2.6, 4.1 H-C): an ENI the controller is
+		// actively operating on is in-flight, not an orphan. Re-checked here at enqueue time
+		// under the lock because the caller's known-set snapshot may predate a create or a
+		// delete-queue pop that happened during the EC2 describe. Not counted as a discovered
+		// orphan. The phase only attributes the log/metric:
+		//   - creating: deleting it would pull the ENI from under a live pod (hazard H-A);
+		//   - deleting: it is mid-processing in the delete pipeline - re-enqueueing would
+		//     duplicate it (G2's dedup extended to the pop window), so count it as a dedup.
+		if phase, inFlight := t.inFlightENIs[branchENIID]; inFlight {
+			if phase == eniPhaseCreating {
+				t.log.Info("skipping in-flight branch eni, create in progress", "eni", branchENIID)
+			} else {
+				branchENIDeleteQueueDedupCount.Inc()
+				t.log.Info("skipping branch eni, delete processing in progress", "eni", branchENIID)
+			}
+			continue
+		}
+		// M5 G2 (design doc section 2.6): an ENI already awaiting deletion is being processed,
+		// not an orphan - re-enqueueing it would double-free its VLAN later (hazard H-B). Do not
+		// re-mark the VLAN and do not count it as a discovered orphan.
+		if t.isENIInDeleteQueueLocked(branchENIID) {
+			branchENIDeleteQueueDedupCount.Inc()
+			t.log.Info("skipping branch eni already in the delete queue", "eni", branchENIID)
+			continue
+		}
+
 		t.log.Info("pushing eni to delete queue as no pod owns it", "eni", branchENIID)
 		// An attached branch ENI owned by no pod in the ledger is an orphan. Count each discovery so
 		// the real orphan rate is observable in Grafana (previously only the log line above existed).
@@ -1023,10 +1448,14 @@ func (t *trunkENI) pushUnassignedBranchInterfacesToDeleteQueue(branchInterfaces 
 				"using reserved vlan id 0 for delete queue", "interface", branchENIID)
 			vlanId = 0
 		} else {
-			// Even though the ENI is going to be deleted, keep the VLAN reserved while it sits in the cool down queue.
-			t.markVlanAssigned(vlanId)
+			// Even though the ENI is going to be deleted, keep the VLAN reserved while it sits in
+			// the cool down queue, owned by this ENI (M5 G3).
+			if err := t.markVlanAssignedWithOwnerLocked(vlanId, branchENIID); err != nil {
+				trunkENIOperationsErrCount.WithLabelValues("mark_invalid_vlan_id").Inc()
+				t.log.Error(err, "failed to mark vlan id assigned", "vlan id", vlanId)
+			}
 		}
-		t.pushENIToDeleteQueue(&ENIDetails{
+		t.pushENIToDeleteQueueLocked(&ENIDetails{
 			ID:                branchENIID,
 			VlanID:            vlanId,
 			deletionTimeStamp: time.Now(),
@@ -1041,7 +1470,18 @@ func (t *trunkENI) PushENIsToFrontOfDeleteQueue(pod *v1.Pod, eniList []*ENIDetai
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
+	// Clear in-flight markers before the dedup check below: a create pushed here
+	// (create/associate failure path) has terminally exited the create flow (M5 G1), and a
+	// popped delete-queue entry being re-pushed (retry / not-yet-cooled-down) is re-entering
+	// the queue - clearing first is what lets the delete pipeline's own re-push pass the
+	// dedup check while a concurrent describe still cannot touch the ENI (it re-checks the
+	// queue it is about to rejoin).
+	t.removeInFlightLocked(eniList)
+
 	if pod != nil {
+		for _, eni := range eniList {
+			t.rememberPodUIDLocked(eni.ID, string(pod.UID))
+		}
 		t.log.Info("pushing ENIs to delete queue and removing pod from cache",
 			"uid", pod.UID, "ENIs", eniList)
 		delete(t.uidToBranchENIMap, string(pod.UID))
@@ -1049,7 +1489,19 @@ func (t *trunkENI) PushENIsToFrontOfDeleteQueue(pod *v1.Pod, eniList []*ENIDetai
 		t.log.Info("pushing ENIs to delete queue", "ENIs", eniList)
 	}
 
-	t.deleteQueue = append(eniList, t.deleteQueue...)
+	// M5 G2 (design doc section 2.6): never insert an ENI ID already present in the queue - a
+	// duplicate entry would later double-free the ENI's VLAN (hazard H-B).
+	var toQueue []*ENIDetails
+	for _, eni := range eniList {
+		if t.isENIInDeleteQueueLocked(eni.ID) {
+			branchENIDeleteQueueDedupCount.Inc()
+			t.log.Info("skipping delete queue push, eni is already in the delete queue", "eni", eni.ID)
+			continue
+		}
+		toQueue = append(toQueue, eni)
+	}
+
+	t.deleteQueue = append(toQueue, t.deleteQueue...)
 }
 
 // popENIFromDeleteQueue pops an ENI from delete queue, if the queue is empty then the false is returned
@@ -1061,6 +1513,13 @@ func (t *trunkENI) popENIFromDeleteQueue() (eni *ENIDetails, hasENI bool) {
 		eni = t.deleteQueue[0]
 		hasENI = true
 		t.deleteQueue = t.deleteQueue[1:]
+		// The popped entry leaves ledger-UNION-queue while its EC2 disassociate/delete call is
+		// in flight. Mark it in-flight (phase=deleting) so a concurrent gate/sweep/M3 describe -
+		// which still sees it attached in EC2 - cannot re-classify it as an orphan and enqueue a
+		// duplicate (the pop window, design doc section 4.1 H-C). Cleared when the processing
+		// pass ends: delete success/forgotten in DeleteCooledDownENIs, or re-queue via
+		// PushENIsToFrontOfDeleteQueue.
+		t.inFlightENIs[eni.ID] = eniPhaseDeleting
 	}
 
 	return eni, hasENI
@@ -1071,12 +1530,20 @@ func (t *trunkENI) addBranchToCache(UID string, branchENIs []*ENIDetails) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
+	// M5 G1 (design doc section 2.6): the ENIs are entering the pod-owned ledger, so they are no
+	// longer in-flight. Done before the duplicate-UID early return so a stale marker can never
+	// be left behind on any exit.
+	t.removeInFlightLocked(branchENIs)
+
 	if _, ok := t.uidToBranchENIMap[UID]; ok {
 		t.log.Info("branch eni already exist not adding again", "request", branchENIs)
 		return
 	}
 
 	t.uidToBranchENIMap[UID] = branchENIs
+	for _, eni := range branchENIs {
+		t.rememberPodUIDLocked(eni.ID, UID)
+	}
 }
 
 // getBranchFromCache returns the branch from the cache
@@ -1088,16 +1555,44 @@ func (t *trunkENI) getBranchFromCache(UID string) (branchENIs []*ENIDetails, isP
 	return
 }
 
-// assignVlanId assigns a free vlan id from the list of available vlan ids. In the future this can be changed to LL
-func (t *trunkENI) assignVlanId() (int, error) {
+// assignVlanId assigns a free vlan id from the list of available vlan ids. In the future this can be changed to LL.
+// podUID identifies the requesting pod in the VLAN lifecycle logs; pass "" when unknown.
+func (t *trunkENI) assignVlanId(podUID string) (int, error) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
+	reuseCooldown := cooldown.GetCoolDown().GetCoolDownPeriod()
+	now := time.Now()
+	blockedByCooldown := false
 	for index, used := range t.usedVlanIds {
-		if !used {
-			t.usedVlanIds[index] = true
-			return index, nil
+		if used {
+			continue
 		}
+		// M1 (design doc section 2.2): a VLAN released by disassociateIfNeeded/releaseSlot is free
+		// in the ledger, but must not be handed out again until reuseCooldown has elapsed since its
+		// ENI entered the delete queue - the node dataplane needs that window to forget the old
+		// pod's rules before the VLAN number means something different.
+		if releasedAt, cooling := t.vlanReleasedAt[index]; cooling && now.Before(releasedAt.Add(reuseCooldown)) {
+			if !blockedByCooldown {
+				t.log.Info("VLAN reuse blocked by cooldown",
+					"vlanID", index, "remainingCooldown", releasedAt.Add(reuseCooldown).Sub(now).String(),
+					"podUID", podUID)
+			}
+			blockedByCooldown = true
+			continue
+		}
+		t.usedVlanIds[index] = true
+		// Fresh assignment: the owning ENI does not exist yet; the owner is recorded once
+		// CreateNetworkInterface returns the ENI ID (M5 G3). Clear any stale record.
+		delete(t.vlanOwner, index)
+		delete(t.vlanReleasedAt, index)
+		if blockedByCooldown {
+			branchENIVlanReuseCooldownBlockedCount.Inc()
+		}
+		return index, nil
+	}
+	if blockedByCooldown {
+		branchENIVlanReuseCooldownBlockedCount.Inc()
 	}
 	return 0, fmt.Errorf("failed to find free vlan id in the available %d ids", len(t.usedVlanIds))
 }
@@ -1121,18 +1616,127 @@ func (t *trunkENI) markVlanAssignedLocked(vlanId int) error {
 	return nil
 }
 
-// freeVlanId frees a vlan ID currently used by a network interface
-func (t *trunkENI) freeVlanId(vlanId int) {
+// markVlanAssignedWithOwner marks a vlan Id as assigned and records eniID as its owner (M5 G3,
+// design doc section 2.6). Reserved vlan id 0 never gets an owner (it is permanently marked and
+// never freed), and an empty eniID leaves any existing owner record untouched.
+func (t *trunkENI) markVlanAssignedWithOwner(vlanId int, eniID string) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
+	if err := t.markVlanAssignedWithOwnerLocked(vlanId, eniID); err != nil {
+		trunkENIOperationsErrCount.WithLabelValues("mark_invalid_vlan_id").Inc()
+		t.log.Error(err, "failed to mark vlan id assigned", "vlan id", vlanId)
+	}
+}
+
+// markVlanAssignedWithOwnerLocked is markVlanAssignedWithOwner's caller-locked counterpart.
+// Caller must hold the trunk lock.
+func (t *trunkENI) markVlanAssignedWithOwnerLocked(vlanId int, eniID string) error {
+	if err := t.markVlanAssignedLocked(vlanId); err != nil {
+		return err
+	}
+	if vlanId != 0 && eniID != "" {
+		t.vlanOwner[vlanId] = eniID
+	}
+	return nil
+}
+
+// addInFlightCreate records eniID as an in-flight branch ENI create (M5 G1, design doc section
+// 2.6) and, since the ENI ID is now known, records it as the owner of vlanID (M5 G3). Must be
+// removed via removeInFlightLocked on every exit for this ENI. podUID is the owning pod
+// for VLAN lifecycle logs; pass "" when unknown.
+func (t *trunkENI) addInFlightCreate(eniID string, vlanID int, podUID string) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.inFlightENIs[eniID] = eniPhaseCreating
+	t.rememberPodUIDLocked(eniID, podUID)
+	if vlanID != 0 {
+		t.vlanOwner[vlanID] = eniID
+	}
+}
+
+func (t *trunkENI) rememberPodUID(eniID, podUID string) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.rememberPodUIDLocked(eniID, podUID)
+}
+
+func (t *trunkENI) rememberPodUIDLocked(eniID, podUID string) {
+	if eniID == "" || podUID == "" {
+		return
+	}
+	if t.eniToPodUID == nil {
+		t.eniToPodUID = make(map[string]string)
+	}
+	t.eniToPodUID[eniID] = podUID
+}
+
+func (t *trunkENI) podUIDForENI(eniID string) string {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+	return t.eniToPodUID[eniID]
+}
+
+// removeInFlightLocked removes each ENI's ID from the in-flight set - a create entering the
+// ledger or exiting to the delete queue (M5 G1), or a delete-queue pop whose processing pass
+// has ended (pop window). Caller must hold the trunk lock.
+func (t *trunkENI) removeInFlightLocked(enis []*ENIDetails) {
+	for _, eni := range enis {
+		delete(t.inFlightENIs, eni.ID)
+	}
+}
+
+// removeInFlight is removeInFlightLocked for a single ENI, taking the lock itself.
+func (t *trunkENI) removeInFlight(eni *ENIDetails) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	delete(t.inFlightENIs, eni.ID)
+}
+
+// freeVlanId frees a vlan ID currently used by a network interface. eniID is the ENI releasing
+// the vlan; if the vlan is owned by a DIFFERENT ENI, the free is refused (M5 G3, design doc
+// section 2.6) because a duplicate delete-queue entry must never release a vlan that meanwhile
+// belongs to a new pod's branch ENI (hazard H-B). An empty eniID or an unrecorded owner preserves
+// legacy ownerless-free behavior. Reserved vlan id 0 is never freed in production: callers
+// (deleteENI, and assignVlanId's never-returns-0 guarantee on a real trunk) never pass it here.
+func (t *trunkENI) freeVlanId(vlanId int, eniID string, podUID string) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.freeVlanIdLocked(vlanId, eniID, podUID)
+}
+
+// freeVlanIdLocked is freeVlanId's caller-locked counterpart, returning whether the VLAN was
+// actually freed (false if it was already unused, or owned by a different ENI - M5 G3). podUID
+// identifies the pod in the freed-VLAN log; pass "" to fall back to the eniID's remembered owner.
+// Caller must hold the trunk lock.
+func (t *trunkENI) freeVlanIdLocked(vlanId int, eniID string, podUID string) bool {
 	isUsed := t.usedVlanIds[vlanId]
 	if !isUsed {
 		trunkENIOperationsErrCount.WithLabelValues("free_unused_vlan_id").Inc()
-		t.log.Error(fmt.Errorf("failed to free a unused vlan id"), "", "vlan id", vlanId)
-		return
+		t.log.Error(fmt.Errorf("refusing to free vlan not marked in use"),
+			"refusing to free a VLAN ID that is not marked in use", "vlan id", vlanId)
+		return false
 	}
+
+	if owner, hasOwner := t.vlanOwner[vlanId]; hasOwner && eniID != "" && owner != eniID {
+		trunkENIOperationsErrCount.WithLabelValues("free_vlan_owner_mismatch").Inc()
+		t.log.Error(fmt.Errorf("refusing to free vlan owned by another eni"),
+			"G3 owner-aware VLAN free guard refused to free a VLAN owned by a different branch ENI",
+			"vlan id", vlanId, "owner", owner, "requester", eniID)
+		return false
+	}
+
 	t.usedVlanIds[vlanId] = false
+	delete(t.vlanOwner, vlanId)
+	uid := podUID
+	if uid == "" {
+		uid = t.eniToPodUID[eniID]
+	}
+	t.log.Info("freed VLAN ID", "vlanID", vlanId, "eniID", eniID, "podUID", uid)
+	delete(t.eniToPodUID, eniID)
+	return true
 }
 
 func (t *trunkENI) getVlanIdFromTag(tags []ec2types.Tag) (int, error) {
@@ -1154,7 +1758,20 @@ func (t *trunkENI) canCreateMore() bool {
 		usedBranches += len(branches)
 	}
 
-	if usedBranches+len(t.deleteQueue) < vpc.Limits[t.instance.Type()].BranchInterface {
+	// M1 (design doc section 2.2): a delete-queue entry whose slot has been positively released
+	// (disassociateIfNeeded succeeded, or as a fallback, delete succeeded) no longer occupies a
+	// trunk slot. An entry never counted as released - including a sweep-discovered orphan with no
+	// known AssociationID, which is still attached in EC2 despite having nothing for us to
+	// disassociate - keeps counting as occupied. Over-counting here is safe (refuses a create that
+	// could have succeeded); under-counting is not (would over-subscribe the trunk).
+	var occupiedInQueue int
+	for _, eni := range t.deleteQueue {
+		if !eni.slotReleased {
+			occupiedInQueue++
+		}
+	}
+
+	if usedBranches+occupiedInQueue < vpc.Limits[t.instance.Type()].BranchInterface {
 		return true
 	}
 	return false

--- a/pkg/provider/branch/trunk/trunk_test.go
+++ b/pkg/provider/branch/trunk/trunk_test.go
@@ -15,6 +15,7 @@ package trunk
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -26,7 +27,10 @@ import (
 	mock_cooldown "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/provider/branch/cooldown"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2"
+	ec2Errors "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/errors"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/vpc"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/k8s"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/branch/cooldown"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -40,6 +44,29 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
+
+// stubK8sWrapperNoConfigMap is a minimal k8s.K8sWrapper that reports no branch-ENI cooldown
+// configmap, so cooldown.InitCoolDownPeriod falls back to cooldown.DefaultCoolDownPeriod. Embeds
+// the interface (nil) so it satisfies k8s.K8sWrapper without implementing every method - only
+// GetConfigMap is ever called on it.
+type stubK8sWrapperNoConfigMap struct {
+	k8s.K8sWrapper
+}
+
+func (stubK8sWrapperNoConfigMap) GetConfigMap(string, string) (*v1.ConfigMap, error) {
+	return nil, fmt.Errorf("no cooldown configmap in tests")
+}
+
+// TestMain initializes the package-level cooldown singleton once before any test runs. M1 made
+// assignVlanId depend on cooldown.GetCoolDown() (the VLAN reuse cooldown window), so a test that
+// exercises VLAN assignment without itself calling cooldown.InitCoolDownPeriod would otherwise
+// panic on a nil singleton depending on which test happens to run first in this binary. A test
+// that cares about an exact period still calls cooldown.InitCoolDownPeriod itself, which simply
+// overrides this default.
+func TestMain(m *testing.M) {
+	cooldown.InitCoolDownPeriod(stubK8sWrapperNoConfigMap{}, zap.New(zap.UseDevMode(true)).WithName("cooldown-test-default"))
+	os.Exit(m.Run())
+}
 
 var (
 	// Instance details
@@ -239,6 +266,12 @@ func getMockHelperInstanceAndTrunkObject(ctrl *gomock.Controller) (*trunkENI, *m
 	EniDetails2.deletionTimeStamp = time.Time{}
 	EniDetails1.deleteRetryCount = 0
 	EniDetails2.deleteRetryCount = 0
+	// M1 (design doc section 2.2): these are shared package-level fixtures, so a test that drives a
+	// real release (disassociateIfNeeded/releaseSlot/deleteENI) must not leak slotReleased=true into
+	// the next test that reuses the same pointer.
+	EniDetails1.slotReleased = false
+	EniDetails2.slotReleased = false
+	ENIDetailsMissingAssociationID.slotReleased = false
 
 	return &trunkENI, mockHelper, mockInstance
 }
@@ -249,6 +282,9 @@ func getMockTrunk() trunkENI {
 		log:               log,
 		usedVlanIds:       make([]bool, MaxAllocatableVlanIds),
 		uidToBranchENIMap: map[string][]*ENIDetails{},
+		inFlightENIs:      map[string]eniPhase{},
+		vlanOwner:         map[int]string{},
+		vlanReleasedAt:    map[int]time.Time{},
 		nodeIDTag: []awsEc2Types.Tag{
 			{
 				Key:   aws.String(config.NetworkInterfaceNodeIDKey),
@@ -269,13 +305,13 @@ func TestTrunkENI_assignVlanId(t *testing.T) {
 	trunkENI := getMockTrunk()
 
 	for i := 0; i < MaxAllocatableVlanIds; i++ {
-		id, err := trunkENI.assignVlanId()
+		id, err := trunkENI.assignVlanId("")
 		assert.NoError(t, err)
 		assert.Equal(t, i, id)
 	}
 
 	// Try allocating one more Vlan Id after breaching max capacity
-	_, err := trunkENI.assignVlanId()
+	_, err := trunkENI.assignVlanId("")
 	assert.NotNil(t, err)
 }
 
@@ -284,15 +320,15 @@ func TestTrunkENI_freeVlanId(t *testing.T) {
 	trunkENI := getMockTrunk()
 
 	// Assign single Vlan Id
-	id, err := trunkENI.assignVlanId()
+	id, err := trunkENI.assignVlanId("")
 	assert.NoError(t, err)
 	assert.Equal(t, 0, id)
 
 	// Free the vlan Id
-	trunkENI.freeVlanId(0)
+	trunkENI.freeVlanId(0, "", "")
 
 	// Assign single Vlan Id again
-	id, err = trunkENI.assignVlanId()
+	id, err = trunkENI.assignVlanId("")
 	assert.NoError(t, err)
 	assert.Equal(t, 0, id)
 }
@@ -303,7 +339,7 @@ func TestTrunkENI_markVlanAssigned(t *testing.T) {
 	// Mark a Vlan as assigned
 	trunkENI.markVlanAssigned(0)
 
-	id, err := trunkENI.assignVlanId()
+	id, err := trunkENI.assignVlanId("")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, id)
 }
@@ -426,7 +462,10 @@ func TestTrunkENI_getBranchInterfaceMap_EmptyList(t *testing.T) {
 	assert.Zero(t, len(branchENIsMap))
 }
 
-// TestTrunkENI_deleteENI tests deleting branch ENI
+// TestTrunkENI_deleteENI tests deleting branch ENI. Disassociation (M1, design doc section 2.2) has
+// moved to disassociateIfNeeded and runs earlier/separately in DeleteCooledDownENIs (see
+// TestTrunkENI_disassociateIfNeeded); deleteENI here only calls DeleteNetworkInterface, plus a
+// fallback release for an ENI whose slot was never positively released beforehand.
 func TestTrunkENI_deleteENI(t *testing.T) {
 	type args struct {
 		eniDetail *ENIDetails
@@ -436,6 +475,7 @@ func TestTrunkENI_deleteENI(t *testing.T) {
 		mockEC2APIHelper *mock_api.MockEC2APIHelper
 		trunkENI         *trunkENI
 	}
+	var freeUnusedVlanErrBefore float64
 	testTrunkENI_deleteENI := []struct {
 		name    string
 		prepare func(f *fields)
@@ -444,52 +484,7 @@ func TestTrunkENI_deleteENI(t *testing.T) {
 		asserts func(f *fields)
 	}{
 		{
-			name: "Vland_Freed, verifies VLANID is freed when branch ENI is deleted",
-			prepare: func(f *fields) {
-				f.mockEC2APIHelper.EXPECT().DisassociateTrunkInterface(&MockAssociationID1).Return(nil)
-				f.mockEC2APIHelper.EXPECT().DeleteNetworkInterface(&Branch1Id).Return(nil)
-			},
-			args: args{
-				eniDetail: EniDetails1,
-				VlanID:    VlanId1,
-			},
-			wantErr: false,
-			asserts: func(f *fields) {
-				assert.False(t, f.trunkENI.usedVlanIds[VlanId1])
-			},
-		},
-		{
-			name: "Vland_NotFreed, verifies VLANID is not freed when branch ENI delete fails",
-			prepare: func(f *fields) {
-				f.mockEC2APIHelper.EXPECT().DisassociateTrunkInterface(&MockAssociationID1).Return(nil)
-				f.mockEC2APIHelper.EXPECT().DeleteNetworkInterface(&Branch1Id).Return(MockError)
-			},
-			args: args{
-				eniDetail: EniDetails1,
-				VlanID:    VlanId1,
-			},
-			wantErr: true,
-			asserts: func(f *fields) {
-				assert.True(t, f.trunkENI.usedVlanIds[VlanId1])
-			},
-		},
-		{
-			name: "DisassociateTrunkInterface_Fails, verifies branch ENI is deleted when disassociation fails for backward compatibility",
-			prepare: func(f *fields) {
-				f.mockEC2APIHelper.EXPECT().DisassociateTrunkInterface(&MockAssociationID1).Return(MockError)
-				f.mockEC2APIHelper.EXPECT().DeleteNetworkInterface(&Branch1Id).Return(nil)
-			},
-			args: args{
-				eniDetail: EniDetails1,
-				VlanID:    VlanId1,
-			},
-			wantErr: false,
-			asserts: func(f *fields) {
-				assert.False(t, f.trunkENI.usedVlanIds[VlanId1])
-			},
-		},
-		{
-			name: "MissingAssociationID, verifies DisassociateTrunkInterface is skipped when association ID is missing and branch ENI is deleted for backward compatibility",
+			name: "Vlan_FreedViaFallback, verifies an ENI whose slot was never released beforehand (e.g. a sweep-discovered orphan with no known AssociationID) still frees its vlan once delete succeeds",
 			prepare: func(f *fields) {
 				f.mockEC2APIHelper.EXPECT().DeleteNetworkInterface(&Branch2Id).Return(nil)
 			},
@@ -500,6 +495,48 @@ func TestTrunkENI_deleteENI(t *testing.T) {
 			wantErr: false,
 			asserts: func(f *fields) {
 				assert.False(t, f.trunkENI.usedVlanIds[VlanId2])
+				assert.True(t, ENIDetailsMissingAssociationID.slotReleased,
+					"a successful delete must positively release the slot as a fallback")
+			},
+		},
+		{
+			name: "Vlan_NotFreed_DeleteFails, verifies VLANID stays reserved and the slot stays occupied when delete fails",
+			prepare: func(f *fields) {
+				f.mockEC2APIHelper.EXPECT().DeleteNetworkInterface(&Branch1Id).Return(MockError)
+			},
+			args: args{
+				eniDetail: EniDetails1,
+				VlanID:    VlanId1,
+			},
+			wantErr: true,
+			asserts: func(f *fields) {
+				assert.True(t, f.trunkENI.usedVlanIds[VlanId1])
+				assert.False(t, EniDetails1.slotReleased,
+					"a delete failure must not release a slot that was never positively released")
+			},
+		},
+		{
+			name: "AlreadyReleased_DeleteDoesNotDoubleFree, verifies deleteENI does not attempt to re-release a slot disassociateIfNeeded already released",
+			prepare: func(f *fields) {
+				// Simulate disassociateIfNeeded having already released the slot and vlan before
+				// delete ever ran (the common M1 case).
+				f.trunkENI.releaseSlot(EniDetails2)
+				freeUnusedVlanErrBefore = testutil.ToFloat64(trunkENIOperationsErrCount.WithLabelValues("free_unused_vlan_id"))
+				f.mockEC2APIHelper.EXPECT().DeleteNetworkInterface(&Branch2Id).Return(nil)
+			},
+			args: args{
+				eniDetail: EniDetails2,
+				VlanID:    VlanId2,
+			},
+			wantErr: false,
+			asserts: func(f *fields) {
+				assert.False(t, f.trunkENI.usedVlanIds[VlanId2])
+				// If deleteENI had tried to release again, freeVlanIdLocked would have logged a
+				// "free_unused_vlan_id" error (the vlan is already free) instead of skipping the
+				// release entirely.
+				assert.Equal(t, freeUnusedVlanErrBefore,
+					testutil.ToFloat64(trunkENIOperationsErrCount.WithLabelValues("free_unused_vlan_id")),
+					"deleteENI must not attempt to re-release an already-released slot")
 			},
 		},
 	}
@@ -528,23 +565,37 @@ func TestTrunkENI_deleteENI(t *testing.T) {
 	}
 }
 
-// TestTrunkENI_DeleteCooledDownENIs_NotCooledDown tests that ENIs that have not cooled down are not deleted
+// TestTrunkENI_DeleteCooledDownENIs_NotCooledDown tests that ENIs that have not cooled down are not
+// deleted, but M1 (design doc section 2.2) still disassociates them immediately - with no cooldown
+// wait - so their trunk slot and vlan are released even though they remain queued for deletion.
 func TestTrunkENI_DeleteCooledDownENIs_NotCooledDown(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	trunkENI := getMockTrunk()
+	trunkENI, ec2APIHelper, _ := getMockHelperInstanceAndTrunkObject(ctrl)
+	trunkENI.usedVlanIds[VlanId1] = true
+	trunkENI.usedVlanIds[VlanId2] = true
 
 	EniDetails1.deletionTimeStamp = time.Now()
 	EniDetails2.deletionTimeStamp = time.Now()
 	trunkENI.deleteQueue = append(trunkENI.deleteQueue, EniDetails1, EniDetails2)
+
+	ec2APIHelper.EXPECT().DisassociateTrunkInterface(&MockAssociationID1).Return(nil)
+	ec2APIHelper.EXPECT().DisassociateTrunkInterface(&MockAssociationID2).Return(nil)
 
 	mockK8sAPI := mock_k8s.NewMockK8sWrapper(ctrl)
 	mockK8sAPI.EXPECT().GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace).Return(createCoolDownMockCM("30"), nil)
 	cooldown.InitCoolDownPeriod(mockK8sAPI, zap.New(zap.UseDevMode(true)).WithName("cooldown"))
 
 	trunkENI.DeleteCooledDownENIs()
+
+	// Delete itself stays gated behind the cooldown, so both entries remain queued.
 	assert.Equal(t, 2, len(trunkENI.deleteQueue))
+	// But the immediate disassociate already ran: the slot and vlan are released.
+	assert.True(t, EniDetails1.slotReleased)
+	assert.True(t, EniDetails2.slotReleased)
+	assert.False(t, trunkENI.usedVlanIds[VlanId1])
+	assert.False(t, trunkENI.usedVlanIds[VlanId2])
 }
 
 // TestTrunkENI_DeleteCooledDownENIs_NoDeletionTimeStamp tests that ENIs are deleted if they don't have any deletion timestamp
@@ -574,7 +625,8 @@ func TestTrunkENI_DeleteCooledDownENIs_NoDeletionTimeStamp(t *testing.T) {
 	assert.Equal(t, 0, len(trunkENI.deleteQueue))
 }
 
-// TestTrunkENI_DeleteCooledDownENIs_CooledDownResource tests that cooled down resources are deleted
+// TestTrunkENI_DeleteCooledDownENIs_CooledDownResource tests that cooled down resources are deleted,
+// and that the not-yet-cooled-down resource left behind is still immediately disassociated (M1).
 func TestTrunkENI_DeleteCooledDownENIs_CooledDownResource(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -589,6 +641,9 @@ func TestTrunkENI_DeleteCooledDownENIs_CooledDownResource(t *testing.T) {
 
 	ec2APIHelper.EXPECT().DisassociateTrunkInterface(&MockAssociationID1).Return(nil)
 	ec2APIHelper.EXPECT().DeleteNetworkInterface(&EniDetails1.ID).Return(nil)
+	// EniDetails2 has not cooled down for delete, but M1 disassociates it anyway, with no cooldown
+	// wait, releasing its slot and vlan even though it remains queued.
+	ec2APIHelper.EXPECT().DisassociateTrunkInterface(&MockAssociationID2).Return(nil)
 
 	mockK8sAPI := mock_k8s.NewMockK8sWrapper(ctrl)
 	mockK8sAPI.EXPECT().GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace).Return(createCoolDownMockCM("30"), nil)
@@ -597,10 +652,15 @@ func TestTrunkENI_DeleteCooledDownENIs_CooledDownResource(t *testing.T) {
 	trunkENI.DeleteCooledDownENIs()
 	assert.Equal(t, 1, len(trunkENI.deleteQueue))
 	assert.Equal(t, EniDetails2, trunkENI.deleteQueue[0])
+	assert.True(t, EniDetails2.slotReleased, "the not-yet-cooled-down entry must still be immediately disassociated")
+	assert.False(t, trunkENI.usedVlanIds[VlanId2], "its vlan must be released even though it remains queued for delete")
 }
 
-// TestTrunkENI_DeleteCooledDownENIs_DeleteFailed tests that when delete fails item is requeued into the delete queue for
-// the retry count
+// TestTrunkENI_DeleteCooledDownENIs_DeleteFailed tests that when delete fails item is requeued into
+// the delete queue for the retry count. M1 (design doc section 2.2): disassociate happens exactly
+// ONCE per ENI - not once per delete retry - because once the slot is positively released,
+// disassociateIfNeeded skips it on every subsequent pass through the queue; a delete failure must
+// not re-occupy the slot.
 func TestTrunkENI_DeleteCooledDownENIs_DeleteFailed(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -619,13 +679,17 @@ func TestTrunkENI_DeleteCooledDownENIs_DeleteFailed(t *testing.T) {
 	cooldown.InitCoolDownPeriod(mockK8sAPI, zap.New(zap.UseDevMode(true)).WithName("cooldown"))
 
 	coolDown.EXPECT().GetCoolDownPeriod().Return(time.Second * 60).AnyTimes()
-	ec2APIHelper.EXPECT().DisassociateTrunkInterface(&MockAssociationID1).Return(nil).Times(MaxDeleteRetries)
+	ec2APIHelper.EXPECT().DisassociateTrunkInterface(&MockAssociationID1).Return(nil)
 	ec2APIHelper.EXPECT().DeleteNetworkInterface(&EniDetails1.ID).Return(MockError).Times(MaxDeleteRetries)
 	ec2APIHelper.EXPECT().DisassociateTrunkInterface(&MockAssociationID2).Return(nil)
 	ec2APIHelper.EXPECT().DeleteNetworkInterface(&EniDetails2.ID).Return(nil)
 
 	trunkENI.DeleteCooledDownENIs()
 	assert.Zero(t, len(trunkENI.deleteQueue))
+	// The repeatedly-failing delete's slot must stay released throughout - it was never re-occupied
+	// by the retries.
+	assert.True(t, EniDetails1.slotReleased)
+	assert.False(t, trunkENI.usedVlanIds[VlanId1])
 }
 
 // TestTrunkENI_DeleteCooledDownENIs_ForgottenMetric verifies that when an ENI exhausts MaxDeleteRetries
@@ -644,8 +708,10 @@ func TestTrunkENI_DeleteCooledDownENIs_ForgottenMetric(t *testing.T) {
 	mockK8sAPI.EXPECT().GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace).Return(createCoolDownMockCM("60"), nil)
 	cooldown.InitCoolDownPeriod(mockK8sAPI, zap.New(zap.UseDevMode(true)).WithName("cooldown"))
 
+	// The immediate disassociate (M1) runs exactly once - not once per delete retry - since it is
+	// skipped on every subsequent pass once the slot is positively released.
+	ec2APIHelper.EXPECT().DisassociateTrunkInterface(&MockAssociationID1).Return(nil)
 	// Every delete attempt fails, so the ENI is retried MaxDeleteRetries times and then forgotten.
-	ec2APIHelper.EXPECT().DisassociateTrunkInterface(&MockAssociationID1).Return(nil).Times(MaxDeleteRetries)
 	ec2APIHelper.EXPECT().DeleteNetworkInterface(&EniDetails1.ID).Return(MockError).Times(MaxDeleteRetries)
 
 	before := testutil.ToFloat64(branchENIDeleteForgottenCount.WithLabelValues("max_delete_retries_exceeded"))
@@ -656,6 +722,229 @@ func TestTrunkENI_DeleteCooledDownENIs_ForgottenMetric(t *testing.T) {
 	after := testutil.ToFloat64(branchENIDeleteForgottenCount.WithLabelValues("max_delete_retries_exceeded"))
 	assert.Equal(t, float64(1), after-before, "expected one forgotten branch ENI to be counted")
 	assert.Zero(t, len(trunkENI.deleteQueue))
+	// Forgetting the ENI (giving up on delete retries) must NOT re-occupy its already-released slot.
+	assert.True(t, EniDetails1.slotReleased)
+	assert.False(t, trunkENI.usedVlanIds[VlanId1])
+}
+
+// TestTrunkENI_disassociateIfNeeded_Success verifies that a successful immediate disassociate (M1,
+// design doc section 2.2) releases the trunk slot and vlan right away, starting the vlan reuse
+// cooldown clock at the ENI's deletionTimeStamp - not at disassociate time - and records the
+// immediate-disassociate success metric.
+func TestTrunkENI_disassociateIfNeeded_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, ec2APIHelper, _ := getMockHelperInstanceAndTrunkObject(ctrl)
+	trunkENI.usedVlanIds[VlanId1] = true
+	deletedAt := time.Now().Add(-5 * time.Second)
+	EniDetails1.deletionTimeStamp = deletedAt
+
+	ec2APIHelper.EXPECT().DisassociateTrunkInterface(&MockAssociationID1).Return(nil)
+
+	before := testutil.ToFloat64(branchENIOperationsSuccessCount.WithLabelValues("immediate_disassociate_succeeded"))
+
+	trunkENI.disassociateIfNeeded(EniDetails1)
+
+	assert.True(t, EniDetails1.slotReleased)
+	assert.False(t, trunkENI.usedVlanIds[VlanId1])
+	assert.Equal(t, deletedAt, trunkENI.vlanReleasedAt[VlanId1],
+		"the reuse cooldown clock must start at the ENI's deletionTimeStamp, not now")
+	assert.Equal(t, float64(1),
+		testutil.ToFloat64(branchENIOperationsSuccessCount.WithLabelValues("immediate_disassociate_succeeded"))-before)
+}
+
+// TestTrunkENI_disassociateIfNeeded_AssociationAlreadyGone verifies that EC2 reporting the
+// association already gone is treated the same as a successful disassociate.
+func TestTrunkENI_disassociateIfNeeded_AssociationAlreadyGone(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, ec2APIHelper, _ := getMockHelperInstanceAndTrunkObject(ctrl)
+	trunkENI.usedVlanIds[VlanId1] = true
+
+	ec2APIHelper.EXPECT().DisassociateTrunkInterface(&MockAssociationID1).
+		Return(fmt.Errorf("%s: already gone", ec2Errors.NotFoundAssociationID))
+
+	trunkENI.disassociateIfNeeded(EniDetails1)
+
+	assert.True(t, EniDetails1.slotReleased)
+	assert.False(t, trunkENI.usedVlanIds[VlanId1])
+}
+
+// TestTrunkENI_disassociateIfNeeded_RealFailureLeavesSlotOccupied verifies that a genuine
+// disassociate failure leaves the slot counted as occupied (requirement 4: over-counting is safe,
+// under-counting is not), so a later processing pass can retry it.
+func TestTrunkENI_disassociateIfNeeded_RealFailureLeavesSlotOccupied(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, ec2APIHelper, _ := getMockHelperInstanceAndTrunkObject(ctrl)
+	trunkENI.usedVlanIds[VlanId1] = true
+
+	ec2APIHelper.EXPECT().DisassociateTrunkInterface(&MockAssociationID1).Return(MockError)
+
+	trunkENI.disassociateIfNeeded(EniDetails1)
+
+	assert.False(t, EniDetails1.slotReleased)
+	assert.True(t, trunkENI.usedVlanIds[VlanId1])
+}
+
+// TestTrunkENI_disassociateIfNeeded_SkipsAlreadyReleased verifies the immediate disassociate is not
+// re-attempted once the slot has already been positively released (no DisassociateTrunkInterface
+// expectation is registered below - gomock fails the test if it is called anyway).
+func TestTrunkENI_disassociateIfNeeded_SkipsAlreadyReleased(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, _, _ := getMockHelperInstanceAndTrunkObject(ctrl)
+	EniDetails1.slotReleased = true
+
+	trunkENI.disassociateIfNeeded(EniDetails1)
+}
+
+// TestTrunkENI_disassociateIfNeeded_SkipsMissingAssociationID verifies a sweep-discovered orphan
+// with no known AssociationID is left for deleteENI's fallback release instead of being
+// disassociated directly - there is nothing for us to disassociate with (no
+// DisassociateTrunkInterface expectation is registered below - gomock fails the test if it is
+// called anyway).
+func TestTrunkENI_disassociateIfNeeded_SkipsMissingAssociationID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, _, _ := getMockHelperInstanceAndTrunkObject(ctrl)
+
+	trunkENI.disassociateIfNeeded(ENIDetailsMissingAssociationID)
+
+	assert.False(t, ENIDetailsMissingAssociationID.slotReleased)
+}
+
+// TestTrunkENI_U1_VlanReuseCooldown verifies M1's VLAN reuse cooldown (design doc section 2.2,
+// test scenario U1): a released vlan is not reassignable before deletionTimeStamp+reuseCooldown and
+// is reassignable after; the owner record is cleared on release; and the blocked-allocation metric
+// fires while the vlan is still cooling.
+func TestTrunkENI_U1_VlanReuseCooldown(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockK8sAPI := mock_k8s.NewMockK8sWrapper(ctrl)
+	mockK8sAPI.EXPECT().GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace).Return(createCoolDownMockCM("30"), nil)
+	cooldown.InitCoolDownPeriod(mockK8sAPI, zap.New(zap.UseDevMode(true)).WithName("cooldown"))
+
+	trunkENI := getMockTrunk()
+	trunkENI.usedVlanIds[0] = true // reserved, as on a real trunk
+
+	releasedEni := &ENIDetails{ID: "eni-released", VlanID: VlanId1, deletionTimeStamp: time.Now().Add(-20 * time.Second)}
+	trunkENI.usedVlanIds[VlanId1] = true
+	trunkENI.vlanOwner[VlanId1] = releasedEni.ID
+	trunkENI.releaseSlot(releasedEni)
+
+	assert.False(t, trunkENI.usedVlanIds[VlanId1], "the vlan must be marked free in the ledger immediately")
+	_, stillOwned := trunkENI.vlanOwner[VlanId1]
+	assert.False(t, stillOwned, "the owner record must be cleared on release")
+
+	// Released 20s ago, still within the 30s reuse cooldown: free in the ledger but must not be
+	// handed out, and the blocked-allocation metric must record it.
+	before := testutil.ToFloat64(branchENIVlanReuseCooldownBlockedCount)
+	consumedId, err := trunkENI.assignVlanId("")
+	assert.NoError(t, err)
+	assert.NotEqual(t, VlanId1, consumedId, "a vlan still inside its reuse cooldown must not be reassigned")
+	assert.Equal(t, float64(1), testutil.ToFloat64(branchENIVlanReuseCooldownBlockedCount)-before)
+	trunkENI.freeVlanId(consumedId, "", "")
+
+	// Past the 30s cooldown window: now reassignable, and the cooldown record is cleared.
+	trunkENI.vlanReleasedAt[VlanId1] = time.Now().Add(-31 * time.Second)
+	id, err := trunkENI.assignVlanId("")
+	assert.NoError(t, err)
+	assert.Equal(t, VlanId1, id, "past its reuse cooldown, the vlan must be reassignable")
+	_, stillCooling := trunkENI.vlanReleasedAt[VlanId1]
+	assert.False(t, stillCooling, "the cooldown record must be cleared once the vlan is reassigned")
+}
+
+// TestTrunkENI_U2_CanCreateMoreAccounting verifies M1's requirement 4 (design doc section 2.2):
+// canCreateMore stops counting a delete-queue entry as occupying a slot only once its release has
+// been positively observed - never inferred from an empty AssociationID, since a sweep-discovered
+// orphan is enqueued with no known AssociationID while still genuinely attached in EC2 (over-counting
+// is safe; under-counting would over-subscribe the trunk).
+func TestTrunkENI_U2_CanCreateMoreAccounting(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, _, mockInstance := getMockHelperInstanceAndTrunkObject(ctrl)
+	mockInstance.EXPECT().Type().Return(InstanceType).AnyTimes()
+
+	limit := vpc.Limits[InstanceType].BranchInterface
+	for i := 0; i < limit-1; i++ {
+		podUID := fmt.Sprintf("filler-pod-%d", i)
+		trunkENI.uidToBranchENIMap[podUID] = []*ENIDetails{{ID: fmt.Sprintf("eni-filler-%d", i)}}
+	}
+
+	queued := &ENIDetails{ID: "eni-queued"}
+	trunkENI.deleteQueue = append(trunkENI.deleteQueue, queued)
+
+	assert.False(t, trunkENI.canCreateMore(),
+		"an unreleased delete-queue entry must still count as occupying a slot")
+
+	queued.slotReleased = true
+	assert.True(t, trunkENI.canCreateMore(),
+		"a positively-released delete-queue entry must free up a slot")
+
+	// A sweep-discovered orphan (empty AssociationID) must not be assumed released just because it
+	// has no known AssociationID - it is still attached in EC2.
+	orphan := &ENIDetails{ID: "eni-orphan-no-association-id"}
+	trunkENI.deleteQueue = append(trunkENI.deleteQueue, orphan)
+	assert.False(t, trunkENI.canCreateMore(),
+		"a sweep-discovered orphan must keep counting as occupied until release is positively observed")
+}
+
+// TestTrunkENI_RegressionE5 is the design doc section 4/5.2 R-E5 regression: on a capacity-full
+// trunk, deleting a pod must free its slot within a single DeleteCooledDownENIs processing pass -
+// not after a full cooldown period - while its vlan remains unavailable for reuse until the reuse
+// cooldown elapses.
+func TestTrunkENI_RegressionE5(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, ec2APIHelper, mockInstance := getMockHelperInstanceAndTrunkObject(ctrl)
+	mockInstance.EXPECT().Type().Return(InstanceType).AnyTimes()
+
+	mockK8sAPI := mock_k8s.NewMockK8sWrapper(ctrl)
+	mockK8sAPI.EXPECT().GetConfigMap(config.VpcCniConfigMapName, config.KubeSystemNamespace).Return(createCoolDownMockCM("30"), nil)
+	cooldown.InitCoolDownPeriod(mockK8sAPI, zap.New(zap.UseDevMode(true)).WithName("cooldown"))
+
+	// Fill the trunk to exactly the c5.xlarge branch-interface limit: limit-1 filler branches plus
+	// the one real pod (owning EniDetails1/VlanId1) that is about to be deleted.
+	limit := vpc.Limits[InstanceType].BranchInterface
+	for i := 0; i < limit-1; i++ {
+		podUID := fmt.Sprintf("filler-pod-%d", i)
+		trunkENI.uidToBranchENIMap[podUID] = []*ENIDetails{{ID: fmt.Sprintf("eni-filler-%d", i)}}
+	}
+	trunkENI.usedVlanIds[VlanId1] = true
+	trunkENI.vlanOwner[VlanId1] = EniDetails1.ID
+	trunkENI.uidToBranchENIMap[PodUID] = []*ENIDetails{EniDetails1}
+
+	assert.False(t, trunkENI.canCreateMore(), "the trunk must start at capacity")
+
+	// Pod deleted: synchronous hand-off to the delete queue, no EC2 call yet.
+	trunkENI.PushBranchENIsToCoolDownQueue(PodUID)
+	assert.False(t, trunkENI.canCreateMore(),
+		"queuing for deletion alone must not free the slot before disassociation is observed")
+
+	// One async processing pass: the delete cooldown has NOT elapsed (deletionTimeStamp is now),
+	// but M1 disassociates immediately anyway.
+	ec2APIHelper.EXPECT().DisassociateTrunkInterface(&MockAssociationID1).Return(nil)
+	trunkENI.DeleteCooledDownENIs()
+
+	assert.True(t, trunkENI.canCreateMore(),
+		"the slot must be available after a single processing pass, not after a full cooldown")
+	assert.Len(t, trunkENI.deleteQueue, 1, "the ENI itself is still awaiting the unchanged delete cooldown")
+
+	// The vlan is free in the ledger but must still be withheld from reuse until the reuse cooldown
+	// elapses (started at deletionTimeStamp, reproducing today's cooldown timing exactly).
+	newVlan, err := trunkENI.assignVlanId("")
+	assert.NoError(t, err)
+	assert.NotEqual(t, VlanId1, newVlan,
+		"the freed vlan must not be reused before its reuse cooldown elapses")
 }
 
 // TestTrunkENI_PushBranchENIsToCoolDownQueue tests that ENIs are pushed to the delete queue if the pod is being deleted
@@ -1077,10 +1366,17 @@ func TestTrunkENI_CreateAndAssociateBranchENIs_ErrorAssociate(t *testing.T) {
 
 	mockInstance.EXPECT().Type().Return(InstanceType)
 	mockInstance.EXPECT().InstanceID().Return(InstanceId)
-	mockInstance.EXPECT().SubnetID().Return(SubnetId).Times(2)
+	// M3 (design doc section 2.4): the failed association now also triggers one error-driven orphan
+	// reclaim describe, which reads the subnet - hence one SubnetID call beyond the two creates.
+	mockInstance.EXPECT().SubnetID().Return(SubnetId).Times(3)
 	mockInstance.EXPECT().SubnetCidrBlock().Return(SubnetCidrBlock).Times(2)
 	mockInstance.EXPECT().SubnetV6CidrBlock().Return(SubnetV6CidrBlock).Times(2)
 	mockInstance.EXPECT().GetConnectionTrackingSpec().Return(nil, nil, nil)
+
+	// The reclaim describe returns the two branch ENIs this very allocation just created. Both are
+	// still in-flight (phase=creating), so the M5 G1 guard keeps the reclaim from enqueueing them and the
+	// delete-queue assertion below is unchanged - proving M3 cannot cannibalize an in-flight create.
+	mockEC2APIHelper.EXPECT().GetBranchNetworkInterface(&trunkId, &SubnetId).Return(branchInterfaces, nil)
 
 	gomock.InOrder(
 		mockEC2APIHelper.EXPECT().CreateNetworkInterface(&BranchEniDescription, &SubnetId, SecurityGroups,
@@ -1626,4 +1922,519 @@ func TestTrunkENI_ShadowReuse_PodReleaseFeedsShadowRecords(t *testing.T) {
 	trunkENI.observeShadowReuse([]string{SecurityGroup1, SecurityGroup2})
 	assert.Equal(t, float64(1),
 		testutil.ToFloat64(orphanReuseShadowHitCount.WithLabelValues(shadowSGMatchExact))-exactBefore)
+}
+
+// TestTrunkENI_U5_PendingCreateSkippedByGateAndSweep verifies M5 G1 (design doc section 2.6): an
+// ENI in the in-flight set (phase=creating) is never classified as an orphan by either the known-set builder shared by
+// the gate and the sweep, or by the sweep's own re-check at enqueue time.
+func TestTrunkENI_U5_PendingCreateSkippedByGateAndSweep(t *testing.T) {
+	trunkENI := getMockTrunk()
+	inflightId := "eni-inflight-create"
+	trunkENI.inFlightENIs[inflightId] = eniPhaseCreating
+
+	knownBranchENIs := trunkENI.knownBranchENIsLocked()
+	_, known := knownBranchENIs[inflightId]
+	assert.True(t, known, "an in-flight create must be part of the known set")
+
+	orphanBefore := testutil.ToFloat64(branchENIOrphanReclaimedCount.WithLabelValues("discovered"))
+	foundUnassigned := trunkENI.pushUnassignedBranchInterfacesToDeleteQueue(
+		map[string]*awsEc2Types.NetworkInterface{
+			inflightId: {NetworkInterfaceId: &inflightId, TagSet: vlan1Tag},
+		})
+
+	assert.False(t, foundUnassigned, "an in-flight create must not be discovered as an orphan")
+	assert.Empty(t, trunkENI.deleteQueue, "an in-flight create must never be enqueued for deletion")
+	assert.Equal(t, float64(0),
+		testutil.ToFloat64(branchENIOrphanReclaimedCount.WithLabelValues("discovered"))-orphanBefore)
+}
+
+// TestTrunkENI_U6_DeleteQueueDedup verifies M5 G2 (design doc section 2.6): none of the three
+// enqueue paths insert a second entry for an ENI ID already in the delete queue.
+func TestTrunkENI_U6_DeleteQueueDedup(t *testing.T) {
+	trunkENI := getMockTrunk()
+	trunkENI.usedVlanIds[VlanId1] = true
+
+	dedupBefore := testutil.ToFloat64(branchENIDeleteQueueDedupCount)
+
+	// pushENIToDeleteQueue (used by the pod-delete path).
+	trunkENI.pushENIToDeleteQueue(EniDetails1)
+	trunkENI.pushENIToDeleteQueue(EniDetails1)
+	assert.Len(t, trunkENI.deleteQueue, 1, "pushENIToDeleteQueue must not insert a duplicate ID")
+
+	// PushENIsToFrontOfDeleteQueue (used by the create-failure path).
+	trunkENI.PushENIsToFrontOfDeleteQueue(nil, []*ENIDetails{EniDetails1})
+	assert.Len(t, trunkENI.deleteQueue, 1, "PushENIsToFrontOfDeleteQueue must not insert a duplicate ID")
+
+	// pushUnassignedBranchInterfacesToDeleteQueue (used by the gate and the sweep).
+	foundUnassigned := trunkENI.pushUnassignedBranchInterfacesToDeleteQueue(
+		map[string]*awsEc2Types.NetworkInterface{
+			Branch1Id: {NetworkInterfaceId: &Branch1Id, TagSet: vlan1Tag},
+		})
+	assert.False(t, foundUnassigned,
+		"an ENI already in the delete queue must not be re-discovered as an orphan")
+	assert.Len(t, trunkENI.deleteQueue, 1,
+		"pushUnassignedBranchInterfacesToDeleteQueue must not insert a duplicate ID")
+
+	assert.Equal(t, float64(3),
+		testutil.ToFloat64(branchENIDeleteQueueDedupCount)-dedupBefore,
+		"all three duplicate attempts must be counted")
+}
+
+// TestTrunkENI_U7_FreeVlanIdOwnerAware verifies M5 G3 (design doc section 2.6): freeVlanId only
+// frees a VLAN whose recorded owner matches the requesting ENI ID (or has no recorded owner, for
+// legacy callers), and reserved VLAN 0 is never handed out for a caller to free in the first place.
+func TestTrunkENI_U7_FreeVlanIdOwnerAware(t *testing.T) {
+	trunkENI := getMockTrunk()
+
+	// A VLAN with no recorded owner still frees (legacy/unknown-tag fallback paths).
+	trunkENI.usedVlanIds[VlanId1] = true
+	trunkENI.freeVlanId(VlanId1, "eni-any", "")
+	assert.False(t, trunkENI.usedVlanIds[VlanId1], "an unowned vlan must still free")
+
+	// A VLAN owned by a different ENI must not be freed.
+	trunkENI.usedVlanIds[VlanId2] = true
+	trunkENI.vlanOwner[VlanId2] = "eni-owner"
+	trunkENI.freeVlanId(VlanId2, "eni-not-the-owner", "")
+	assert.True(t, trunkENI.usedVlanIds[VlanId2], "a vlan owned by another eni must not be freed")
+	assert.Equal(t, "eni-owner", trunkENI.vlanOwner[VlanId2])
+
+	// The rightful owner can free it.
+	trunkENI.freeVlanId(VlanId2, "eni-owner", "")
+	assert.False(t, trunkENI.usedVlanIds[VlanId2], "the rightful owner must be able to free the vlan")
+	_, stillOwned := trunkENI.vlanOwner[VlanId2]
+	assert.False(t, stillOwned, "the owner record must be cleared once freed")
+
+	// Reserved VLAN 0 is initialized permanently used and is never handed out by assignVlanId,
+	// so no caller ever reaches freeVlanId(0, ...) on a real trunk; markVlanAssignedWithOwnerLocked
+	// also never records an owner for it.
+	assert.NoError(t, trunkENI.markVlanAssignedWithOwnerLocked(0, "eni-x"))
+	_, ownerRecordedForVlan0 := trunkENI.vlanOwner[0]
+	assert.False(t, ownerRecordedForVlan0, "reserved vlan 0 must never get an owner")
+}
+
+// TestTrunkENI_RegressionHA is the design doc section 4 H-A regression: an ENI created in the
+// Associate-to-cache window (present in EC2, attached, but not yet in the pod-owned ledger) must
+// never be swept as an orphan by the ledger-verify gate.
+func TestTrunkENI_RegressionHA(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, mockHelper, _ := getMockHydratedTrunk(t, ctrl)
+
+	// Simulate CreateAndAssociateBranchENIs having just created and associated a new branch ENI
+	// for a different pod, but not yet reached addBranchToCache.
+	inflightId := "eni-inflight-associate-window"
+	inflightVlan := 5
+	trunkENI.inFlightENIs[inflightId] = eniPhaseCreating
+	trunkENI.usedVlanIds[inflightVlan] = true
+	trunkENI.vlanOwner[inflightVlan] = inflightId
+
+	inflight := &awsEc2Types.NetworkInterface{
+		InterfaceType:      awsEc2Types.NetworkInterfaceTypeBranch,
+		NetworkInterfaceId: &inflightId,
+		TagSet: []awsEc2Types.Tag{{
+			Key:   aws.String(config.VLandIDTag),
+			Value: aws.String(strconv.Itoa(inflightVlan)),
+		}, trunkIDTag},
+	}
+	attached := append(append([]*awsEc2Types.NetworkInterface{}, branchInterfaces...), inflight)
+	mockHelper.EXPECT().GetBranchNetworkInterface(&trunkId, &SubnetId).Return(attached, nil).Times(1)
+
+	err := trunkENI.verifyBranchLedger()
+	assert.NoError(t, err)
+	assert.True(t, trunkENI.branchLedgerVerified)
+
+	assert.Empty(t, trunkENI.deleteQueue,
+		"an in-flight create must not be enqueued for deletion by the ledger-verify gate")
+	assert.True(t, trunkENI.usedVlanIds[inflightVlan], "the in-flight create's vlan must remain reserved")
+}
+
+// TestTrunkENI_RegressionHB is the design doc section 4 H-B regression: an ENI already in the
+// delete queue must not be re-enqueued by the sweep (G2), and even if a stale duplicate delete
+// somehow still ran, owner-aware freeVlanId (G3) must not release a vlan that has since been
+// reassigned to a new pod's branch ENI.
+func TestTrunkENI_RegressionHB(t *testing.T) {
+	trunkENI := getMockTrunk()
+	// Reserve vlan 0 like a real trunk so assignVlanId's lowest-free scan lands on sharedVlan
+	// once it is freed, instead of on the mock's otherwise-unreserved index 0.
+	trunkENI.usedVlanIds[0] = true
+
+	sharedVlan := 1
+	oldENI := &ENIDetails{ID: "eni-old-awaiting-delete", VlanID: sharedVlan}
+	trunkENI.usedVlanIds[sharedVlan] = true
+	trunkENI.vlanOwner[sharedVlan] = oldENI.ID
+
+	// The orphan sweep discovers the ENI awaiting deletion once...
+	trunkENI.pushENIToDeleteQueue(oldENI)
+	assert.Len(t, trunkENI.deleteQueue, 1)
+
+	// ...and a second sweep pass (e.g. before EC2 confirms the delete) must not duplicate it (G2).
+	foundUnassigned := trunkENI.pushUnassignedBranchInterfacesToDeleteQueue(
+		map[string]*awsEc2Types.NetworkInterface{
+			oldENI.ID: {NetworkInterfaceId: &oldENI.ID, TagSet: vlan1Tag},
+		})
+	assert.False(t, foundUnassigned)
+	assert.Len(t, trunkENI.deleteQueue, 1, "the awaiting-delete ENI must not be duplicated in the queue")
+
+	// The single queued entry is popped and actually deleted, freeing its vlan.
+	popped, hasENI := trunkENI.popENIFromDeleteQueue()
+	assert.True(t, hasENI)
+	assert.Equal(t, oldENI.ID, popped.ID)
+	trunkENI.freeVlanId(sharedVlan, popped.ID, "")
+	assert.False(t, trunkENI.usedVlanIds[sharedVlan])
+
+	// A new pod immediately grabs the now-free vlan.
+	newVlan, err := trunkENI.assignVlanId("")
+	assert.NoError(t, err)
+	assert.Equal(t, sharedVlan, newVlan)
+	trunkENI.addInFlightCreate("eni-new-owner", newVlan, "")
+
+	// If a stale duplicate of the old ENI's delete somehow still ran (the race G2 closes at the
+	// source), owner-aware freeVlanId (G3) refuses to release the vlan out from under the new
+	// owner.
+	trunkENI.freeVlanId(sharedVlan, oldENI.ID, "")
+	assert.True(t, trunkENI.usedVlanIds[sharedVlan],
+		"the vlan must remain reserved for the new owner despite the stale duplicate free")
+	assert.Equal(t, "eni-new-owner", trunkENI.vlanOwner[sharedVlan])
+}
+
+// --- M3: error-driven orphan reclaim (design doc section 2.4) ---------------------------------
+
+// newReclaimTrunk returns a trunk wired with mocks and a trunk ID, ready for the error-driven
+// reclaim path (which describes the trunk's branch ENIs).
+func newReclaimTrunk(ctrl *gomock.Controller) (*trunkENI, *mock_api.MockEC2APIHelper) {
+	trunkENI, mockHelper, mockInstance := getMockHelperInstanceAndTrunkObject(ctrl)
+	trunkENI.trunkENIId = trunkId
+	mockInstance.EXPECT().SubnetID().Return(SubnetId).AnyTimes()
+	return trunkENI, mockHelper
+}
+
+// TestTrunkENI_U4_ErrorDrivenReclaim_EnqueuesOrphan proves the reactive floor: after a failed
+// branch-ENI addition, one describe runs and an attached-but-unknown ENI is enqueued for deletion.
+func TestTrunkENI_U4_ErrorDrivenReclaim_EnqueuesOrphan(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, mockHelper := newReclaimTrunk(ctrl)
+	orphanID := "eni-orphan-holding-slot"
+	mockHelper.EXPECT().GetBranchNetworkInterface(&trunkId, &SubnetId).Return(
+		[]*awsEc2Types.NetworkInterface{
+			{NetworkInterfaceId: &orphanID, TagSet: vlan1Tag},
+		}, nil).Times(1)
+
+	orphanBefore := testutil.ToFloat64(branchENIErrorDrivenOrphanCount)
+
+	trunkENI.reclaimOrphansAfterAddFailure(fmt.Errorf("InsufficientCapacityOnTrunk: no capacity"))
+
+	assert.Len(t, trunkENI.deleteQueue, 1, "the orphan wedging the trunk must be enqueued")
+	assert.Equal(t, orphanID, trunkENI.deleteQueue[0].ID)
+	assert.Equal(t, float64(1), testutil.ToFloat64(branchENIErrorDrivenOrphanCount)-orphanBefore)
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		branchENIErrorDrivenReclaimCount.WithLabelValues(reclaimResultReclaimed, reclaimErrorClassCapacity)))
+}
+
+// TestTrunkENI_U4_ErrorDrivenReclaim_VlanInUseClass proves a VLAN-collision failure also triggers
+// the reclaim (design section 2.4: the trigger is ANY addition failure, not just capacity).
+func TestTrunkENI_U4_ErrorDrivenReclaim_VlanInUseClass(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, mockHelper := newReclaimTrunk(ctrl)
+	orphanID := "eni-orphan-holding-vlan"
+	mockHelper.EXPECT().GetBranchNetworkInterface(&trunkId, &SubnetId).Return(
+		[]*awsEc2Types.NetworkInterface{
+			{NetworkInterfaceId: &orphanID, TagSet: vlan2Tag},
+		}, nil).Times(1)
+
+	before := testutil.ToFloat64(
+		branchENIErrorDrivenReclaimCount.WithLabelValues(reclaimResultReclaimed, reclaimErrorClassVlanInUse))
+
+	trunkENI.reclaimOrphansAfterAddFailure(fmt.Errorf("VlanId 2 is already in use on the trunk"))
+
+	assert.Len(t, trunkENI.deleteQueue, 1)
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		branchENIErrorDrivenReclaimCount.WithLabelValues(reclaimResultReclaimed, reclaimErrorClassVlanInUse))-before)
+}
+
+// TestTrunkENI_U4_ErrorDrivenReclaim_CleanWhenEC2Agrees proves that when EC2 agrees with the ledger
+// nothing is enqueued: the failure was not caused by an orphan.
+func TestTrunkENI_U4_ErrorDrivenReclaim_CleanWhenEC2Agrees(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, mockHelper := newReclaimTrunk(ctrl)
+	owned := &ENIDetails{ID: "eni-owned-by-pod", VlanID: VlanId1}
+	trunkENI.uidToBranchENIMap["pod-uid"] = []*ENIDetails{owned}
+	mockHelper.EXPECT().GetBranchNetworkInterface(&trunkId, &SubnetId).Return(
+		[]*awsEc2Types.NetworkInterface{
+			{NetworkInterfaceId: &owned.ID, TagSet: vlan1Tag},
+		}, nil).Times(1)
+
+	before := testutil.ToFloat64(
+		branchENIErrorDrivenReclaimCount.WithLabelValues(reclaimResultClean, reclaimErrorClassOther))
+
+	trunkENI.reclaimOrphansAfterAddFailure(fmt.Errorf("some unrelated transient failure"))
+
+	assert.Empty(t, trunkENI.deleteQueue, "a pod-owned ENI must never be reclaimed")
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		branchENIErrorDrivenReclaimCount.WithLabelValues(reclaimResultClean, reclaimErrorClassOther))-before)
+}
+
+// TestTrunkENI_U4_ErrorDrivenReclaim_RateWindow proves the failure-path describe is bounded: a
+// second failure inside errorDrivenReclaimWindow must not issue another describe.
+func TestTrunkENI_U4_ErrorDrivenReclaim_RateWindow(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, mockHelper := newReclaimTrunk(ctrl)
+	// Exactly one describe for two back-to-back failures.
+	mockHelper.EXPECT().GetBranchNetworkInterface(&trunkId, &SubnetId).Return(
+		[]*awsEc2Types.NetworkInterface{}, nil).Times(1)
+
+	skipBefore := testutil.ToFloat64(
+		branchENIErrorDrivenReclaimCount.WithLabelValues(reclaimResultSkippedWindow, reclaimErrorClassCapacity))
+
+	trunkENI.reclaimOrphansAfterAddFailure(fmt.Errorf("capacity exceeded"))
+	trunkENI.reclaimOrphansAfterAddFailure(fmt.Errorf("capacity exceeded"))
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		branchENIErrorDrivenReclaimCount.WithLabelValues(reclaimResultSkippedWindow, reclaimErrorClassCapacity))-skipBefore,
+		"the second failure inside the window must be skipped, not describe again")
+}
+
+// TestTrunkENI_U4_ErrorDrivenReclaim_DescribeFailure proves a failed reclaim describe never panics
+// and never mutates ledger state - the caller's original allocation error stands.
+func TestTrunkENI_U4_ErrorDrivenReclaim_DescribeFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, mockHelper := newReclaimTrunk(ctrl)
+	mockHelper.EXPECT().GetBranchNetworkInterface(&trunkId, &SubnetId).Return(nil, MockError).Times(1)
+
+	before := testutil.ToFloat64(
+		branchENIErrorDrivenReclaimCount.WithLabelValues(reclaimResultDescribeError, reclaimErrorClassCapacity))
+
+	trunkENI.reclaimOrphansAfterAddFailure(fmt.Errorf("capacity exceeded"))
+
+	assert.Empty(t, trunkENI.deleteQueue, "a failed describe must not change ledger state")
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		branchENIErrorDrivenReclaimCount.WithLabelValues(reclaimResultDescribeError, reclaimErrorClassCapacity))-before)
+}
+
+// TestTrunkENI_ErrorDrivenReclaim_RespectsM5KnownSet proves the reclaim reuses the shared M5 known
+// set: an in-flight create (hazard H-A) and an ENI already awaiting deletion (hazard H-B) are never
+// reclaimed, so M3 cannot reintroduce either hazard.
+func TestTrunkENI_ErrorDrivenReclaim_RespectsM5KnownSet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, mockHelper := newReclaimTrunk(ctrl)
+	inflightID := "eni-inflight-create"
+	queuedID := "eni-awaiting-delete"
+	trunkENI.inFlightENIs[inflightID] = eniPhaseCreating
+	trunkENI.deleteQueue = append(trunkENI.deleteQueue, &ENIDetails{ID: queuedID, VlanID: VlanId2})
+
+	mockHelper.EXPECT().GetBranchNetworkInterface(&trunkId, &SubnetId).Return(
+		[]*awsEc2Types.NetworkInterface{
+			{NetworkInterfaceId: &inflightID, TagSet: vlan1Tag},
+			{NetworkInterfaceId: &queuedID, TagSet: vlan2Tag},
+		}, nil).Times(1)
+
+	trunkENI.reclaimOrphansAfterAddFailure(fmt.Errorf("capacity exceeded"))
+
+	assert.Len(t, trunkENI.deleteQueue, 1, "no duplicate entry and no in-flight create enqueued")
+	assert.Equal(t, queuedID, trunkENI.deleteQueue[0].ID)
+}
+
+// TestTrunkENI_RegressionE4 replays design hazard E4: orphans the ledger does not know occupy the
+// trunk's real branch slots, so canCreateMore wrongly allows an allocation that then fails to
+// associate. Without the reclaim the node loops create/delete forever. This asserts the wedge is
+// broken - after the failure the orphans are queued for deletion, which is what frees the slots.
+func TestTrunkENI_RegressionE4(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, mockHelper := newReclaimTrunk(ctrl)
+	orphan1 := "eni-orphan-1"
+	orphan2 := "eni-orphan-2"
+	mockHelper.EXPECT().GetBranchNetworkInterface(&trunkId, &SubnetId).Return(
+		[]*awsEc2Types.NetworkInterface{
+			{NetworkInterfaceId: &orphan1, TagSet: vlan1Tag},
+			{NetworkInterfaceId: &orphan2, TagSet: vlan2Tag},
+		}, nil).Times(1)
+
+	// The ledger is empty: it believes the trunk is idle while EC2 has two attached orphans.
+	assert.Empty(t, trunkENI.uidToBranchENIMap)
+
+	trunkENI.reclaimOrphansAfterAddFailure(fmt.Errorf("InsufficientCapacityOnTrunk"))
+
+	assert.Len(t, trunkENI.deleteQueue, 2, "both slot-holding orphans must be queued for deletion")
+	queued := map[string]bool{}
+	for _, eni := range trunkENI.deleteQueue {
+		queued[eni.ID] = true
+	}
+	assert.True(t, queued[orphan1] && queued[orphan2])
+}
+
+// TestReclaimErrorClass documents that classification is best-effort observability and that an
+// unrecognized error is still eligible for reclaim (reported as "other", never excluded).
+func TestReclaimErrorClass(t *testing.T) {
+	assert.Equal(t, reclaimErrorClassCapacity, reclaimErrorClass(fmt.Errorf("InsufficientCapacityOnTrunk")))
+	assert.Equal(t, reclaimErrorClassCapacity, reclaimErrorClass(fmt.Errorf("ResourceLimitExceeded")))
+	assert.Equal(t, reclaimErrorClassVlanInUse, reclaimErrorClass(fmt.Errorf("VlanId already in use")))
+	assert.Equal(t, reclaimErrorClassOther, reclaimErrorClass(fmt.Errorf("RequestLimitExceeded throttle")))
+	assert.Equal(t, reclaimErrorClassOther, reclaimErrorClass(nil))
+}
+
+// --- Pop window (design doc section 4.1 H-C) ---------------------------------------------------
+
+// TestTrunkENI_RegressionPopWindow proves the delete-side in-flight guard: an ENI popped from the
+// delete queue is outside the ledger AND the queue while its EC2 disassociate/delete call runs, so
+// a concurrent gate/sweep/M3 describe - which still sees it attached in EC2 - must not re-classify
+// it as an orphan and enqueue a duplicate. The concurrent sweep is triggered deterministically from
+// inside the mocked DisassociateTrunkInterface call, i.e. exactly inside the pop window.
+func TestTrunkENI_RegressionPopWindow(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, mockHelper := newReclaimTrunk(ctrl)
+
+	vlan := 5
+	eni := &ENIDetails{
+		ID:                "eni-pop-window",
+		VlanID:            vlan,
+		AssociationID:     "trunk-assoc-pop-window",
+		deletionTimeStamp: time.Now().Add(-10 * time.Minute), // past cooldown: delete proceeds this pass
+	}
+	trunkENI.usedVlanIds[vlan] = true
+	trunkENI.vlanOwner[vlan] = eni.ID
+	trunkENI.pushENIToDeleteQueue(eni)
+
+	vlanTag := []awsEc2Types.Tag{{
+		Key:   aws.String(config.VLandIDTag),
+		Value: aws.String(strconv.Itoa(vlan)),
+	}, trunkIDTag}
+
+	discoveredBefore := testutil.ToFloat64(branchENIOrphanReclaimedCount.WithLabelValues("discovered"))
+
+	mockHelper.EXPECT().DisassociateTrunkInterface(&eni.AssociationID).DoAndReturn(
+		func(*string) error {
+			// Mid-call: the ENI is popped and its disassociate is "in flight". Run the sweep now;
+			// its describe still reports the ENI attached.
+			mockHelper.EXPECT().GetBranchNetworkInterface(&trunkId, &SubnetId).Return(
+				[]*awsEc2Types.NetworkInterface{{NetworkInterfaceId: &eni.ID, TagSet: vlanTag}}, nil)
+			found, err := trunkENI.ReconcileUnassignedBranchENIs()
+			assert.NoError(t, err)
+			assert.False(t, found, "a mid-processing delete-queue ENI must not be classified as an orphan")
+			assert.Empty(t, trunkENI.deleteQueue, "the concurrent sweep must not enqueue a duplicate")
+			return nil
+		})
+	mockHelper.EXPECT().DeleteNetworkInterface(&eni.ID).Return(nil)
+
+	trunkENI.DeleteCooledDownENIs()
+
+	assert.Empty(t, trunkENI.deleteQueue)
+	assert.Empty(t, trunkENI.inFlightENIs, "the deleting marker must be cleared when the pass ends")
+	assert.False(t, trunkENI.usedVlanIds[vlan], "the VLAN must end up freed by the real delete flow")
+	assert.Equal(t, float64(0),
+		testutil.ToFloat64(branchENIOrphanReclaimedCount.WithLabelValues("discovered"))-discoveredBefore,
+		"the pop window must not distort the discovered-orphan metric")
+}
+
+// TestTrunkENI_PopWindow_EnqueueRecheck covers the second guard layer: even when a stale known-set
+// snapshot (taken before the pop) already classified the ENI as unassigned, the enqueue-time
+// re-check under the lock skips an ENI whose delete is being processed, counting it as a
+// delete-queue dedup - not as a discovered orphan - and leaving its VLAN ownership untouched.
+func TestTrunkENI_PopWindow_EnqueueRecheck(t *testing.T) {
+	trunkENI := getMockTrunk()
+
+	vlan := VlanId2
+	eniID := "eni-mid-delete-processing"
+	trunkENI.usedVlanIds[vlan] = true
+	trunkENI.vlanOwner[vlan] = eniID
+	trunkENI.inFlightENIs[eniID] = eniPhaseDeleting
+
+	discoveredBefore := testutil.ToFloat64(branchENIOrphanReclaimedCount.WithLabelValues("discovered"))
+	dedupBefore := testutil.ToFloat64(branchENIDeleteQueueDedupCount)
+
+	found := trunkENI.pushUnassignedBranchInterfacesToDeleteQueue(
+		map[string]*awsEc2Types.NetworkInterface{
+			eniID: {NetworkInterfaceId: &eniID, TagSet: vlan2Tag},
+		})
+
+	assert.False(t, found)
+	assert.Empty(t, trunkENI.deleteQueue, "an ENI being processed by the delete pipeline must not be re-enqueued")
+	assert.Equal(t, eniID, trunkENI.vlanOwner[vlan], "VLAN ownership must be left untouched")
+	assert.Equal(t, float64(1),
+		testutil.ToFloat64(branchENIDeleteQueueDedupCount)-dedupBefore,
+		"the skip is attributed to the delete-queue dedup counter (G2 extended to the pop window)")
+	assert.Equal(t, float64(0),
+		testutil.ToFloat64(branchENIOrphanReclaimedCount.WithLabelValues("discovered"))-discoveredBefore)
+}
+
+// TestTrunkENI_RegressionE2 proves the full E2 recovery chain end to end (design doc sections 4.1
+// E2 and 2.5 M4): persistent EC2 failures exhaust MaxDeleteRetries and the ENI is forgotten -
+// dropped from the queue while still attached in EC2, its VLAN still held (the leak). The sweep
+// then rediscovers it as an orphan, re-enqueues it with a fresh retry budget, and once the delete
+// finally succeeds the VLAN is freed - proving a forgotten ENI's VLAN is never PERMANENTLY leaked.
+func TestTrunkENI_RegressionE2(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	trunkENI, mockHelper := newReclaimTrunk(ctrl)
+
+	vlan := 7
+	eni := &ENIDetails{
+		ID:                "eni-e2-forgotten",
+		VlanID:            vlan,
+		AssociationID:     "trunk-assoc-e2",
+		deletionTimeStamp: time.Now().Add(-10 * time.Minute),
+	}
+	trunkENI.usedVlanIds[vlan] = true
+	trunkENI.vlanOwner[vlan] = eni.ID
+	trunkENI.pushENIToDeleteQueue(eni)
+
+	// Phase 1 - produce the E2 leak: disassociate keeps failing (slot conservatively stays
+	// occupied, VLAN never freed) and delete fails until MaxDeleteRetries is exhausted within
+	// the pass, so the ENI is forgotten while still attached in EC2.
+	mockHelper.EXPECT().DisassociateTrunkInterface(&eni.AssociationID).Return(MockError).Times(MaxDeleteRetries)
+	mockHelper.EXPECT().DeleteNetworkInterface(&eni.ID).Return(MockError).Times(MaxDeleteRetries)
+	forgottenBefore := testutil.ToFloat64(branchENIDeleteForgottenCount.WithLabelValues("max_delete_retries_exceeded"))
+
+	trunkENI.DeleteCooledDownENIs()
+
+	assert.Equal(t, float64(1),
+		testutil.ToFloat64(branchENIDeleteForgottenCount.WithLabelValues("max_delete_retries_exceeded"))-forgottenBefore)
+	assert.Empty(t, trunkENI.deleteQueue, "the forgotten ENI is dropped from the queue")
+	assert.Empty(t, trunkENI.inFlightENIs, "a forgotten ENI must not linger in the in-flight set - the sweep must be able to rediscover it")
+	assert.True(t, trunkENI.usedVlanIds[vlan], "this is the E2 leak state: the VLAN is still held with nobody driving its release")
+
+	// Phase 2 - the sweep rediscovers the forgotten ENI attached in EC2 and re-enqueues it with a
+	// fresh retry budget.
+	vlanTag := []awsEc2Types.Tag{{
+		Key:   aws.String(config.VLandIDTag),
+		Value: aws.String(strconv.Itoa(vlan)),
+	}, trunkIDTag}
+	mockHelper.EXPECT().GetBranchNetworkInterface(&trunkId, &SubnetId).Return(
+		[]*awsEc2Types.NetworkInterface{{NetworkInterfaceId: &eni.ID, TagSet: vlanTag}}, nil)
+
+	found, err := trunkENI.ReconcileUnassignedBranchENIs()
+	assert.NoError(t, err)
+	assert.True(t, found, "the sweep must rediscover the forgotten ENI as an orphan")
+	assert.Len(t, trunkENI.deleteQueue, 1)
+
+	// The rediscovered entry was just enqueued with deletionTimeStamp=now; age it past the delete
+	// cooldown so the delete proceeds in the next pass (cooldown timing itself is covered by U1).
+	trunkENI.deleteQueue[0].deletionTimeStamp = time.Now().Add(-10 * time.Minute)
+
+	// Phase 3 - the delete finally succeeds (no disassociate call: the sweep entry has no known
+	// AssociationID, its slot/VLAN release is the fallback at successful delete).
+	mockHelper.EXPECT().DeleteNetworkInterface(&eni.ID).Return(nil)
+
+	trunkENI.DeleteCooledDownENIs()
+
+	assert.Empty(t, trunkENI.deleteQueue)
+	assert.Empty(t, trunkENI.inFlightENIs)
+	assert.False(t, trunkENI.usedVlanIds[vlan], "R-E2: the forgotten ENI's VLAN must not be permanently leaked")
+	assert.NotContains(t, trunkENI.vlanOwner, vlan, "the VLAN's ownership record must be cleared with it")
 }

--- a/test/integration/perpodsg/perpodsg_test.go
+++ b/test/integration/perpodsg/perpodsg_test.go
@@ -14,10 +14,12 @@
 package perpodsg_test
 
 import (
+	"fmt"
 	"time"
 
 	cninode "github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1alpha1"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/vpc"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/branch"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/branch/trunk"
@@ -176,6 +178,117 @@ var _ = Describe("Branch ENI Pods", func() {
 				sgpWrapper.CreateSecurityGroupPolicy(frameWork.K8sClient, ctx, securityGroupPolicy)
 				pod = podWrapper.CreateAndWaitForPodToStart(frameWork.PodManager, ctx, pod)
 				eniList = verify.VerifyNetworkingOfPodUsingENI(*pod, securityGroups)
+			})
+		})
+
+		// M1 (design doc section 2.2, requirements.md S2): after a branch-ENI pod is deleted, its
+		// trunk slot is released in the same reconcile pass (a replacement pod on the SAME node comes
+		// up without waiting a full cooldown), while the VLAN id it held is withheld from reuse until
+		// reuseCooldown elapses (the replacement is assigned a DIFFERENT vlan id, never the one just
+		// freed). Both pods are pinned to one node so they share a trunk - the cooldown is per-trunk.
+		//
+		// The node is filled to (branch-ENI limit - 1) with filler pods BEFORE the pod under test is
+		// created, so the trunk sits at exactly full capacity when the pod under test is deleted. This
+		// is required for the slot-release assertion to mean anything: on a trunk nowhere near its
+		// limit, a replacement pod gets a fresh slot regardless of whether the old one was released
+		// immediately or not at all - the assertion would pass even if M1's immediate-release path
+		// were completely broken. At full capacity, the replacement can ONLY reach Running if the
+		// just-deleted pod's slot was actually freed in time.
+		Context("when a branch ENI pod is deleted and a replacement is created on a trunk at full capacity", func() {
+			var (
+				targetNode  string
+				branchLimit int
+				fillerPods  []*v1.Pod
+				firstPod    *v1.Pod
+				secondPod   *v1.Pod
+				firstENIs   []*trunk.ENIDetails
+				secondENIs  []*trunk.ENIDetails
+			)
+
+			JustBeforeEach(func() {
+				Expect(nodeList.Items).NotTo(BeEmpty())
+				targetNode = nodeList.Items[0].Name
+				instanceID := frameWork.NodeManager.GetInstanceID(&nodeList.Items[0])
+				instanceDetails, err := frameWork.EC2Manager.GetInstanceDetails(instanceID)
+				Expect(err).NotTo(HaveOccurred())
+				branchLimit = vpc.Limits[string(instanceDetails.InstanceType)].BranchInterface
+				Expect(branchLimit).To(BeNumerically(">", 1),
+					"target node's instance type must support at least 2 branch ENIs for this test to mean anything")
+				fillerPods = nil
+			})
+
+			JustAfterEach(func() {
+				// firstPod is deleted mid-test and set to nil on the happy path; clean it up
+				// here so a failure between its creation and deletion does not leak a pod
+				// that pins the node at full branch-ENI capacity.
+				if firstPod != nil {
+					_ = frameWork.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, firstPod)
+				}
+				if secondPod != nil {
+					_ = frameWork.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, secondPod)
+				}
+				for _, filler := range fillerPods {
+					_ = frameWork.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, filler)
+				}
+			})
+
+			It("releases the slot immediately but withholds the freed vlan until its reuse cooldown elapses", func() {
+				sgpWrapper.CreateSecurityGroupPolicy(frameWork.K8sClient, ctx, securityGroupPolicy)
+
+				By(fmt.Sprintf("filling the target node to %d/%d branch-ENI capacity with filler pods",
+					branchLimit-1, branchLimit))
+				for i := 0; i < branchLimit-1; i++ {
+					fillerPod, err := manifest.NewDefaultPodBuilder().
+						Namespace(namespace).
+						Name(fmt.Sprintf("%sfiller-%d", utils.ResourceNamePrefix, i)).
+						Labels(map[string]string{podLabelKey: podLabelValue}).
+						NodeName(targetNode).Build()
+					Expect(err).NotTo(HaveOccurred())
+					fillerPod = podWrapper.CreateAndWaitForPodToStart(frameWork.PodManager, ctx, fillerPod)
+					verify.VerifyNetworkingOfPodUsingENI(*fillerPod, securityGroups)
+					fillerPods = append(fillerPods, fillerPod)
+				}
+
+				By("creating the pod under test, bringing the trunk to full capacity")
+				firstPod, err = manifest.NewDefaultPodBuilder().
+					Namespace(namespace).
+					Name(utils.ResourceNamePrefix + "first").
+					Labels(map[string]string{podLabelKey: podLabelValue}).
+					NodeName(targetNode).Build()
+				Expect(err).NotTo(HaveOccurred())
+				firstPod = podWrapper.CreateAndWaitForPodToStart(frameWork.PodManager, ctx, firstPod)
+				firstENIs = verify.VerifyNetworkingOfPodUsingENI(*firstPod, securityGroups)
+				Expect(firstENIs).NotTo(BeEmpty())
+				freedVlan := firstENIs[0].VlanID
+				freedENIID := firstENIs[0].ID
+
+				By("deleting the pod under test, releasing its trunk slot on a now-at-capacity trunk")
+				Expect(frameWork.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, firstPod)).To(Succeed())
+				firstPod = nil
+
+				By("creating a replacement pod on the same node immediately, within the vlan reuse cooldown")
+				secondPod, err = manifest.NewDefaultPodBuilder().
+					Namespace(namespace).
+					Name(utils.ResourceNamePrefix + "second").
+					Labels(map[string]string{podLabelKey: podLabelValue}).
+					NodeName(targetNode).Build()
+				Expect(err).NotTo(HaveOccurred())
+				// M1 slot release assertion: with the trunk left at exactly branchLimit-1 used slots
+				// (the fillers) plus this one pending create, the replacement can reach Running ONLY
+				// if the deleted pod's slot was actually freed - a broken immediate-release path would
+				// leave it stuck Pending on ErrCurrentlyAtMaxCapacity instead.
+				secondPod = podWrapper.CreateAndWaitForPodToStart(frameWork.PodManager, ctx, secondPod)
+				secondENIs = verify.VerifyNetworkingOfPodUsingENI(*secondPod, securityGroups)
+				Expect(secondENIs).NotTo(BeEmpty())
+
+				By("asserting the replacement did NOT reuse the just-freed vlan id while it is still cooling")
+				Expect(secondENIs[0].VlanID).NotTo(Equal(freedVlan),
+					"a vlan still inside its reuse cooldown must not be handed to the replacement pod")
+				Expect(secondENIs[0].ID).NotTo(Equal(freedENIID),
+					"the replacement must get a fresh branch ENI, not the one just released")
+
+				By("waiting for the deleted pod's branch ENI to be fully deleted")
+				Expect(frameWork.EC2Manager.WaitTillTheENIIsDeleted(ctx, freedENIID)).To(Succeed())
 			})
 		})
 

--- a/test/integration/perpodsg/sg_regression_test.go
+++ b/test/integration/perpodsg/sg_regression_test.go
@@ -1,0 +1,259 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package perpodsg_test
+
+import (
+	"fmt"
+
+	"github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1beta1"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/vpc"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/provider/branch/trunk"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/manifest"
+	podWrapper "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/pod"
+	sgpWrapper "github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/resource/k8s/sgp"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/test/framework/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+)
+
+// Scale-regression layer A (doc/reports/scale-acceptance/redesign-regression-soak-vlan-test-plan.md,
+// 测试 1/测试 3 的 e2e 子集): every assertion here needs only the CLUSTER account - the pod-eni
+// annotation (the controller's committed ledger view) and EC2 describe (the truth). Anything that
+// needs control-plane host access (leader restart for R-E1, metric families on :8443, preflight)
+// lives in the plan's driver scripts, not in this suite.
+//
+// The suite answers the top-risk question for the redesign's ledger changes: after pods travel the
+// M1 release/cooldown path, the delete/recreate churn path, and the at-capacity contention path
+// (which organically exercises M3 reclaim, as observed in the S3/S4 acceptance runs), does every
+// pod still hold a branch ENI carrying EXACTLY its own SGP's security groups - no
+// cross-contamination, no stale ENI reuse, no VLAN held by two live pods, and no leaked ENIs.
+var _ = Describe("SG correctness regression across redesign lifecycle paths", Label("scale-regression"), func() {
+	var (
+		namespace string
+
+		sgpAlpha *v1beta1.SecurityGroupPolicy
+		sgpBeta  *v1beta1.SecurityGroupPolicy
+
+		labelKey   string
+		alphaValue string
+		betaValue  string
+
+		sgAlpha []string
+		sgBeta  []string
+
+		targetNode  string
+		branchLimit int
+
+		// every pod this spec created and has not yet deleted; best-effort cleanup
+		livePods []*v1.Pod
+	)
+
+	BeforeEach(func() {
+		namespace = "sg-regression"
+		labelKey = "sgp"
+		alphaValue = "alpha"
+		betaValue = "beta"
+		sgAlpha = []string{securityGroupID1}
+		sgBeta = []string{securityGroupID2}
+		livePods = nil
+
+		Expect(nodeList.Items).NotTo(BeEmpty())
+		targetNode = nodeList.Items[0].Name
+		instanceID := frameWork.NodeManager.GetInstanceID(&nodeList.Items[0])
+		instanceDetails, err := frameWork.EC2Manager.GetInstanceDetails(instanceID)
+		Expect(err).NotTo(HaveOccurred())
+		branchLimit = vpc.Limits[string(instanceDetails.InstanceType)].BranchInterface
+		Expect(branchLimit).To(BeNumerically(">", 1))
+	})
+
+	JustBeforeEach(func() {
+		By("creating the namespace and the two SGPs with DISTINCT security groups")
+		Expect(frameWork.NSManager.CreateNamespace(ctx, namespace)).To(Succeed())
+
+		var err error
+		sgpAlpha, err = manifest.NewSGPBuilder().
+			Name("sgp-alpha").Namespace(namespace).
+			PodMatchLabel(labelKey, alphaValue).
+			SecurityGroup(sgAlpha).Build()
+		Expect(err).NotTo(HaveOccurred())
+		sgpBeta, err = manifest.NewSGPBuilder().
+			Name("sgp-beta").Namespace(namespace).
+			PodMatchLabel(labelKey, betaValue).
+			SecurityGroup(sgBeta).Build()
+		Expect(err).NotTo(HaveOccurred())
+		sgpWrapper.CreateSecurityGroupPolicy(frameWork.K8sClient, ctx, sgpAlpha)
+		sgpWrapper.CreateSecurityGroupPolicy(frameWork.K8sClient, ctx, sgpBeta)
+	})
+
+	JustAfterEach(func() {
+		By("cleaning up pods, SGPs, and the namespace")
+		for _, pod := range livePods {
+			_ = frameWork.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, pod)
+		}
+		_ = frameWork.SGPManager.DeleteAndWaitTillSecurityGroupIsDeleted(ctx, sgpAlpha)
+		_ = frameWork.SGPManager.DeleteAndWaitTillSecurityGroupIsDeleted(ctx, sgpBeta)
+		Expect(frameWork.NSManager.DeleteAndWaitTillNamespaceDeleted(ctx, namespace)).To(Succeed())
+	})
+
+	// createPods creates count pods pinned to targetNode with the given label value and name
+	// prefix, waits for each to run, verifies its branch ENI carries exactly wantSG, and returns
+	// the pods with their ENI details.
+	createPods := func(count int, labelValue, namePrefix string, wantSG []string) ([]*v1.Pod, [][]*trunk.ENIDetails) {
+		var pods []*v1.Pod
+		var enis [][]*trunk.ENIDetails
+		for i := 0; i < count; i++ {
+			pod, err := manifest.NewDefaultPodBuilder().
+				Namespace(namespace).
+				Name(fmt.Sprintf("%s%s-%d", utils.ResourceNamePrefix, namePrefix, i)).
+				Labels(map[string]string{labelKey: labelValue}).
+				NodeName(targetNode).Build()
+			Expect(err).NotTo(HaveOccurred())
+			pod = podWrapper.CreateAndWaitForPodToStart(frameWork.PodManager, ctx, pod)
+			livePods = append(livePods, pod)
+			enis = append(enis, verify.VerifyNetworkingOfPodUsingENI(*pod, wantSG))
+			pods = append(pods, pod)
+		}
+		return pods, enis
+	}
+
+	// assertNoVlanDoubleHold asserts the ledger invariant a customer would experience as a VLAN
+	// conflict: no two LIVE pods on the shared trunk hold the same vlan id (per their pod-eni
+	// annotations, the controller's committed allocation record).
+	assertNoVlanDoubleHold := func(labelValues ...string) {
+		vlanHolder := map[int]string{}
+		for _, labelValue := range labelValues {
+			pods, err := frameWork.PodManager.GetPodsWithLabel(ctx, namespace, labelKey, labelValue)
+			Expect(err).NotTo(HaveOccurred())
+			for _, pod := range pods {
+				if pod.DeletionTimestamp != nil {
+					continue
+				}
+				eniDetails, err := frameWork.PodManager.GetENIDetailsFromPodAnnotation(pod.Annotations)
+				Expect(err).NotTo(HaveOccurred())
+				for _, eni := range eniDetails {
+					holder, taken := vlanHolder[eni.VlanID]
+					Expect(taken).To(BeFalse(), fmt.Sprintf(
+						"vlan %d held by two live pods at once: %s and %s", eni.VlanID, holder, pod.Name))
+					vlanHolder[eni.VlanID] = pod.Name
+				}
+			}
+		}
+	}
+
+	Context("when one SGP's pods churn next to another SGP's steady pods", func() {
+		It("keeps every pod on exactly its own SGP's security groups and never disturbs the neighbor", func() {
+			const podsPerSGP = 3
+
+			By("baseline: pods of both SGPs on one shared trunk, each on its own SG")
+			_, _ = createPods(podsPerSGP, alphaValue, "alpha", sgAlpha)
+			betaPods, betaENIs := createPods(podsPerSGP, betaValue, "beta", sgBeta)
+			assertNoVlanDoubleHold(alphaValue, betaValue)
+
+			By("churning ONLY the alpha pods: delete all, recreate immediately (inside the vlan reuse cooldown)")
+			var alphaOld []*v1.Pod
+			for _, pod := range livePods {
+				if pod.Labels[labelKey] == alphaValue {
+					alphaOld = append(alphaOld, pod)
+				}
+			}
+			for _, pod := range alphaOld {
+				Expect(frameWork.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, pod)).To(Succeed())
+			}
+			livePods = betaPods
+
+			_, alphaNewENIs := createPods(podsPerSGP, alphaValue, "alpha-replacement", sgAlpha)
+
+			By("asserting the replacements carry ONLY sg-alpha (createPods already verified) and hold no duplicate vlans")
+			Expect(alphaNewENIs).To(HaveLen(podsPerSGP))
+			assertNoVlanDoubleHold(alphaValue, betaValue)
+
+			By("asserting the beta pods were completely undisturbed by the neighbor churn")
+			for i, pod := range betaPods {
+				current, err := frameWork.PodManager.GetPodsWithLabel(ctx, namespace, labelKey, betaValue)
+				Expect(err).NotTo(HaveOccurred())
+				for _, cur := range current {
+					if cur.Name != pod.Name {
+						continue
+					}
+					curENIs, err := frameWork.PodManager.GetENIDetailsFromPodAnnotation(cur.Annotations)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(curENIs[0].ID).To(Equal(betaENIs[i][0].ID),
+						"a steady pod's branch ENI must not be swapped by a neighbor SGP's churn")
+				}
+				verify.VerifyNetworkingOfPodUsingENI(*pod, sgBeta)
+			}
+		})
+	})
+
+	// The strongest cluster-side proxy for "SG stays correct THROUGH the reclaim machinery": the
+	// delete-all/recreate-all swap at exactly full trunk capacity is the same workload that drove
+	// M1 immediate release plus organic M3 error-driven reclaim in the S3/S4 acceptance runs. If
+	// any freed/reclaimed state leaked across the swap, a beta pod would surface it here as a
+	// wrong SG, a duplicated vlan, or a stuck Pending.
+	Context("when a full-capacity trunk swaps every pod from one SGP to another", func() {
+		It("brings all replacement pods up on the new SGP's security groups with no leak from the old set", func() {
+			By(fmt.Sprintf("filling the target node to full branch-ENI capacity (%d) with alpha pods", branchLimit))
+			_, alphaENIs := createPods(branchLimit, alphaValue, "swap-alpha", sgAlpha)
+
+			var oldENIIDs []string
+			for _, enis := range alphaENIs {
+				for _, eni := range enis {
+					oldENIIDs = append(oldENIIDs, eni.ID)
+				}
+			}
+
+			By("deleting ALL alpha pods at once (grace 0) and immediately demanding full capacity for beta pods")
+			Expect(frameWork.PodManager.DeleteAllPodsForcefully(ctx, labelKey, alphaValue)).To(Succeed())
+			livePods = nil
+
+			_, _ = createPods(branchLimit, betaValue, "swap-beta", sgBeta)
+
+			By("asserting no vlan is double-held after the swap")
+			assertNoVlanDoubleHold(betaValue)
+
+			By("asserting every alpha branch ENI is eventually deleted from EC2 (no orphan leak)")
+			for _, eniID := range oldENIIDs {
+				Expect(frameWork.EC2Manager.WaitTillTheENIIsDeleted(ctx, eniID)).To(Succeed(),
+					fmt.Sprintf("old branch ENI %s must not leak after the at-capacity swap", eniID))
+			}
+		})
+	})
+
+	// VLAN double-hold invariant under repeated fast churn (plan 测试 3 的 lite 版). Full
+	// 120-vlan-pool saturation needs a sustained ~3.4 deletes/second on one trunk and stays in
+	// the real-env plan (INCONCLUSIVE there if unreached); the deterministic reuse-cooldown
+	// assertion is the dedicated full-capacity spec in perpodsg_test.go. What this spec pins is
+	// the invariant a customer would feel: across repeated delete-all/recreate-all cycles, no
+	// vlan id is ever recorded against two live pods, and every survivor stays on its own SG.
+	Context("when a pod batch churns repeatedly on one trunk", func() {
+		It("never records the same vlan id against two live pods across churn cycles", func() {
+			const batchSize = 4
+			const cycles = 3
+
+			for cycle := 0; cycle < cycles; cycle++ {
+				By(fmt.Sprintf("churn cycle %d: creating %d pods", cycle, batchSize))
+				_, _ = createPods(batchSize, alphaValue, fmt.Sprintf("churn-%d", cycle), sgAlpha)
+				assertNoVlanDoubleHold(alphaValue)
+
+				if cycle < cycles-1 {
+					By(fmt.Sprintf("churn cycle %d: deleting the whole batch at once (grace 0)", cycle))
+					Expect(frameWork.PodManager.DeleteAllPodsForcefully(ctx, labelKey, alphaValue)).To(Succeed())
+					livePods = nil
+				}
+			}
+		})
+	})
+})


### PR DESCRIPTION
**Stacked series 2/3** — based on #693 (this PR's diff shows ONLY this slice: +1904/-97 in pkg/provider/branch + integration tests). Merge #693 first; GitHub retargets this to the release branch automatically when the base branch is deleted on merge.

**Issues: delete cooldown holds trunk capacity hostage (#595); orphaned branch ENIs wedge nodes permanently (capacity blind spot); high-churn races can double-free a VLAN into a live pod.**

- **M1 split delete**: immediate disassociate frees the trunk slot in one processing pass; ENI delete timing and VLAN reuse cooldown unchanged (no dataplane-visible change); conservative `slotReleased` accounting; capacity requeue 60s -> 10s.
- **M3 error-driven reclaim**: any failed branch-ENI addition triggers one describe -> orphan classification via the shared known set -> dedup-aware enqueue; bounded to 1 describe / 30s / trunk.
- **M5 guards**: in-flight set (`inFlightENIs` phase=creating|deleting) closes the create window (H-A), delete-queue dedup (H-B), and the pop window; owner-aware `freeVlanId` as defense in depth.
- VLAN lifecycle logs (assign/free/immediate-disassociate/cooldown-blocked, with vlanID+eniID+podUID) and per-mechanism counters.
- Tests: U1-U7 + Regression E2/E4/E5/HA/HB/PopWindow unit tests; full-capacity slot-release integration test; scale-regression e2e specs (SG cross-contamination, at-capacity SGP swap, VLAN double-hold).

Scale evidence (1500-node beta cluster, at-capacity churn): 223 orphans reclaimed in one 7.5-min window, no create/fail wedge; owner guard refused 18 duplicate frees; no VLAN conflict observed.