### PR TITLE
Updating the wait for cache sync function

### DIFF
--- a/controllers/custom/custom_controller.go
+++ b/controllers/custom/custom_controller.go
@@ -145,8 +145,11 @@ func (c *CustomController) Start(ctx context.Context) error {
 		c.log.Info("starting custom controller")
 		go coreController.Run(ctx.Done())
 
-		// Wait till cache sync
-		c.WaitForCacheSync(coreController)
+		// Wait till cache sync. Workers must not start against a partially
+		// populated data store.
+		if err := c.WaitForCacheSync(ctx, coreController); err != nil {
+			return err
+		}
 
 		c.log.Info("Starting Workers", "worker count",
 			c.options.MaxConcurrentReconciles)
@@ -165,16 +168,24 @@ func (c *CustomController) Start(ctx context.Context) error {
 	return nil
 }
 
-// WaitForCacheSync tills the cache has synced, this must be done under
-// mutex lock to prevent other controllers from starting at same time
-func (c *CustomController) WaitForCacheSync(controller cache.Controller) {
-	for !controller.HasSynced() && controller.LastSyncResourceVersion() == "" {
-		c.log.Info("waiting for controller to sync")
-		time.Sleep(time.Second * 1)
+// WaitForCacheSync blocks until the entire initial list has been drained into
+// the pod data store, then flips the sync condition other controllers gate on.
+//
+// HasSynced is the only correct signal here: DeltaFIFO reports it true only once
+// initialPopulationCount has drained to zero, and because Pop holds the FIFO lock
+// across our Process func, that cannot be observed until the data store write for
+// the final item has returned
+
+func (c *CustomController) WaitForCacheSync(ctx context.Context, controller cache.Controller) error {
+	start := time.Now()
+	c.log.Info("start sync wait for pod controller")
+	if !cache.WaitForNamedCacheSync(c.options.Name, ctx.Done(), controller.HasSynced) {
+		return fmt.Errorf("%s: pod data store did not sync before shutdown", c.options.Name)
 	}
 	c.conditions.SetPodDataStoreSyncStatus(true)
 
-	c.log.Info("cache has synced successfully")
+	c.log.Info("cache has synced successfully", "duration", time.Since(start))
+	return nil
 }
 
 // newOptimizedListWatcher returns a list watcher with a custom list function that converts the


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The custom controller does not use client-go's SharedIndexInformer. Instead it wires the low-level client-go primitives directly (see controllers/custom/builder.go):
1\ a Reflector (LIST + WATCH against the API server),
2\ a DeltaFIFO queue,
3\ a custom cache.Config.Process function that strips down the Pod object and writes it into the shared data store.

The reflector fills the FIFO; Process drains it into the store.
Until the store is populated, the controller holds back its own workers and — via SetPodDataStoreSyncStatus — every other controller that gates on the pod cache:

The current wait condition - 

```
for !controller.HasSynced() && controller.LastSyncResourceVersion() == "" {
 time.Sleep(1s)
}
```

This wait condition has the bug: the loop exits as soon as either condition is satisfied. The reflector sets `LastSyncResourceVersion` after finishing the list call, before any item has been drained into the store, while `HasSynced()` is only set after the queue is drained into the store.
This makes it a race. If processing happens quickly, downstream controllers get the right pod cache. 

NodeReconciler → InitTrunk, initializes the node and checks for leaked branch ENIs by reconciling the branch ENIs in EC2 against those claimed by pods in the cache. When the cache is incomplete, the node reconciler will find in-use branch ENIs as leaked and deletes them - breaking the networking for running pods. 

`HasSynced()` is the correct signal - DeltaFIFO reports it true only once the queue is fully drained and blocks the other process

This PR fixes the wait condition so that it waits only for the pod cache to be fully populated in the shared data store

Testing 

Ran 3k and 7k pods test and multiple rollout restarts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
