### PR TITLE
Measure CNINode name collisions after EC2 private-IP reuse

### DIFF
--- a/controllers/crds/cninode_controller.go
+++ b/controllers/crds/cninode_controller.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-vpc-resource-controller-k8s/apis/vpcresources/v1alpha1"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2"
 	ec2API "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2/api"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2/api/cleanup"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
@@ -134,6 +135,10 @@ func (r *CNINodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			// Requeue request so it can be retried
 			return ctrl.Result{}, err
 		}
+	}
+
+	if nodeFound {
+		r.checkInstanceIDCollision(cniNode, node)
 	}
 
 	if cniNode.GetDeletionTimestamp().IsZero() {
@@ -254,6 +259,30 @@ func (r *CNINodeReconciler) SetupWithManager(mgr ctrl.Manager, maxNodeConcurrent
 		For(&v1alpha1.CNINode{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxNodeConcurrentReconciles}).
 		Complete(r)
+}
+
+// checkInstanceIDCollision compares a CNINode's checkpointed instance ID against the live
+// node's instance ID (parsed from spec.providerID) to detect a leaked CNINode name reused by a
+// different EC2 instance after a private IP reuse (design-cn.md §2.7/§4.2 E7; issue #515). This
+// is detection/measurement only: it never fails the reconcile, and it skips silently whenever
+// either side of the comparison is unavailable (no checkpoint yet, or an unparseable providerID).
+func (r *CNINodeReconciler) checkInstanceIDCollision(cniNode *v1alpha1.CNINode, node *v1.Node) {
+	if cniNode.Status.ReinitCheckpoint == nil || cniNode.Status.ReinitCheckpoint.Instance.InstanceID == "" {
+		return
+	}
+	recordedInstanceID := cniNode.Status.ReinitCheckpoint.Instance.InstanceID
+
+	liveInstanceID, ok := utils.InstanceIDFromProviderID(node.Spec.ProviderID)
+	if !ok {
+		return
+	}
+
+	if recordedInstanceID != liveInstanceID {
+		r.log.Error(nil, "CNINode recorded instance ID does not match the node's live instance ID; "+
+			"possible CNINode name collision from a leaked object and EC2 private IP reuse (#515)",
+			"node", cniNode.Name, "recordedInstanceID", recordedInstanceID, "liveInstanceID", liveInstanceID)
+		ec2.RecordInstanceIDCollision(ec2.CollisionSourceBind)
+	}
 }
 
 // waitTillCNINodeDeleted waits for CNINode to be deleted with timeout and returns error

--- a/controllers/crds/cninode_controller_test.go
+++ b/controllers/crds/cninode_controller_test.go
@@ -8,10 +8,12 @@ import (
 	mock_api "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/api"
 	mock_cleanup "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/aws/ec2/api/cleanup"
 	mock_k8s "github.com/aws/amazon-vpc-resource-controller-k8s/mocks/amazon-vcp-resource-controller-k8s/pkg/k8s"
+	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2"
 	ec2API "github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2/api"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/ec2/api/cleanup"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/config"
 	"github.com/golang/mock/gomock"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -276,6 +278,118 @@ func TestCNINodeReconcile(t *testing.T) {
 			if tt.asserts != nil {
 				tt.asserts(res, err, cniNode)
 			}
+		})
+	}
+}
+
+// TestCNINodeReconcile_InstanceIDCollision proves the "bind" side of M6 (design-cn.md §2.7,
+// §4.2 E7; issue #515): every CNINode reconcile with a live node compares the CNINode's
+// checkpointed instance ID against the node's live instance ID (parsed from spec.providerID),
+// increments cninode_instance_id_collision_total{source="bind"} on a mismatch, leaves it
+// untouched on a match, and skips silently (no error, no metric change) whenever either side of
+// the comparison is unavailable.
+func TestCNINodeReconcile_InstanceIDCollision(t *testing.T) {
+	const recordedInstanceID = "i-0aaaaaaaaaaaaaaaa"
+	const liveInstanceID = "i-0bbbbbbbbbbbbbbbb"
+
+	nodeWithProviderID := func(providerID string) *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: mockName,
+				Labels: map[string]string{
+					config.NodeLabelOS: "linux",
+				},
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: providerID,
+			},
+		}
+	}
+
+	cniNodeWithCheckpoint := func(instanceID string) *v1alpha1.CNINode {
+		cniNode := &v1alpha1.CNINode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: mockName,
+				Labels: map[string]string{
+					config.NodeLabelOS: "linux",
+				},
+			},
+			Spec: v1alpha1.CNINodeSpec{
+				Tags: map[string]string{
+					config.VPCCNIClusterNameKey: mockClusterName,
+				},
+			},
+		}
+		if instanceID != "" {
+			cniNode.Status = v1alpha1.CNINodeStatus{
+				ReinitCheckpoint: &v1alpha1.ReinitCheckpoint{
+					SnapshotVersion: v1alpha1.CNINodeStatusSnapshotVersion,
+					Instance:        v1alpha1.InstanceStatus{InstanceID: instanceID},
+				},
+			}
+		}
+		return cniNode
+	}
+
+	tests := []struct {
+		name      string
+		node      *corev1.Node
+		cniNode   *v1alpha1.CNINode
+		wantDelta float64
+	}{
+		{
+			name:      "mismatched instance ID increments the bind collision counter",
+			node:      nodeWithProviderID("aws:///us-west-2a/" + liveInstanceID),
+			cniNode:   cniNodeWithCheckpoint(recordedInstanceID),
+			wantDelta: 1,
+		},
+		{
+			name:      "matching instance ID does not increment the counter",
+			node:      nodeWithProviderID("aws:///us-west-2a/" + recordedInstanceID),
+			cniNode:   cniNodeWithCheckpoint(recordedInstanceID),
+			wantDelta: 0,
+		},
+		{
+			name:      "missing providerID skips the check",
+			node:      nodeWithProviderID(""),
+			cniNode:   cniNodeWithCheckpoint(recordedInstanceID),
+			wantDelta: 0,
+		},
+		{
+			name:      "unparseable providerID skips the check",
+			node:      nodeWithProviderID("not-a-providerid"),
+			cniNode:   cniNodeWithCheckpoint(recordedInstanceID),
+			wantDelta: 0,
+		},
+		{
+			name:      "no checkpoint yet skips the check",
+			node:      nodeWithProviderID("aws:///us-west-2a/" + liveInstanceID),
+			cniNode:   cniNodeWithCheckpoint(""),
+			wantDelta: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mock := NewCNINodeMock(ctrl, tt.cniNode, tt.node)
+			mockFinalizerManager := mock_k8s.NewMockFinalizerManager(ctrl)
+			mockFinalizerManager.EXPECT().
+				AddFinalizers(gomock.Any(), gomock.Any(), config.NodeTerminationFinalizer).
+				Return(nil)
+			mock.Reconciler.finalizerManager = mockFinalizerManager
+			mock.Reconciler.k8sAPI = mock_k8s.NewMockK8sWrapper(ctrl)
+
+			before := testutil.ToFloat64(ec2.InstanceIDCollisionCount.WithLabelValues(ec2.CollisionSourceBind))
+
+			res, err := mock.Reconciler.Reconcile(context.Background(), reconcileRequest)
+			assert.NoError(t, err)
+			assert.Equal(t, reconcile.Result{}, res)
+
+			after := testutil.ToFloat64(ec2.InstanceIDCollisionCount.WithLabelValues(ec2.CollisionSourceBind))
+			assert.Equal(t, tt.wantDelta, after-before)
 		})
 	}
 }

