### PR TITLE
chore: scope SecurityGroup Ingress to VPC CIDR

### DIFF
--- a/test/framework/resource/aws/ec2/manager.go
+++ b/test/framework/resource/aws/ec2/manager.go
@@ -64,16 +64,45 @@ func (d *Manager) GetInstanceDetails(instanceID string) (*ec2types.Instance, err
 	return &describeInstanceOutput.Reservations[0].Instances[0], nil
 }
 
+// getVPCIpRanges returns the IPv4 CIDR block(s) associated with the VPC,
+// usually 192.168.0.0/16 for the eksctl created clusters.
+func (d *Manager) getVPCIpRanges() ([]ec2types.IpRange, error) {
+	output, err := d.ec2Client.DescribeVpcs(context.TODO(), &ec2.DescribeVpcsInput{
+		VpcIds: []string{d.vpcID},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(output.Vpcs) == 0 {
+		return nil, fmt.Errorf("no VPC found for ID %s", d.vpcID)
+	}
+
+	var ipRanges []ec2types.IpRange
+	for _, association := range output.Vpcs[0].CidrBlockAssociationSet {
+		if association.CidrBlock != nil {
+			ipRanges = append(ipRanges, ec2types.IpRange{CidrIp: association.CidrBlock})
+		}
+	}
+	if len(ipRanges) == 0 {
+		return nil, fmt.Errorf("no IPv4 CIDR blocks found for VPC %s", d.vpcID)
+	}
+	return ipRanges, nil
+}
+
 func (d *Manager) AuthorizeSecurityGroupIngress(securityGroupID string, port int,
 	protocol string,
 ) error {
-	_, err := d.ec2Client.AuthorizeSecurityGroupIngress(context.TODO(), &ec2.AuthorizeSecurityGroupIngressInput{
+	ipRanges, err := d.getVPCIpRanges()
+	if err != nil {
+		return err
+	}
+	_, err = d.ec2Client.AuthorizeSecurityGroupIngress(context.TODO(), &ec2.AuthorizeSecurityGroupIngressInput{
 		GroupId: &securityGroupID,
 		IpPermissions: []ec2types.IpPermission{
 			{
 				FromPort:   aws.Int32(int32(port)),
 				IpProtocol: aws.String(protocol),
-				IpRanges:   []ec2types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
+				IpRanges:   ipRanges,
 				ToPort:     aws.Int32(int32(port)),
 			},
 		},
@@ -101,13 +130,17 @@ func (d *Manager) AuthorizeSecurityGroupEgress(securityGroupID string, port int,
 func (d *Manager) RevokeSecurityGroupIngress(securityGroupID string, port int,
 	protocol string,
 ) error {
-	_, err := d.ec2Client.RevokeSecurityGroupIngress(context.TODO(), &ec2.RevokeSecurityGroupIngressInput{
+	ipRanges, err := d.getVPCIpRanges()
+	if err != nil {
+		return err
+	}
+	_, err = d.ec2Client.RevokeSecurityGroupIngress(context.TODO(), &ec2.RevokeSecurityGroupIngressInput{
 		GroupId: aws.String(securityGroupID),
 		IpPermissions: []ec2types.IpPermission{
 			{
 				FromPort:   aws.Int32(int32(port)),
 				IpProtocol: aws.String(protocol),
-				IpRanges:   []ec2types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
+				IpRanges:   ipRanges,
 				ToPort:     aws.Int32(int32(port)),
 			},
 		},

--- a/test/integration/windows/windows_test.go
+++ b/test/integration/windows/windows_test.go
@@ -1195,7 +1195,7 @@ func GetCommandToTestHostConnectivity(host string, port int32, retries int, slee
 // Install and start the dot net web server, it's light weight so starts pretty quick
 func GetCommandToStartHttpServer() string {
 	return "Add-WindowsFeature Web-Server; Invoke-WebRequest " +
-		"-Uri 'https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe'" +
+		"-Uri 'https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v2.0.1.10/ServiceMonitor.exe'" +
 		" -OutFile 'C:\\ServiceMonitor.exe'; " +
 		"echo 'ok' > C:\\inetpub\\wwwroot\\default.html; " + "C:\\ServiceMonitor.exe 'w3svc'; "
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Scoping SG ingress for Windows Integration Tests to just the VPC CIDR range for the test clusters (usually `192.168.0.0/16` for `eksctl`-created clusters).

This is being done to avoid opening SG ingress to 0.0.0.0/0 during the test runs.

Also fixes an issue with the `dotnetbinaries` URL that was being used to download ServiceMonitor for tests:
```
Invoke-WebRequest : The remote name could not be resolved:
'dotnetbinaries.blob.core.windows.net'
```
This was deprecated as seen in https://github.com/dotnet/announcements/issues/351 (in favor of the replaced github url).

*Testing*:
```
------------------------------
[AfterSuite]
/Users/cdirubb/workplace/amazon-vpc-resource-controller-k8s/test/integration/windows/windows_suite_test.go:89
  STEP: updating the configmap @ 08/31/26 20:01:14.018
  STEP: revoking the security group ingress for HTTP traffic @ 08/31/26 20:01:24.065
[AfterSuite] PASSED [10.633 seconds]
------------------------------

Ran 37 of 40 Specs in 5613.432 seconds
SUCCESS! -- 37 Passed | 0 Failed | 0 Pending | 3 Skipped
PASS

Ginkgo ran 1 suite in 1h33m38.8442525s
Test Suite Passed
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
