### PR TITLE
Unpin go directive to minor-only (1.26), completing #688

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-vpc-resource-controller-k8s
 
-go 1.26.5
+go 1.26
 
 require (
 	github.com/aws/amazon-vpc-cni-k8s v1.19.4


### PR DESCRIPTION
One-line stack maintenance for #693/#694/#695: #688 reverted .go-version to floating 1.26 but left go.mod pinned at 1.26.5. CI resolves the toolchain via go-version-file: go.mod, so vuln_check installs exactly go1.26.5 and fails on stdlib vulns fixed in 1.26.6+ (GO-2026-6218/-6090/-6089/-6088). Floating 1.26 matches master. Same fix is needed on release-1.7.16-onwards itself (separate PR to follow).