--- a/pkg/aws/ec2/instance.go
+++ b/pkg/aws/ec2/instance.go
@@ -403,6 +403,10 @@ func (i *ec2Instance) HydrateFromCNINodeStatus(status rcv1alpha1.CNINodeStatus) 
 
 	instanceStatus := status.ReinitCheckpoint.Instance
 	if instanceStatus.InstanceID != i.instanceID {
+		i.log.Error(nil, "CNINode recorded instance ID does not match the node's live instance ID; "+
+			"possible CNINode name collision from a leaked object and EC2 private IP reuse (#515)",
+			"node", i.name, "recordedInstanceID", instanceStatus.InstanceID, "liveInstanceID", i.instanceID)
+		RecordInstanceIDCollision(CollisionSourceHydrate)
 		return false, HydrateMissInstanceIDMismatch
 	}
 	if instanceStatus.InstanceType == "" {

--- a/pkg/aws/ec2/instance_test.go
+++ b/pkg/aws/ec2/instance_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/golang/mock/gomock"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -518,6 +519,40 @@ func TestEc2Instance_HydrateFromCNINodeStatus_MissingSubnetMask(t *testing.T) {
 	ok, reason = inst3.HydrateFromCNINodeStatus(s)
 	assert.False(t, ok)
 	assert.Equal(t, HydrateMissSubnetV6Mask, reason)
+}
+
+// TestEc2Instance_HydrateFromCNINodeStatus_InstanceIDMismatch proves U8 (design-cn.md §5.1,
+// §2.7/§4.2 E7; issue #515): a CNINode snapshot whose checkpointed instance ID does not match the
+// live instance it is being hydrated against is a clean cache-miss (HydrateMissInstanceIDMismatch)
+// and increments cninode_instance_id_collision_total{source="hydrate"} exactly once. A matching
+// instance ID must hydrate successfully and must not touch the counter at all.
+func TestEc2Instance_HydrateFromCNINodeStatus_InstanceIDMismatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	before := testutil.ToFloat64(InstanceIDCollisionCount.WithLabelValues(CollisionSourceHydrate))
+
+	inst, _ := getMockInstance(ctrl)
+	s := validHydrateStatus()
+	s.ReinitCheckpoint.Instance.InstanceID = "i-differentinstance"
+	ok, reason := inst.HydrateFromCNINodeStatus(s)
+	assert.False(t, ok)
+	assert.Equal(t, HydrateMissInstanceIDMismatch, reason)
+	assert.False(t, inst.LoadedFromCNINodeStatus())
+
+	assert.Equal(t, float64(1),
+		testutil.ToFloat64(InstanceIDCollisionCount.WithLabelValues(CollisionSourceHydrate))-before,
+		"instance ID mismatch must increment the collision counter with source=hydrate exactly once")
+
+	// Matching instance IDs: no collision, counter untouched, snapshot hydrates.
+	before = testutil.ToFloat64(InstanceIDCollisionCount.WithLabelValues(CollisionSourceHydrate))
+	inst2, _ := getMockInstance(ctrl)
+	ok, reason = inst2.HydrateFromCNINodeStatus(validHydrateStatus())
+	assert.True(t, ok, "valid snapshot should hydrate; got reason %q", reason)
+	assert.Equal(t, HydrateHit, reason)
+	assert.Equal(t, float64(0),
+		testutil.ToFloat64(InstanceIDCollisionCount.WithLabelValues(CollisionSourceHydrate))-before,
+		"matching instance IDs must not increment the collision counter")
 }
 
 // TestHydrateResult_WireValuesStable pins the string values of every HydrateResult constant.

--- a/pkg/aws/ec2/metrics.go
+++ b/pkg/aws/ec2/metrics.go
@@ -1,0 +1,61 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ec2
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Collision detection sources for cninode_instance_id_collision_total: CollisionSourceBind is
+// recorded every time the CNINode controller reconciles a node's CNINode (steady-state
+// signal); CollisionSourceHydrate is recorded on the restart/leader-change hydrate fast path
+// (HydrateFromCNINodeStatus). Both feed the same counter so the two signals can be told apart
+// via the source label while still summing to a single "how often does this happen" number
+// (design-cn.md §2.7, §4.2 E7; issue #515).
+const (
+	CollisionSourceBind    = "bind"
+	CollisionSourceHydrate = "hydrate"
+)
+
+// InstanceIDCollisionCount is exported so both detection sites (the CNINode controller's bind
+// check and the hydrate fast path in this package) increment the same counter, and so tests
+// outside this package can assert on it directly.
+var (
+	InstanceIDCollisionCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cninode_instance_id_collision_total",
+			Help: "The number of times a CNINode's recorded instance ID did not match the instance ID it was checked against, indicating a leaked CNINode name reused by a different EC2 instance",
+		},
+		[]string{"source"},
+	)
+
+	prometheusRegisterOnce sync.Once
+)
+
+// RecordInstanceIDCollision increments the CNINode instance-ID collision counter for the given
+// detection source. Registers the metric lazily on first use so callers never need to know
+// about controller startup ordering.
+func RecordInstanceIDCollision(source string) {
+	prometheusRegister()
+	InstanceIDCollisionCount.WithLabelValues(source).Inc()
+}
+
+func prometheusRegister() {
+	prometheusRegisterOnce.Do(func() {
+		metrics.Registry.MustRegister(InstanceIDCollisionCount)
+	})
+}

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -201,6 +202,31 @@ func DeconstructIPsFromPrefix(prefix string) ([]string, error) {
 		deconstructedIPs = append(deconstructedIPs, ipAddr)
 	}
 	return deconstructedIPs, nil
+}
+
+// instanceIDFromProviderIDPattern matches the last path segment of an AWS node's
+// spec.providerID (e.g. "aws:///us-west-2c/i-0123456789abcdef0") against the EC2 instance ID
+// shape, so a providerID from an unexpected source/format is treated as unparseable rather than
+// silently extracted as garbage.
+var instanceIDFromProviderIDPattern = regexp.MustCompile(`^i-[0-9a-f]+$`)
+
+// InstanceIDFromProviderID extracts the EC2 instance ID from a Kubernetes node's
+// spec.providerID. Returns ok=false if providerID is empty, not AWS-formed, or its last path
+// segment does not look like an EC2 instance ID - callers should skip whatever check depends on
+// the live instance ID rather than acting on a bad parse.
+func InstanceIDFromProviderID(providerID string) (instanceID string, ok bool) {
+	if !strings.HasPrefix(providerID, "aws://") {
+		return "", false
+	}
+	idx := strings.LastIndex(providerID, "/")
+	if idx == -1 {
+		return "", false
+	}
+	instanceID = providerID[idx+1:]
+	if !instanceIDFromProviderIDPattern.MatchString(instanceID) {
+		return "", false
+	}
+	return instanceID, true
 }
 
 func IsNitroInstance(instanceType string) (bool, error) {

--- a/pkg/utils/helper_test.go
+++ b/pkg/utils/helper_test.go
@@ -535,6 +535,56 @@ func TestIsNitroInstance_NonNitro(t *testing.T) {
 	assert.False(t, isNitro)
 }
 
+// TestInstanceIDFromProviderID covers the parser M6's bind-time collision check relies on to
+// get the live instance ID off a node (design-cn.md §2.7; issue #515): a well-formed AWS
+// providerID parses to its instance ID, while anything missing, non-AWS, or whose last path
+// segment does not look like an EC2 instance ID is reported as unparseable rather than guessed at.
+func TestInstanceIDFromProviderID(t *testing.T) {
+	tests := []struct {
+		name           string
+		providerID     string
+		wantInstanceID string
+		wantOk         bool
+	}{
+		{
+			name:           "well formed provider ID",
+			providerID:     "aws:///us-west-2c/i-0123456789abcdef0",
+			wantInstanceID: "i-0123456789abcdef0",
+			wantOk:         true,
+		},
+		{
+			name:       "empty provider ID",
+			providerID: "",
+			wantOk:     false,
+		},
+		{
+			name:       "non-AWS provider ID",
+			providerID: "azure:///westus/some-vm-id",
+			wantOk:     false,
+		},
+		{
+			name:       "last segment is not an instance ID shape",
+			providerID: "aws:///us-west-2c/not-an-instance-id",
+			wantOk:     false,
+		},
+		{
+			name:       "no path segments after scheme",
+			providerID: "aws://",
+			wantOk:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotInstanceID, gotOk := InstanceIDFromProviderID(tt.providerID)
+			assert.Equal(t, tt.wantOk, gotOk)
+			if tt.wantOk {
+				assert.Equal(t, tt.wantInstanceID, gotInstanceID)
+			}
+		})
+	}
+}
+
 // TestGetSourceAcctAndArn tests that generating account ID and cluster ARN
 func TestGetSourceAcctAndArn(t *testing.T) {
 	accountID := "123456789876"


### PR DESCRIPTION
**Stack 3/3** — this layer's diff only (+319 in the CNINode controller / ec2 / utils).

**Issue: a leaked CNINode + EC2 private-IP reuse hands a new instance a stale CNINode (#515). The eventual fix (instance-id naming) is a disruptive schema migration — ship measurement first so that decision is data-driven.**

- `cninode_instance_id_collision_total{source=bind|hydrate}`: bind-time detection in the CNINode reconciler (live instance ID parsed from `spec.providerID` with strict shape validation) plus the existing hydrate-mismatch site feeding the same counter.
- Detection/measurement only: never fails a reconcile, silently skips on missing/unparseable providerID, hydrate fallback unchanged, no CRD/schema change.

Scale evidence: constructed collision on a 1500-node beta cluster — detected, EC2 fallback taken, counter incremented (S5 PASS).

---
## Validation (2026-08-21, 1500-node beta cluster, image `redesign-be75a56`)

**S5 collision scenario (constructed leaked-CNINode + reused name): PASS** — mismatch detected, EC2 fallback taken (no state corruption), `cninode_instance_id_collision_total` incremented with the expected source label.

**8h steady-state soak: counter stays exactly 0** under ~30k branch-ENI operations of churn — the detector is silent when no collision exists (no false positives), and detection never perturbed any reconcile.

Full report: `doc/reports/scale-acceptance/redesign-regression-soak-vlan-test-report.md` in the test workspace.